### PR TITLE
get a BUILD_NUMBER into .env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,13 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Append circleCI build number to version
+          command: |
+            git config user.email "devops@pillar.io"
+            git config user.name "Issabot"
+            npm version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$CIRCLE_BUILD_NUM
+            echo 'BUILD_NUMBER=$(node -e "console.log(require('./package.json').version);")' >> .env
       - restore_cache:
           key: node-{{ checksum "./yarn.lock" }}
       - run:
@@ -123,6 +130,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Append circleCI build number to version
+          command: |
+            git config user.email "devops@pillar.io"
+            git config user.name "Issabot"
+            npm version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$CIRCLE_BUILD_NUM
+            echo 'BUILD_NUMBER=$(node -e "console.log(require('./package.json').version);")' >> .env
+      - run:
           name: Install Expo cli
           command: yarn global add exp
       - run:
@@ -202,6 +216,13 @@ jobs:
     steps:
       - checkout:
           path: ~/pillarwallet
+      - run:
+          name: Append circleCI build number to version
+          command: |
+            git config user.email "devops@pillar.io"
+            git config user.name "Issabot"
+            npm version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$CIRCLE_BUILD_NUM
+            echo 'BUILD_NUMBER=$(node -e "console.log(require('./package.json').version);")' >> .env
       - restore_cache:
           key: node-{{ checksum "../yarn.lock" }}
       - run:


### PR DESCRIPTION
@jsidorenko 
- this should create a BUILD_NUMBER in .env for each build

1) we don't have any way of testing this other than to push a build through, so if we're in a world where we can't risk doing a build that fails then we just can't implement this
2) without more thought (and change, therefore risk..) it's going to be quite primitive; eg. because the ios+android builds are in separate jobs they will have different numbers. However if we can echo the BUILD_NUMBER somewhere in the app it will remove one potential source of confusion and we can tighten up later..
