### PR TITLE
copy the generated ipa file into a directory and archive it..

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,14 @@ jobs:
           command: |
             chmod +x .circleci/announceDeployment.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "TestFlight"
+      - run:
+          name: prepare to archive ipa file
+          command: |
+            mkdir -p ./toArchive
+            cp ./ios/pillarwallet.ipa ./toArchive
+      - store_artifacts:
+          path: ./toArchive
+          destination: app_build
 
   deploy_android:
     working_directory: ~/pillarwallet/android


### PR DESCRIPTION
NB I've added these steps at the end of the iOS deploy job, so even if my steps mess up the release will still go out..

99+% sure my change is fine, though, provided we're right about where the file has been generated..