### PR TITLE
The rn-signal-protocol-messaging version updated to "1.0.69".

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
-    "rn-signal-protocol-messaging": "1.0.68",
+    "rn-signal-protocol-messaging": "1.0.69",
     "shuffle-array": "^1.0.1",
     "stream-browserify": "^1.0.0",
     "string_decoder": "~0.10.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10817,9 +10817,9 @@ rn-nodeify@tradle/rn-nodeify:
     semver "^5.0.1"
     xtend "^4.0.0"
 
-rn-signal-protocol-messaging@1.0.68:
-  version "1.0.68"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.68.tgz#bfa114dd57d3086d8b60fc2880c9172a896efba4"
+rn-signal-protocol-messaging@1.0.69:
+  version "1.0.69"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.69.tgz#6454d5d16ef747619b39167cedcf0b05f59268dc"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
It fixed the crash of the app in Android when you open the chat.