### PR TITLE
Fixed the dark overlay issue on the 'Add Token' page

### DIFF
--- a/src/screens/AddToken/AddToken.js
+++ b/src/screens/AddToken/AddToken.js
@@ -356,6 +356,7 @@ class AddToken extends React.Component<Props, State> {
             <SearchBar
               inputProps={{
                 onChange: this.handleSearchChange,
+                onBlur: this.handleSearchBlur,
                 onFocus: this.handleSearchFocus,
                 value: query,
                 autoCapitalize: 'none',


### PR DESCRIPTION
Fixed the dark overlay issue on the 'Add Token' page. It will disappear if you press the cancel button.