### PR TITLE
Update Intercom's api

### DIFF
--- a/src/actions/notificationsActions.js
+++ b/src/actions/notificationsActions.js
@@ -60,7 +60,7 @@ export const startListeningIntercomNotificationsAction = () => {
 export const stopListeningIntercomNotificationsAction = () => {
   return () => {
     if (!intercomNotificationsListener) return;
-    Intercom.reset();
+    Intercom.logout();
     Intercom.removeEventListener(Intercom.Notifications.UNREAD_COUNT, intercomNotificationsListener);
   };
 };


### PR DESCRIPTION
Intercom.reset() function is now deprecated and changed for Intercom.logout(). You can refer to this [ticket](https://github.com/tinycreative/react-native-intercom/pull/235).
Thanks to @diablourbano for finding that