### PR TITLE
Feature/remove ropsten related warnings in prod version

### DIFF
--- a/src/components/WarningBanner/WarningBanner.js
+++ b/src/components/WarningBanner/WarningBanner.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import styled from 'styled-components/native';
 import { fontSizes, baseColors, fontWeights } from 'utils/variables';
 import { BoldText } from 'components/Typography';
+import { NETWORK_PROVIDER } from 'react-native-dotenv';
 
 const WarningBannerBackground = styled.View`
   background-color: ${baseColors.fireEngineRed};
@@ -25,7 +26,7 @@ type Props = {
 }
 
 const WarningBanner = (props: Props) => {
-  if (__DEV__) {
+  if (NETWORK_PROVIDER === 'ropsten') {
     return (
       <WarningBannerBackground small={props.small} rounded={props.rounded}>
         <WarningBannerText small={props.small}>


### PR DESCRIPTION
Task [3276](https://2030io.kanbanize.com/ctrl_board/4/cards/3276/details)
Remove 'roptsen' related warnings from the production version of the app