### PR TITLE
Export build number in CircleCI config for iOS development build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ aliases:
           export buildNumber=$(node -e "console.log(require('./package.json').version);")
           rm .env
           cp environments/.env.staging ./.env
-          sed -i "s/_build_number_/$buildNumber/g" .env
+          sed -i.bak "s/_build_number_/$buildNumber/g" .env
           echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
 
 # Default for iOS Build machine
@@ -218,7 +218,7 @@ jobs:
             export buildNumber=$(node -e "console.log(require('./package.json').version);")
             rm .env
             cp environments/.env.staging ./.env
-            sed -i.bak s/_build_number_/$buildNumber/g .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: ios-node-{{ checksum "./yarn.lock" }}
@@ -307,7 +307,7 @@ jobs:
             export buildNumber=$(node -e "console.log(require('./package.json').version);")
             rm .env
             cp environments/.env.production ./.env
-            sed -i.bak s/_build_number_/$buildNumber/g .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: ios-node-{{ checksum "./yarn.lock" }}
@@ -401,7 +401,7 @@ jobs:
             export buildNumber=$(node -e "console.log(require('./package.json').version);")
             rm .env
             cp environments/.env.production ./.env
-            sed -i "s/_build_number_/$buildNumber/g" .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: android-node-{{ checksum "../yarn.lock" }}
@@ -497,7 +497,7 @@ jobs:
             export buildNumber=$(node -e "console.log(require('./package.json').version);")
             rm .env
             cp environments/.env.staging ./.env
-            sed -i "s/_build_number_/$buildNumber/g" .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: android-node-{{ checksum "../yarn.lock" }}


### PR DESCRIPTION
This sets the build number environment variable to make it available during the build process, merge "add_android_build" first .