### PR TITLE
Remove Gemfile creation from circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,12 +278,6 @@ jobs:
       - run:
           name: Install Bundler
           command: sudo gem install bundler
-      - run:
-          name: Creating Gemfile in ios dir
-          command: cd ios && bundle init
-      - run:
-          name: Install fastlane gem
-          command: echo 'gem "fastlane"' >> ./ios/Gemfile
       - restore_cache:
           key: ios-gems-{{ checksum "./ios/Gemfile" }}
       - run:
@@ -367,12 +361,6 @@ jobs:
       - run:
           name: Install Bundler
           command: sudo gem install bundler
-      - run:
-          name: Creating Gemfile in ios dir
-          command: cd ios && bundle init
-      - run:
-          name: Install fastlane gem
-          command: echo 'gem "fastlane"' >> ./ios/Gemfile
       - restore_cache:
           key: ios-gems-{{ checksum "./ios/Gemfile" }}
       - run:
@@ -448,12 +436,6 @@ jobs:
           key: android-node-{{ checksum "../yarn.lock" }}
           paths:
             - ~/pillarwallet/nodes_modules
-      - run:
-          name: Creating Gemfile in android dir
-          command: bundle init
-      - run:
-          name: Install fastlane gem
-          command: echo 'gem "fastlane"' >> Gemfile
       - restore_cache:
           key: android-gems-{{ checksum "Gemfile" }}
       - run:
@@ -544,12 +526,6 @@ jobs:
           key: android-node-{{ checksum "../yarn.lock" }}
           paths:
             - ~/pillarwallet/nodes_modules
-      - run:
-          name: Creating Gemfile in android dir
-          command: bundle init
-      - run:
-          name: Install fastlane gem
-          command: echo 'gem "fastlane"' >> Gemfile
       - restore_cache:
           key: android-gems-{{ checksum "Gemfile" }}
       - run:


### PR DESCRIPTION
Gemfile files are now present in ios/ and android/ , this pull request removes the creation of the Gemfiles from CircleCI build instructions, this fixes the builds that are being triggered in master.