### PR TITLE
bugFix/162451709 Notification Payload Decimals

### DIFF
--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -70,10 +70,15 @@ export const processNotification = (notification: Object, myEthAddress?: string)
 
     let message = '';
     let title = '';
-    const { asset, status, value } = parsedNotification;
+    const {
+      asset,
+      status,
+      value,
+      decimals,
+    } = parsedNotification;
     const sender = parsedNotification.fromAddress.toUpperCase();
     const receiver = parsedNotification.toAddress.toUpperCase();
-    const amount = utils.formatUnits(utils.bigNumberify(value.toString()));
+    const amount = utils.formatUnits(utils.bigNumberify(value.toString()), decimals);
 
     if (receiver === myEthAddress && status === 'pending') {
       title = `${amount} ${asset}`;


### PR DESCRIPTION
Extended bcx notification payload with decimals to show correct amount in a Toast in-app