### PR TITLE
Avoid GiftedChat warning on rendering

### DIFF
--- a/src/actions/__tests__/chatActions.test.js
+++ b/src/actions/__tests__/chatActions.test.js
@@ -47,7 +47,7 @@ describe('Chat Actions', () => {
 
       it('should call the dispatch function', () => {
         const msg = {
-          _id: timestamp,
+          _id: timestamp.toString(),
           createdAt: timestamp,
           text: message.text,
           user: {

--- a/src/actions/chatActions.js
+++ b/src/actions/chatActions.js
@@ -73,7 +73,7 @@ export const sendMessageByContactAction = (username: string, message: Object) =>
 
     const timestamp = new Date(message.createdAt).getTime();
     const msg = {
-      _id: timestamp,
+      _id: timestamp.toString(),
       createdAt: timestamp,
       text: message.text,
       user: {


### PR DESCRIPTION
This PR removes a warning when creating a new chat message which could be the source of the crash reported on pivotal issue #162528102

`add toString to _id property of chat message to avoid List key warning`