### PR TITLE
Update Assets Pattern (162684286)

### DIFF
--- a/src/components/AssetPattern/AssetPattern.js
+++ b/src/components/AssetPattern/AssetPattern.js
@@ -61,7 +61,13 @@ export default class AssetPattern extends React.Component<Props, {}> {
   generatePattern = (token: string, icon: string, isListed: boolean) => {
     const paternDetails = [];
     const uniqueCode = [];
-    token.split('').forEach((letter) => {
+    const tokenSymbols = token.split('');
+
+    if (tokenSymbols.length < 2) {
+      uniqueCode.push(tokenSymbols[0].charCodeAt(0) > 78 ? 72 : 84);
+    }
+
+    tokenSymbols.forEach((letter) => {
       uniqueCode.push(letter.charCodeAt(0));
     });
 


### PR DESCRIPTION
Task [#162684286](https://www.pivotaltracker.com/story/show/162684286)

Revain token pattern breaks because its name code contains only one symbol.
Updated code version pushes in additional charCode to unique code array for tokens that name code is shorter than 2 symbols so pattern wouldn't break on such cases.