### PR TITLE
fixed signal init params for ios due version mismatch

### DIFF
--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -15,7 +15,7 @@ export default class Chat {
     credentials.host = SIGNAL_SERVER_HOST;
 
     if (Platform.OS === 'ios') {
-      return this.client.createClient(credentials);
+      return this.client.createClient(credentials.username, credentials.accessToken, credentials.host);
     }
 
     credentials.errorTrackingDSN = SENTRY_DSN;


### PR DESCRIPTION
Signal init param mismatch for iOS due switching between multiple Signal Client versions