### PR TITLE
Fix/android build license fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,7 +725,6 @@ workflows:
             branches:
               only:
                   - develop
-                  - fix/android-build-license-fix
       - stage_ios:
           requires:
             - build


### PR DESCRIPTION
This PR is a workaround to the newly released API 28 license acceptance requirement until CircleCI has updated their docker image.