### PR TITLE
signal client version 1.0.135

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "redux-async-queue": "^1.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
-    "rn-signal-protocol-messaging": "1.0.133",
+    "rn-signal-protocol-messaging": "1.0.135",
     "shuffle-array": "^1.0.1",
     "stream-browserify": "^1.0.0",
     "string_decoder": "~0.10.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12935,10 +12935,10 @@ rn-nodeify@tradle/rn-nodeify:
     semver "^5.0.1"
     xtend "^4.0.0"
 
-rn-signal-protocol-messaging@1.0.133:
-  version "1.0.133"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.133.tgz#419d5fa2ea4e4ad95e9042b0299a4ca380d1b4f6"
-  integrity sha1-QZ1foupOStlekEKwKZpMo4DRtPY=
+rn-signal-protocol-messaging@1.0.135:
+  version "1.0.135"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.135.tgz#038bd6cf75c11d8d13870e1a264e59e0ff436a28"
+  integrity sha1-A4vWz3XBHY0Thw4aJk5Z4P9Daig=
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
Currently if Android Signal remote fails (token expired, etc.) it generates new local pre keys and tries to send them to remote – **this doesn't cause any issues for messaging**, but creates a specific amount of useless local pre keys. We didn't have the remote failing before, but after moving to OAuth this scenario needs to be covered in Android. iOS Signal client is OK as it operates the response in a different way – it tries to parse 200 HTTP response as JSON and doesn't mark 200 HTTP response as successful until it has valid JSON.

This Signal client version adds additional check to Android: generate new amount of local pre keys if remote response code is 200 (HTTP OK)
