### PR TITLE
rn-signal-protocol-messaging version bump 1.0.146

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "redux-async-queue": "^1.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
-    "rn-signal-protocol-messaging": "1.0.142",
+    "rn-signal-protocol-messaging": "1.0.146",
     "shuffle-array": "^1.0.1",
     "stream-browserify": "^1.0.0",
     "string_decoder": "~0.10.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12935,10 +12935,10 @@ rn-nodeify@tradle/rn-nodeify:
     semver "^5.0.1"
     xtend "^4.0.0"
 
-rn-signal-protocol-messaging@1.0.142:
-  version "1.0.142"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.142.tgz#6d8cac9dbe1e2a93e405ba737b129b829d3f2d7b"
-  integrity sha1-bYysnb4eKpPkBbpzexKbgp0/LXs=
+rn-signal-protocol-messaging@1.0.146:
+  version "1.0.146"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.146.tgz#0291de15a7f37527a2bc53ccab31f0a969ca6aa9"
+  integrity sha1-ApHeFafzdSeivFPMqzHwqWnKaqk=
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
This PR covers changes in 2 Signal Client versions:
- Android Signal client API caller network connectivity check
- Android Signal client API caller TLS/SSL certificate management