### PR TITLE
Enable Keyboard aware scroll view for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
         <activity
             android:name=".experience.ExperienceActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="adjustPan"
             android:theme="@style/AppTheme">
         </activity>
 

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -41,6 +41,12 @@ type FooterProps = {
   keyboardVerticalOffset?: number,
 };
 
+type ScrollWrapperProps = {
+  children?: React.Node,
+  regularPadding?: boolean,
+  color?: string,
+};
+
 export const Center = styled.View`
   align-items: center;
 `;
@@ -76,7 +82,7 @@ export const Wrapper = styled.View`
 
 `;
 
-export const ScrollWrapper = styled(KeyboardAwareScrollView)`
+export const KAScrollView = styled(KeyboardAwareScrollView)`
   padding: ${props => (props.regularPadding ? '0 20px' : '0')};
   background-color: ${props => (props.color ? props.color : 'transparent')};
   flex: 1;
@@ -90,6 +96,18 @@ const FooterInner = styled.KeyboardAvoidingView`
   flex-direction: ${props => (props.column ? 'row' : 'column')};
   background-color: ${props => props.backgroundColor ? props.backgroundColor : 'transparent'};
 `;
+
+export const ScrollWrapper = (props: ScrollWrapperProps) => {
+  return (
+    <KAScrollView
+      regularPadding={props.regularPadding}
+      color={props.color}
+      enableOnAndroid
+    >
+      {props.children}
+    </KAScrollView>
+  );
+};
 
 export const Footer = (props: FooterProps) => {
   return (


### PR DESCRIPTION
Attempt to fix an error captured in task [163598508](https://www.pivotaltracker.com/story/show/163598508).

Situation:
I was not able to replicate the issue on my Android devices (Nexus 5X Android 8.1, Motorola Moto G5 Android 7.0).

Such warning that is seen on the video, is being displayed if any exception occurs (1) and devServer's prop bundleLoadedFromServer is undefined or null (2).

1 part is not clear as there is no additional information on the warning due to failed symbolicateStackTrace execution.

2 part is caused by JS bundle being pre-bundled in __DEV__ environment for Staging app and not loaded from the server.

That being said, I could only assume what would cause exception on Android devices on this screen.
Here we are using `keyboard-aware-scroll-view` component. To work on Android, `enableOnAndroid` should be set to true.
I've enabled it on Android and updated Android manifest as suggested in the [documentation](https://github.com/APSL/react-native-keyboard-aware-scroll-view#android-support).