### PR TITLE
fix/163861820_TxNote_parsing_issue

### DIFF
--- a/src/utils/txNotes.js
+++ b/src/utils/txNotes.js
@@ -17,18 +17,23 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+
+import { UNDECRYPTABLE_MESSAGE } from 'constants/messageStatus';
+
 export function extractTxNotesFromMessages(txNotesRaw: Object[] = []): Object[] {
   const txNotes = [];
   if (txNotesRaw && txNotesRaw.length > 0) {
     txNotesRaw.forEach(({ messages = [] }) => {
       if (Array.isArray(messages)) {
-        messages.forEach(({ content }) => {
-          const txNote = JSON.parse(content);
+        messages.forEach((message) => {
+          if (message.status === UNDECRYPTABLE_MESSAGE) return;
+          const txNote = JSON.parse(message.content);
           txNotes.push(txNote);
         });
       } else {
-        messages.messages.forEach(({ content }) => {
-          const txNote = JSON.parse(content);
+        messages.messages.forEach((message) => {
+          if (message.status === UNDECRYPTABLE_MESSAGE) return;
+          const txNote = JSON.parse(message.content);
           txNotes.push(txNote);
         });
       }


### PR DESCRIPTION
Task [163861820](https://www.pivotaltracker.com/story/show/163861820).

PR includes a fix for an error caught on Sentry.
Undecryptable messages would no longer be parsed and shown.

