### PR TITLE
Fix Missing Dates on Android

### DIFF
--- a/src/screens/Chat/Chat.js
+++ b/src/screens/Chat/Chat.js
@@ -218,7 +218,6 @@ const renderDay = (props: Props) => (
       fontWeight: '400',
       fontSize: fontSizes.extraSmall,
       fontFamily: 'Aktiv Grotesk App',
-      textTransform: 'capitalize',
     }}
     dateFormat="LL"
   />


### PR DESCRIPTION
This PR solves the problem on Android with `Date of Message` not being displayed.

The issue is at RN level, based on [this issue](https://github.com/facebook/react-native/issues/21966) and the debug done on the app textTransform="capitalize" for textStyle doesn't work on android. However text is already capitalized.