### PR TITLE
removed UIFileSharingEnabled flag from xcode info.plist

### DIFF
--- a/ios/pillarwallet/Info.plist
+++ b/ios/pillarwallet/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIFileSharingEnabled</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Debugging from device is complete, restoring back to original Info.plist file without UIFileSharingEnabled flag.