### PR TITLE
Separate prod builds webhook for the support team

### DIFF
--- a/.circleci/announceProdBuilds.sh
+++ b/.circleci/announceProdBuilds.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+applicationName=$1
+targetEnvironment=$2
+
+payload=$(
+cat <<EOM
+{
+    "attachments": [
+        {
+            "fallback": "$applicationName has succesfully deployed to $targetEnvironment.",
+            "color": "#33CC66",
+            "pretext": "$applicationName has succesfully deployed to $targetEnvironment.",
+            "title": "$CIRCLE_PROJECT_REPONAME",
+            "title_link": "https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_WORKSPACE_ID",
+            "text": "build number: $CIRCLE_BUILD_NUM",
+            "ts": $(date '+%s')
+        }
+    ]
+}
+EOM
+)
+
+curl -X POST --data-urlencode payload="$payload" "$SLACK_WEBHOOK_SUPPORT_URL"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,7 +442,7 @@ jobs:
       - run:
            name: Announce Deployment
            command: |
-             chmod +x .circleci/announceDeployment.sh
+             chmod +x .circleci/announceProdBuilds.sh
              .circleci/announceDeployment.sh "Pillar Wallet" "Production TestFlight"
       - run:
           name: Copy production iOS artifact to S3
@@ -590,7 +590,7 @@ jobs:
           name: Announce Deployment
           command: |
             cd ~/pillarwallet
-            chmod +x .circleci/announceDeployment.sh
+            chmod +x .circleci/announceProdBuilds.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "Production Google Play Store"
       - run:
           name: Announce Prod Android URL


### PR DESCRIPTION
This will add a separate slack hook to send the message when prod builds are finished and sent to the respective stores. 
These messages will be sent to the support channel in order to have the support team updated that there is a new prod build.