### PR TITLE
 Revert to 9.4.0 xcode and revert Fastfile commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,7 @@ workflows:
           filters:
             branches:
               only:
-                  - fix/revert-xcode-version
+                  - master
       - build-and-test
       - whitesource:
           requires:
@@ -765,7 +765,7 @@ workflows:
           filters:
             branches:
               only:
-                  - fix/revert-xcode-version
+                  - develop
       - dev_build_android:
           requires:
             - build-and-test
@@ -779,7 +779,7 @@ workflows:
           filters:
             branches:
               only:
-                  - fix/revert-xcode-version
+                  - master
       - stage_android:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ aliases:
 defaults_ios: &defaults_ios
   working_directory: ~/pillarwallet
   macos:
-    xcode: "10.1.0"
+    xcode: "9.4.0"
   environment:
     FL_OUTPUT_DIR: output
     _JAVA_OPTIONS: "-Xms128m -Xmx3024m"
@@ -243,7 +243,7 @@ jobs:
   build:
     working_directory: ~/pillarwallet
     macos:
-      xcode: "10.1.0"
+      xcode: "9.4.0"
     environment:
       FL_OUTPUT_DIR: output
     resource_class: large
@@ -267,7 +267,7 @@ jobs:
   stage_ios:
     working_directory: ~/pillarwallet
     macos:
-      xcode: "10.1.0"
+      xcode: "9.4.0"
     environment:
       FL_OUTPUT_DIR: output
     shell: /bin/bash --login -o pipefail
@@ -369,7 +369,7 @@ jobs:
   prod_ios:
     working_directory: ~/pillarwallet
     macos:
-      xcode: "10.1.0"
+      xcode: "9.4.0"
     environment:
       FL_OUTPUT_DIR: output
     shell: /bin/bash --login -o pipefail
@@ -754,7 +754,7 @@ workflows:
           filters:
             branches:
               only:
-                  - master
+                  - fix/revert-xcode-version
       - build-and-test
       - whitesource:
           requires:
@@ -765,7 +765,7 @@ workflows:
           filters:
             branches:
               only:
-                  - develop
+                  - fix/revert-xcode-version
       - dev_build_android:
           requires:
             - build-and-test
@@ -779,7 +779,7 @@ workflows:
           filters:
             branches:
               only:
-                  - master
+                  - fix/revert-xcode-version
       - stage_android:
           requires:
             - build

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
           team_id: "J9DEY3FGPD"
         )
     sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration release -scheme pillarwallet -derivedDataPath ../build"
-    sh "mkdir -p ../build/pillarwallet/Payload && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet.app/libswiftRemoteMirror.dylib && cp -R /Users/distiller/pillarwallet/ios/build/pillarwallet/SwiftSupport/iphoneos/ /Users/distiller/pillarwallet/ios/build/pillarwallet/Payload/pillarwallet.app/Frameworks/ && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet.ipa *"
+    sh "mkdir -p ../build/pillarwallet/Payload && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet.ipa *"
     sigh(force: true)
     sh "fastlane sigh resign ../pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../AppStore_com.pillarproject.wallet.mobileprovision'"
     commit = last_git_commit
@@ -58,7 +58,7 @@ platform :ios do
     sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration Staging.Release -scheme Staging -derivedDataPath ../build -verbose "
 
     # manually zip the results into an ipa
-    sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cp -R /Users/distiller/pillarwallet/ios/build/pillarwallet/SwiftSupport/iphoneos/ /Users/distiller/pillarwallet/ios/build/pillarwallet/Payload/pillarwallet-staging.app/Frameworks/ && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
+    sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
 
     # download the signing cert
     sigh(


### PR DESCRIPTION
Reverting back to 9.4.0 xcode in order to unblock the prod builds and continue working on a fix for the dylibs.