### PR TITLE
fix/164369232_disable_autocompletion_on_seed_verification

### DIFF
--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -241,6 +241,13 @@ class ImportWallet extends React.Component<Props, State> {
         errorMessage: this.getError(IMPORT_WALLET_PRIVATE_KEY),
       },
     };
+    const inputProps = {
+      onChange: this.handleValueChange(tabsInfo[activeTab].changeName),
+      value: tabsInfo[activeTab].value,
+      autoCapitalize: 'none',
+      multiline: activeTab === TWORDSPHRASE,
+      numberOfLines: 3,
+    };
 
     return (
       <Container>
@@ -255,14 +262,8 @@ class ImportWallet extends React.Component<Props, State> {
           </Paragraph>
           <InputWrapper>
             <TextInput
+              inputProps={Platform.OS === 'ios' ? inputProps : { ...inputProps, keyboardType: 'visible-password' }}
               label={tabsInfo[activeTab].inputLabel}
-              inputProps={{
-                onChange: this.handleValueChange(tabsInfo[activeTab].changeName),
-                value: tabsInfo[activeTab].value,
-                autoCapitalize: 'none',
-                multiline: activeTab === TWORDSPHRASE,
-                numberOfLines: 3,
-              }}
               errorMessage={tabsInfo[activeTab].errorMessage}
               viewWidth={activeTab === TWORDSPHRASE ? (window.width - (spacing.rhythm * 2) - 2) : window.width - 95}
               inputType="secondary"


### PR DESCRIPTION
This PR includes:
1. Setting keyboardType to `visible-password` for Android to disable autocompletion (suggestions).
(It's already disabled on iOS by setting `autoCorrect` to false.

Background: 
Task [164369232](https://www.pivotaltracker.com/story/show/164369232).