### PR TITLE
Fix/164369232 disable autocompletion on seed verification_vol2

### DIFF
--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -262,7 +262,9 @@ class ImportWallet extends React.Component<Props, State> {
           </Paragraph>
           <InputWrapper>
             <TextInput
-              inputProps={Platform.OS === 'ios' ? inputProps : { ...inputProps, keyboardType: 'visible-password' }}
+              inputProps={Platform.OS === 'ios'
+                ? inputProps
+                : { ...inputProps, keyboardType: 'email-address', importantForAutofill: 'no' }}
               label={tabsInfo[activeTab].inputLabel}
               errorMessage={tabsInfo[activeTab].errorMessage}
               viewWidth={activeTab === TWORDSPHRASE ? (window.width - (spacing.rhythm * 2) - 2) : window.width - 95}

--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -264,7 +264,12 @@ class ImportWallet extends React.Component<Props, State> {
             <TextInput
               inputProps={Platform.OS === 'ios'
                 ? inputProps
-                : { ...inputProps, keyboardType: 'email-address', importantForAutofill: 'no' }}
+                : {
+                ...inputProps,
+                  keyboardType: 'email-address',
+                  importantForAutofill: 'no',
+                  autoComplete: 'off',
+              }}
               label={tabsInfo[activeTab].inputLabel}
               errorMessage={tabsInfo[activeTab].errorMessage}
               viewWidth={activeTab === TWORDSPHRASE ? (window.width - (spacing.rhythm * 2) - 2) : window.width - 95}


### PR DESCRIPTION
This PR includes a fix for a previous PR:
If keyboardType is set to `visible-password` input may no longer have multiple lines.

Suggestions on Android is also not visible if keyboard type is set to 'email-address'.
The layout is fairly the same (on 'email-address' layout there's one additional button visible - for @ symbol).

So the previously added prop keyboardType is changed to 'email-address' for Android.
And couple more props are being passed in to be extra sure input values won't be tracked as important for autofill.