### PR TITLE
fix/profile_images_not_showing

### DIFF
--- a/src/screens/Contact/Contact.js
+++ b/src/screens/Contact/Contact.js
@@ -205,9 +205,14 @@ class Contact extends React.Component<Props, State> {
     const localContact = contacts.find(({ username }) => username === contact.username);
     const isAccepted = !!localContact;
     const displayContact = localContact || contact;
-    const userAvatar = displayContact.profileLargeImage
-      ? this.getUserAvatar(isAccepted, displayContact.profileLargeImage, displayContact.lastUpdateTime)
+
+    // due to the fact that profileLargeImage is not being passed in connections notifications payload for now
+    // profileImage is set here as a fallback so requester's avatar (if exists) would be visible
+    const existingProfileImage = displayContact.profileLargeImage || displayContact.profileImage;
+    const userAvatar = existingProfileImage
+      ? this.getUserAvatar(isAccepted, existingProfileImage, displayContact.lastUpdateTime)
       : undefined;
+
     const unreadCount = this.getUnreadCount(chats, displayContact.username);
 
     return (

--- a/src/screens/People/People.js
+++ b/src/screens/People/People.js
@@ -241,7 +241,7 @@ class PeopleScreen extends React.Component<Props, State> {
       <ListItemWithImage
         label={item.username}
         onPress={this.handleContactCardPress(item)}
-        avatarUrl={item.profileLargeImage}
+        avatarUrl={item.profileImage}
         navigateToProfile={this.handleContactCardPress(item)}
         imageUpdateTimeStamp={item.lastUpdateTime}
       />


### PR DESCRIPTION
This PR includes:
1. Update on avatar url for avatars on Profile screen (change from `profileLargeImage` to `profileImage`)
2. Update on Contact screen - profileImage is added as a fallback (due to the fact that  `profileLargeImage` is not being passed in connection notifications payload.
I've already contacted Meggie for this.