### PR TITLE
fix/fix-scroll-to-input

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -45,6 +45,9 @@ type ScrollWrapperProps = {
   children?: React.Node,
   regularPadding?: boolean,
   color?: string,
+  disableAutomaticScroll?: boolean,
+  onKeyboardWillShow?: Function,
+  innerRef?: Object,
 };
 
 export const Center = styled.View`
@@ -103,6 +106,9 @@ export const ScrollWrapper = (props: ScrollWrapperProps) => {
       regularPadding={props.regularPadding}
       color={props.color}
       enableOnAndroid
+      enableAutomaticScroll={!props.disableAutomaticScroll}
+      innerRef={props.innerRef}
+      onKeyboardWillShow={props.onKeyboardWillShow}
     >
       {props.children}
     </KAScrollView>

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -159,7 +159,6 @@ const AbsoluteSpinner = styled(Spinner)`
 `;
 
 class TextInput extends React.Component<Props, State> {
-  rnInput: Object;
   multilineInputField: Object;
 
   state = {
@@ -174,8 +173,6 @@ class TextInput extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-
-    this.rnInput = React.createRef();
     this.multilineInputField = React.createRef();
   }
 

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -23,7 +23,7 @@ import { Item as NBItem, Input, Label } from 'native-base';
 import { fontSizes, fontWeights, baseColors, UIColors, spacing } from 'utils/variables';
 import IconButton from 'components/IconButton';
 import { BaseText, BoldText } from 'components/Typography';
-import { View, TouchableOpacity, Platform, TextInput as RNInput } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import Spinner from 'components/Spinner';
 
 type inputPropsType = {
@@ -56,6 +56,7 @@ type Props = {
   labelBigger?: boolean,
   keyboardAvoidance?: boolean,
   loading?: boolean,
+  onLayout?: Function,
 }
 
 type State = {
@@ -199,27 +200,13 @@ class TextInput extends React.Component<Props, State> {
   handleChange = (e: EventLike) => {
     const { inputProps: { onChange } } = this.props;
     const value = e.nativeEvent.text;
-    onChange(value);
+    if (onChange) onChange(value);
   };
 
   handleFocus = () => {
     this.setState({
       isFocused: true,
     });
-  };
-
-  handleMultilineFocus = () => {
-    if (!this.state.isFocused) {
-      this.rnInput.current.focus();
-      this.setState({
-        isFocused: false,
-      }, () => {
-        setTimeout(() => {
-          this.multilineInputField._root.focus();
-          this.handleFocus();
-        }, 50);
-      });
-    }
   };
 
   render() {
@@ -240,13 +227,13 @@ class TextInput extends React.Component<Props, State> {
       lowerCase,
       labelBigger,
       loading,
+      onLayout,
     } = this.props;
     const { value = '' } = inputProps;
     const { isFocused } = this.state;
     const inputType = inputTypes[this.props.inputType] || inputTypes.default;
     const additionalRightPadding = loading ? 36 : 0;
-    const variableFocus = Platform.OS === 'ios' && inputProps.multiline && this.props.keyboardAvoidance ?
-      this.handleMultilineFocus : this.handleFocus;
+
     return (
       <View style={{ paddingBottom: 10 }}>
         <Item
@@ -264,7 +251,7 @@ class TextInput extends React.Component<Props, State> {
             onChange={this.handleChange}
             onBlur={this.handleBlur}
             onEndEditing={() => this.handleBlur}
-            onFocus={variableFocus}
+            onFocus={this.handleFocus}
             value={value}
             inputType={inputType}
             autoCorrect={autoCorrect}
@@ -276,14 +263,8 @@ class TextInput extends React.Component<Props, State> {
               textAlignVertical: inputProps.multiline ? 'top' : 'center',
               marginBottom: 10,
             }}
+            onLayout={onLayout}
           />
-          {Platform.OS === 'ios' &&
-          <RNInput
-            caretHidden
-            autoCorrect={false}
-            ref={this.rnInput}
-            style={{ marginTop: -10 }}
-          />}
           {!!loading && <AbsoluteSpinner width={30} height={30} />}
           {!!icon && <FloatingButton onPress={onIconPress} icon={icon} color={iconColor} fontSize={30} />}
           {!!postfix && <PostFix>{postfix}</PostFix>}

--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -35,6 +35,7 @@ type Props = {
 type State = {
   note: ?string,
   rinkebyETH: string,
+  scrollPos: number,
 };
 
 const FooterWrapper = styled.View`
@@ -56,14 +57,17 @@ const Value = styled(BoldText)`
 class SendCollectibleConfirm extends React.Component<Props, State> {
   assetData: Object;
   receiver: string;
+  scroll: Object;
 
   constructor(props) {
     super(props);
+    this.scroll = React.createRef();
     this.assetData = this.props.navigation.getParam('assetData', {});
     this.receiver = this.props.navigation.getParam('receiver', '');
     this.state = {
       note: null,
       rinkebyETH: '',
+      scrollPos: 0,
     };
   }
 
@@ -82,7 +86,7 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
     const { wallet } = this.props;
     const rinkebyETHBlanace = await fetchRinkebyETHBalance(wallet.address);
     this.setState({ rinkebyETH: rinkebyETHBlanace });
-  }
+  };
 
   handleFormSubmit = () => {
     Keyboard.dismiss();
@@ -123,7 +127,7 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
   render() {
     const { contacts, session, gasInfo } = this.props;
     const { name } = this.assetData;
-    const { rinkebyETH } = this.state;
+    const { rinkebyETH, scrollPos } = this.state;
 
     const to = this.receiver;
     const txFeeInWei = this.getTxFeeInWei();
@@ -139,7 +143,14 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
             onBack={() => this.props.navigation.goBack(null)}
             title="review and confirm"
           />
-          <ScrollWrapper regularPadding>
+          <ScrollWrapper
+            regularPadding
+            disableAutomaticScroll
+            innerRef={ref => { this.scroll = ref; }}
+            onKeyboardWillShow={() => {
+              this.scroll.scrollToPosition(0, scrollPos);
+            }}
+          >
             <LabeledRow>
               <Label>Collectible</Label>
               <Value>{name}</Value>
@@ -177,6 +188,11 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
               labelBigger
               noBorder
               keyboardAvoidance
+              onLayout={(e) => {
+                const scrollPosition = e.nativeEvent.layout.y + 180;
+                this.setState({ scrollPos: scrollPosition });
+              }
+              }
             />
             }
           </ScrollWrapper>

--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -191,8 +191,7 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
               onLayout={(e) => {
                 const scrollPosition = e.nativeEvent.layout.y + 180;
                 this.setState({ scrollPos: scrollPosition });
-              }
-              }
+              }}
             />
             }
           </ScrollWrapper>

--- a/src/screens/SendToken/SendTokenConfirm.js
+++ b/src/screens/SendToken/SendTokenConfirm.js
@@ -41,6 +41,7 @@ type Props = {
 
 type State = {
   note: ?string,
+  scrollPos: number,
 };
 
 const FooterWrapper = styled.View`
@@ -60,10 +61,14 @@ const Value = styled(BoldText)`
 `;
 
 class SendTokenContacts extends React.Component<Props, State> {
+  scroll: Object;
+
   constructor(props) {
     super(props);
+    this.scroll = React.createRef();
     this.state = {
       note: null,
+      scrollPos: 0,
     };
   }
 
@@ -81,6 +86,7 @@ class SendTokenContacts extends React.Component<Props, State> {
   }
 
   render() {
+    const { scrollPos } = this.state;
     const { contacts, session, navigation } = this.props;
     const {
       amount,
@@ -98,7 +104,14 @@ class SendTokenContacts extends React.Component<Props, State> {
             onBack={() => this.props.navigation.goBack(null)}
             title="send"
           />
-          <ScrollWrapper regularPadding>
+          <ScrollWrapper
+            regularPadding
+            disableAutomaticScroll
+            innerRef={ref => { this.scroll = ref; }}
+            onKeyboardWillShow={() => {
+              this.scroll.scrollToPosition(0, scrollPos);
+            }}
+          >
             <Title subtitle title="Review and Confirm" />
             <LabeledRow>
               <Label>Amount</Label>
@@ -132,6 +145,11 @@ class SendTokenContacts extends React.Component<Props, State> {
               labelBigger
               noBorder
               keyboardAvoidance
+              onLayout={(e) => {
+                const scrollPosition = e.nativeEvent.layout.y + 180;
+                this.setState({ scrollPos: scrollPosition });
+                }
+              }
             />
             }
           </ScrollWrapper>


### PR DESCRIPTION
This PR includes these updates on transactions confirmation screens:
1. Disabled automatic scroll;
2. Added manual scroll method on `KeyboardWillShow` event (works on iOS only) to handle scroll to the bottom of focused text input.
(On Android it is handled automatically due to `softInputMode` set in manifest.