### PR TITLE
changed intercom logout calling place, added intercom fcm update

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -47,6 +47,7 @@ import Storage from 'services/storage';
 import { navigate, getNavigationState, getNavigationPathAndParamsState } from 'services/navigation';
 import ChatService from 'services/chat';
 import firebase from 'react-native-firebase';
+import Intercom from 'react-native-intercom';
 import { toastWalletBackup } from 'utils/toasts';
 import { updateOAuthTokensCB, onOAuthTokensFailedCB } from 'utils/oAuth';
 import { setupSentryAction } from 'actions/appActions';
@@ -85,6 +86,7 @@ export const loginAction = (pin: string, touchID?: boolean = false, onLoginSucce
       const userState = user.walletId ? REGISTERED : PENDING;
       if (userState === REGISTERED) {
         const fcmToken = await firebase.messaging().getToken().catch(() => null);
+        await Intercom.sendTokenToIntercom(fcmToken).catch(() => null);
         const signalCredentials = {
           userId: user.id,
           username: user.username,
@@ -271,6 +273,7 @@ export const lockScreenAction = (onLoginSuccess?: Function, errorMessage?: strin
 
 export const logoutAction = () => {
   return async (dispatch: Function) => {
+    Intercom.logout();
     navigate(NavigationActions.navigate({ routeName: ONBOARDING_FLOW }));
     dispatch({ type: LOG_OUT });
     dispatch({ type: UPDATE_APP_SETTINGS, payload: {} });

--- a/src/actions/notificationsActions.js
+++ b/src/actions/notificationsActions.js
@@ -110,7 +110,6 @@ export const startListeningIntercomNotificationsAction = () => {
 export const stopListeningIntercomNotificationsAction = () => {
   return () => {
     if (!intercomNotificationsListener) return;
-    Intercom.logout();
     Intercom.removeEventListener(Intercom.Notifications.UNREAD_COUNT, intercomNotificationsListener);
   };
 };


### PR DESCRIPTION
Covers following Intercom Push Notification issues:
1. Intercom logout is called when app becomes inactive or is locked which unsubscribes from Push Notifications.
2. Intercom Push Notifications token is never updated after registration.