### PR TITLE
Fix/nav top title overlap

### DIFF
--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -254,7 +254,9 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
                               "fontWeight": "700",
                               "lineHeight": 28,
                             },
-                            Object {},
+                            Object {
+                              "fontFamily": "Aktiv Grotesk App",
+                            },
                           ],
                         ],
                       ]

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -254,9 +254,12 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
                               "fontWeight": "700",
                               "lineHeight": 28,
                             },
-                            Object {
-                              "fontFamily": "Aktiv Grotesk App",
-                            },
+                            Array [
+                              Object {
+                                "fontFamily": "Aktiv Grotesk App",
+                              },
+                              Object {},
+                            ],
                           ],
                         ],
                       ]

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -54,7 +54,7 @@ const Text = styled(BoldText)`
   font-size: ${props => props.subtitle ? fontSizes.medium : fontSizes.large};
   font-weight: ${fontWeights.bold};
   ${({ align }) => align === 'center' && `
-    width: 100%;
+    flex: 1;
     text-align: center;
   `}
 `;

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -47,6 +47,10 @@ const Wrapper = styled.View`
     width: maxWidth;
   `}
   ${({ fullWidth }) => fullWidth ? 'width: 100%;' : ''}
+  ${({ align }) => align === 'center' && `
+    flex-direction: row;
+    align-items: center;
+  `}
 `;
 
 const Text = styled(BoldText)`

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -91,6 +91,13 @@ const Title = (props: Props) => {
 
   const noBlueDotNeeded = noBlueDot || !title;
 
+  /**
+   *  `fontFamily` has to stay here as it affects font rendering
+   *  otherwise if it's taken then once font is being shorten with ellipsis
+   *  on Android it gets cut
+   */
+  const titleStylesFix = { ...titleStyles, fontFamily: `Aktiv Grotesk App${Platform.OS === 'android' ? '_bold' : ''}` };
+
   return (
     <Wrapper
       noMargin={noMargin}
@@ -105,7 +112,7 @@ const Title = (props: Props) => {
             align={align}
             subtitle={subtitle}
             {...ellipsized}
-            style={titleStyles}
+            style={titleStylesFix}
             fullWidth={fullWidth}
           >
             {title}
@@ -117,7 +124,7 @@ const Title = (props: Props) => {
           align={align}
           subtitle={subtitle}
           {...ellipsized}
-          style={titleStyles}
+          style={titleStylesFix}
           fullWidth={fullWidth}
         >
           {title}

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -58,7 +58,7 @@ const Text = styled(BoldText)`
   font-size: ${props => props.subtitle ? fontSizes.medium : fontSizes.large};
   font-weight: ${fontWeights.bold};
   ${({ align }) => align === 'center' && `
-    flex: 1;
+    line-height: 25px;
     text-align: center;
   `}
 `;
@@ -68,6 +68,15 @@ const BlueDot = styled(BoldText)`
   font-size: ${Platform.OS === 'ios' ? 30 : 26}px;
 `;
 
+
+/**
+ *  this separate definition has to stay here as it affects font rendering
+ *  otherwise if it's taken then once font is being shorten with ellipsis
+ *  on Android it gets cut
+ */
+const AktivTextTitle = styled(Text)`
+  fontFamily: 'Aktiv Grotesk App${Platform.OS === 'android' ? '_bold' : ''};
+`;
 
 const Title = (props: Props) => {
   const ellipsized = !props.fullWidth ? {
@@ -91,13 +100,6 @@ const Title = (props: Props) => {
 
   const noBlueDotNeeded = noBlueDot || !title;
 
-  /**
-   *  `fontFamily` has to stay here as it affects font rendering
-   *  otherwise if it's taken then once font is being shorten with ellipsis
-   *  on Android it gets cut
-   */
-  const titleStylesFix = { ...titleStyles, fontFamily: `Aktiv Grotesk App${Platform.OS === 'android' ? '_bold' : ''}` };
-
   return (
     <Wrapper
       noMargin={noMargin}
@@ -108,28 +110,28 @@ const Title = (props: Props) => {
     >
       {onTitlePress ?
         <TouchableOpacity onPress={onTitlePress}>
-          <Text
+          <AktivTextTitle
             align={align}
             subtitle={subtitle}
             {...ellipsized}
-            style={titleStylesFix}
+            style={titleStyles}
             fullWidth={fullWidth}
           >
             {title}
             {!subtitle && !noBlueDotNeeded && <BlueDot dotColor={dotColor}>.</BlueDot>}
-          </Text>
+          </AktivTextTitle>
         </TouchableOpacity>
         :
-        <Text
+        <AktivTextTitle
           align={align}
           subtitle={subtitle}
           {...ellipsized}
-          style={titleStylesFix}
+          style={titleStyles}
           fullWidth={fullWidth}
         >
           {title}
           {!subtitle && !noBlueDotNeeded && <BlueDot dotColor={dotColor}>.</BlueDot>}
-        </Text>
+        </AktivTextTitle>
       }
     </Wrapper>
   );

--- a/src/components/Typography/Typography.js
+++ b/src/components/Typography/Typography.js
@@ -18,6 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import styled from 'styled-components/native';
+import { Platform } from 'react-native';
 import { UIColors, baseColors, fontSizes, fontWeights } from 'utils/variables';
 
 export const BaseText = styled.Text`
@@ -29,7 +30,7 @@ export const BaseText = styled.Text`
 `;
 
 export const BoldText = styled(BaseText)`
-  font-family: Aktiv Grotesk App;
+  font-family: Aktiv Grotesk App${Platform.OS === 'android' && '_bold'};
   font-weight: 600;
   include-font-padding: false;
   text-align-vertical: center;

--- a/src/components/Typography/Typography.js
+++ b/src/components/Typography/Typography.js
@@ -18,7 +18,6 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import styled from 'styled-components/native';
-import { Platform } from 'react-native';
 import { UIColors, baseColors, fontSizes, fontWeights } from 'utils/variables';
 
 export const BaseText = styled.Text`
@@ -30,7 +29,7 @@ export const BaseText = styled.Text`
 `;
 
 export const BoldText = styled(BaseText)`
-  font-family: Aktiv Grotesk App${Platform.OS === 'android' && '_bold'};
+  font-family: Aktiv Grotesk App;
   font-weight: 600;
   include-font-padding: false;
   text-align-vertical: center;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164678792

This PR includes few fixes in following order:
1. Fixed full width title overlapping top bar left/right controls.
2. Fixed Android cropping text issue that needed both to define other font and add `fontFamily` style to component level which solves text overflow ellipsis method as described here – https://github.com/facebook/react-native/issues/15114#issuecomment-364458149.
3. Fixed iOS issue that appeared after solving No 1 – needed to realign title to center.