### PR TITLE
Change the name of iOS and android apps to be the same

### DIFF
--- a/.circleci/announceProdBuilds.sh
+++ b/.circleci/announceProdBuilds.sh
@@ -10,9 +10,9 @@ cat <<EOM
 {
     "attachments": [
         {
-            "fallback": "$applicationName has succesfully deployed to $targetEnvironment.",
+            "fallback": "<!here> - $applicationName has succesfully deployed to $targetEnvironment.",
             "color": "#33CC66",
-            "pretext": "$applicationName has succesfully deployed to $targetEnvironment.",
+            "pretext": "<!here> - $applicationName has succesfully deployed to $targetEnvironment.",
             "title": "$CIRCLE_PROJECT_REPONAME",
             "title_link": "https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_WORKSPACE_ID",
             "text": "build number: $appBuildNumber",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,6 @@ jobs:
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            echo $APP_BUILD_NUMBER
             npm --no-git-tag-version version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$APP_BUILD_NUMBER
             export buildNumber=$(node -e "console.log(require('./package.json').version);")
             rm .env
@@ -189,7 +188,7 @@ jobs:
           command: |
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            cd ios && bundle exec fastlane deploy_ios_hockeyapp APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber
+            cd ios && bundle exec fastlane deploy_ios_hockeyapp APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Staging"
       - run:
           name: prepare to archive ipa file
           command: |
@@ -352,7 +351,7 @@ jobs:
           command: |
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            cd ios && bundle exec fastlane deploy_staging APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber
+            cd ios && bundle exec fastlane deploy_staging APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Staging"
       - run:
           name: Copy staging iOS artifact to S3
           command: |
@@ -593,7 +592,7 @@ jobs:
           command: |
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            cd ios && bundle exec fastlane deploy_prod APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber
+            cd ios && bundle exec fastlane deploy_prod APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Wallet"
       - run:
           name: Copy production iOS artifact to S3
           command: |

--- a/android/app/src/staging/res/values/strings.xml
+++ b/android/app/src/staging/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Pillar Wallet Staging</string>
+    <string name="app_name">Pillar Staging</string>
 </resources>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -11,6 +11,7 @@ platform :ios do
   lane :deploy_prod do |options|
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
     match(type: "appstore",
           readonly: true,
@@ -35,6 +36,7 @@ platform :ios do
     # insert circleCI's build number as our build number
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
     # ensure we don't have automatic code signing set up
     disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
@@ -116,6 +118,7 @@ platform :ios do
     # insert circleCI's build number as our build number
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
     # ensure we don't have automatic code signing set up
     disable_automatic_code_signing(path: "pillarwallet.xcodeproj")


### PR DESCRIPTION
This PR will align the application names on both iOS and android. Prod apps will be **Pillar Wallet**, staging and hockey apps will be **Pillar Staging**.

Also, this PR will add a mention @ here to the ProdBuilds script that sends out a message for new production app builds to the support channel.