### PR TITLE
Add Infura configuration - #164771648

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,9 @@ aliases:
           cp environments/.env.staging ./.env
           sed -i.bak "s/_build_number_/$buildNumber/g" .env
           sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+          sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
           echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
-          
+
 # Default for iOS Build machine
 defaults_ios: &defaults_ios
   working_directory: ~/pillarwallet
@@ -182,6 +183,7 @@ jobs:
             cp environments/.env.staging ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
             sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+            sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - run:
           name: Upload to Hockeyapp
@@ -257,6 +259,7 @@ jobs:
             cp environments/.env.staging ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
             sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+            sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - run:
           name: Initial build
@@ -302,6 +305,7 @@ jobs:
             cp environments/.env.staging ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
             sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+            sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: ios-node-{{ checksum "./yarn.lock" }}
@@ -543,6 +547,7 @@ jobs:
             cp environments/.env.production ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
             sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+            sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: ios-node-{{ checksum "./yarn.lock" }}
@@ -668,6 +673,7 @@ jobs:
             cp environments/.env.production ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
             sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" .env
+            sed -i.bak "s/_infura_project_id_/$INFURA_PROJECT_ID/g" .env
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - restore_cache:
           key: android-node-{{ checksum "../yarn.lock" }}

--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@ BUILD_NUMBER=STAGING::_build_number_
 BUILD_TYPE=development
 OPEN_SEA_API=https://rinkeby-api.opensea.io/api/v1
 OPEN_SEA_API_KEY=
+INFURA_PROJECT_ID=

--- a/environments/.env.production
+++ b/environments/.env.production
@@ -11,3 +11,4 @@ BUILD_NUMBER=_build_number_
 BUILD_TYPE=production
 OPEN_SEA_API=https://api.opensea.io/api/v1
 OPEN_SEA_API_KEY=_open_sea_api_key_
+INFURA_PROJECT_ID=_infura_project_id_

--- a/environments/.env.staging
+++ b/environments/.env.staging
@@ -11,3 +11,4 @@ BUILD_NUMBER=STAGING::_build_number_
 BUILD_TYPE=staging
 OPEN_SEA_API=https://rinkeby-api.opensea.io/api/v1
 OPEN_SEA_API_KEY=_open_sea_api_key_
+INFURA_PROJECT_ID=_infura_project_id_

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -19,7 +19,6 @@
 */
 import merge from 'lodash.merge';
 import { Sentry } from 'react-native-sentry';
-import { providers } from 'ethers';
 import { NETWORK_PROVIDER } from 'react-native-dotenv';
 import {
   UPDATE_ASSETS_STATE,
@@ -55,7 +54,7 @@ import type {
 } from 'models/Transaction';
 import type { Asset, Assets } from 'models/Asset';
 import { transformAssetsToObject } from 'utils/assets';
-import { delay, noop, uniqBy } from 'utils/common';
+import { delay, getEthereumProvider, noop, uniqBy } from 'utils/common';
 import { buildHistoryTransaction } from 'utils/history';
 import { saveDbAction } from './dbActions';
 import { fetchCollectiblesAction } from './collectiblesActions';
@@ -85,7 +84,7 @@ export const sendAssetAction = (
       txCount: { data: { lastNonce } },
       collectibles: { assets, transactionHistory: collectiblesHistory },
     } = getState();
-    wallet.provider = providers.getDefaultProvider(NETWORK_PROVIDER);
+    wallet.provider = getEthereumProvider(NETWORK_PROVIDER);
     const transactionCount = await wallet.provider.getTransactionCount(wallet.address, 'pending');
 
     let nonce;

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -17,18 +17,17 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import { Contract, utils, providers } from 'ethers';
+import { Contract, utils } from 'ethers';
 import { NETWORK_PROVIDER, COLLECTIBLES_NETWORK } from 'react-native-dotenv';
 import cryptocompare from 'cryptocompare';
+import { Sentry } from 'react-native-sentry';
 import { ETH, supportedFiatCurrencies } from 'constants/assetsConstants';
 import type { Asset } from 'models/Asset';
 import ERC20_CONTRACT_ABI from 'abi/erc20.json';
 import ERC721_CONTRACT_ABI from 'abi/erc721.json';
 import ERC721_CONTRACT_ABI_SAFE_TRANSFER_FROM from 'abi/erc721_safeTransferFrom.json';
 import ERC721_CONTRACT_ABI_TRANSFER_FROM from 'abi/erc721_transferFrom.json';
-import { Sentry } from 'react-native-sentry';
-
-const PROVIDER = NETWORK_PROVIDER;
+import { getEthereumProvider } from 'utils/common';
 
 type Address = string;
 
@@ -72,7 +71,7 @@ export function transferERC20(options: ERC20TransferOptions) {
     decimals = 18,
     nonce,
   } = options;
-  wallet.provider = providers.getDefaultProvider(PROVIDER);
+  wallet.provider = getEthereumProvider(NETWORK_PROVIDER);
   const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, wallet);
   if (decimals > 0) {
     return contract.transfer(to, utils.parseUnits(amount.toString(), decimals), { nonce });
@@ -89,7 +88,7 @@ export async function transferERC721(options: ERC721TransferOptions) {
     wallet,
     nonce,
   } = options;
-  wallet.provider = providers.getDefaultProvider(COLLECTIBLES_NETWORK);
+  wallet.provider = getEthereumProvider(COLLECTIBLES_NETWORK);
 
   const code = await wallet.provider.getCode(contractAddress).then((result) => result);
 
@@ -138,24 +137,24 @@ export function transferETH(options: ETHTransferOptions) {
     to,
     nonce,
   };
-  wallet.provider = providers.getDefaultProvider(PROVIDER);
+  wallet.provider = getEthereumProvider(NETWORK_PROVIDER);
   return wallet.sendTransaction(trx);
 }
 
 // Fetch methods are temporary until the BCX API provided
 
 export function fetchETHBalance(walletAddress: Address) {
-  const provider = providers.getDefaultProvider(PROVIDER);
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
   return provider.getBalance(walletAddress).then(utils.formatEther);
 }
 
 export function fetchRinkebyETHBalance(walletAddress: Address) {
-  const provider = providers.getDefaultProvider('rinkeby');
+  const provider = getEthereumProvider('rinkeby');
   return provider.getBalance(walletAddress).then(utils.formatEther);
 }
 
 export function fetchERC20Balance(walletAddress: Address, contractAddress: Address, decimals: number = 18) {
-  const provider = providers.getDefaultProvider(PROVIDER);
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
   const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, provider);
   return contract.balanceOf(walletAddress).then((wei) => utils.formatUnits(wei, decimals));
 }
@@ -181,17 +180,17 @@ export function getExchangeRates(assets: string[]): Promise<?Object> {
 
 // from the getTransaction() method you'll get the the basic tx info without the status
 export function fetchTransactionInfo(hash: string): Promise<?Object> {
-  const provider = providers.getDefaultProvider(PROVIDER);
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
   return provider.getTransaction(hash).catch(() => null);
 }
 
 // receipt available for mined transactions only, here you can get the status of the tx
 export function fetchTransactionReceipt(hash: string): Promise<?Object> {
-  const provider = providers.getDefaultProvider(PROVIDER);
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
   return provider.getTransactionReceipt(hash).catch(() => null);
 }
 
 export function fetchLastBlockNumber(): Promise<number> {
-  const provider = providers.getDefaultProvider(PROVIDER);
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
   return provider.getBlockNumber().then(parseInt).catch(() => 0);
 }

--- a/src/testUtils/jestSetup.js
+++ b/src/testUtils/jestSetup.js
@@ -76,9 +76,9 @@ jest.setMock('ethers', {
   },
   providers: {
     getDefaultProvider: () => mockInjectedProvider,
-    JsonRpcProvider: () => mockInjectedProvider,
-    EtherscanProvider: () => mockInjectedProvider,
-    FallbackProvider: () => mockInjectedProvider,
+    JsonRpcProvider: jest.fn().mockImplementation(() => mockInjectedProvider),
+    EtherscanProvider: jest.fn().mockImplementation(() => mockInjectedProvider),
+    FallbackProvider: jest.fn().mockImplementation(() => mockInjectedProvider),
   },
 });
 

--- a/src/testUtils/jestSetup.js
+++ b/src/testUtils/jestSetup.js
@@ -59,6 +59,10 @@ Object.defineProperty(mockWallet, 'RNencrypt', {
   value: () => Promise.resolve({ address: 'encry_pted' }),
 });
 
+const mockInjectedProvider = {
+  getBalance: () => Promise.resolve(1), // dummy balance
+};
+
 jest.setMock('ethers', {
   Wallet: {
     fromMnemonic: () => mockWallet,
@@ -71,9 +75,10 @@ jest.setMock('ethers', {
     getAddress: utils.getAddress,
   },
   providers: {
-    getDefaultProvider: () => ({
-      getBalance: () => Promise.resolve(1), // ropsten dummy balance
-    }),
+    getDefaultProvider: () => mockInjectedProvider,
+    JsonRpcProvider: () => mockInjectedProvider,
+    EtherscanProvider: () => mockInjectedProvider,
+    FallbackProvider: () => mockInjectedProvider,
   },
 });
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -28,6 +28,8 @@ import {
   AppState,
   DeviceEventEmitter,
 } from 'react-native';
+import { providers } from 'ethers';
+import { INFURA_PROJECT_ID } from 'react-native-dotenv';
 
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -213,3 +215,20 @@ export const smallScreen = () => {
   }
   return Dimensions.get('window').width < 410;
 };
+
+export function getEthereumProvider(network: string) {
+  // Connect to INFURA
+  const infuraNetwork = (network === 'homestead') ? 'mainnet' : network;
+  const infuraUrl = `https://${infuraNetwork}.infura.io/v3/${INFURA_PROJECT_ID}`;
+  const infuraProvider = new providers.JsonRpcProvider(infuraUrl, network);
+
+  // Connect to Etherscan
+  const etherscanProvider = new providers.EtherscanProvider(network);
+
+  // Creating a provider to automatically fallback onto Etherscan
+  // if INFURA is down
+  return new providers.FallbackProvider([
+    infuraProvider,
+    etherscanProvider,
+  ]);
+}


### PR DESCRIPTION
This PR adds configuration for Infura and changes the way we connect to different Ethereum providers. As the first source, we will use the Infura Provider, if this service is off, then we use Etherscan as a fallback.
Task [164771648](https://www.pivotaltracker.com/story/show/164771648)