### PR TITLE
Remove stage_ios from prod approval step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -819,7 +819,6 @@ workflows:
       - release_to_prod:
           type: approval
           requires:
-            - stage_ios
             - stage_android
       - prod_ios:
           requires:


### PR DESCRIPTION
Remove stage_ios from approval step so we can trigger a prod build for android.