### PR TITLE
remove Audio permissions for RNCamera (not needed)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,9 +32,6 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />

--- a/ios/pillarwallet/Info.plist
+++ b/ios/pillarwallet/Info.plist
@@ -77,8 +77,6 @@
 	<string>Allow Pillar Wallet to access your contacts</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Allow Pillar Wallet to use your location</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Allow Pillar Wallet to access your microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Allow Pillar Wallet to access your device&apos;s accelerometer</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/src/components/Camera/Camera.js
+++ b/src/components/Camera/Camera.js
@@ -354,6 +354,7 @@ class Camera extends React.Component<Props, State> {
       <React.Fragment>
         {!!isVisible &&
         <RNCamera
+          captureAudio={false}
           ref={ref => {
             this.camera = ref;
           }}

--- a/src/components/QRCodeScanner/QRCodeScanner.js
+++ b/src/components/QRCodeScanner/QRCodeScanner.js
@@ -178,6 +178,7 @@ export default class QRCodeScanner extends React.Component<Props, State> {
     const handleQRRead = Platform.OS === 'ios' ? this.handleIosQRRead : this.handleAndroidQRRead;
     return (
       <RNCamera
+        captureAudio={false}
         ref={ref => {
           this.camera = ref;
         }}


### PR DESCRIPTION
This PR removes the permissions required for `Video` with `RNCamera` since that feature is not used, on android the permissions removed are:
```
<uses-permission android:name="android.permission.RECORD_AUDIO"/>
<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
```
and iOS
```
<!-- Include this only if you are planning to use the microphone for video recording -->
<key>NSMicrophoneUsageDescription</key>
<string>Your message to user when the microphone is accessed for the first time</string>
```

Also `captureAudio` prop is set to false explicitly otherwise iOS was throwing a warning.