### PR TITLE
Change production ios prov. profile

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
 
     sigh(force: true)
 
-    sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.staging.mobileprovision'"
+    sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.mobileprovision'"
 
     commit = last_git_commit
     upload_to_testflight(changelog: commit[:message],


### PR DESCRIPTION
Wrong prov. profile was used for resigning ios prod build, correct one added now.