### PR TITLE
Fix/artifactory 401 error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
       - *node_restore_cache
       - *node_artifactory_authenticate
       - *node_artifactory_set_registry
-      - *ios_latest_yarn
+#      - *ios_latest_yarn
       - *yarn_install
       - *node_save_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
       - *node_restore_cache
       - *node_artifactory_authenticate
       - *node_artifactory_set_registry
-      - *android_latest_yarn
+#      - *android_latest_yarn
       - *yarn_install
       - *node_save_cache
 
@@ -414,7 +414,7 @@ jobs:
       - attach_workspace: &attach_workspace
           at: /tmp/workspace
 
-      - *android_latest_yarn
+#      - *android_latest_yarn
 
       - run:
           name: Install Python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,7 +825,7 @@ workflows:
           filters:
             branches:
               only:
-                  - fix/artifactory-401-error
+                  - develop
       - stage_ios:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
       - *node_restore_cache
       - *node_artifactory_authenticate
       - *node_artifactory_set_registry
-      - *ios_latest_yarn
+#      - *ios_latest_yarn
       - *yarn_install
       - *node_save_cache
 
@@ -329,7 +329,7 @@ jobs:
             name: set Registry to use Artifactory
             command: npm config set registry https://pillarproject.jfrog.io/pillarproject/api/npm/npm/
 
-      - *ios_latest_yarn
+#      - *ios_latest_yarn
 
       - run:
           name: Install node dependencies
@@ -825,7 +825,7 @@ workflows:
           filters:
             branches:
               only:
-                  - develop
+                  - fix/artifactory-401-error
       - stage_ios:
           requires:
             - build-and-test


### PR DESCRIPTION
Removing the npm install yarn command on the ios image beacuse it fails with that:

```
npm ERR! code E401
npm ERR! Unable to authenticate, need: Basic realm="Artifactory Realm"
```

Same command on android image is not failing, tested, but removing it as well just to not have differences.