### PR TITLE
fix/require PIN on Token Generation When State Changed

### DIFF
--- a/src/actions/__tests__/connectionKeyPairActions.test.js
+++ b/src/actions/__tests__/connectionKeyPairActions.test.js
@@ -314,13 +314,13 @@ describe('ConnectionKeyPair actions', () => {
       const expectedActions = [
         { type: UPDATE_WALLET_STATE, payload: GENERATING_CONNECTIONS },
         { type: UPDATE_CONNECTION_KEY_PAIRS, payload: [...connectionKeyPairsMock] },
-        { type: UPDATE_WALLET_STATE, payload: DECRYPTED },
         { type: UPDATE_CONNECTION_KEY_PAIRS, payload: [...connectionKeyPairsMock.slice(2, 7)] },
         { type: UPDATE_CONNECTION_KEY_PAIRS, payload: [...connectionKeyPairsMock.slice(2, 7)] },
         { type: UPDATE_CONNECTION_IDENTITY_KEYS, payload: mapIdentityKeysResponseMock.slice(0, 2) },
         { type: UPDATE_INVITATIONS, payload: [...invitationsMock] },
         { type: UPDATE_CONTACTS, payload: [...contactsMock] },
         { type: UPDATE_CONNECTION_IDENTITY_KEYS, payload: [] },
+        { type: UPDATE_WALLET_STATE, payload: DECRYPTED },
       ];
 
       // $FlowFixMe

--- a/src/actions/connectionKeyPairActions.js
+++ b/src/actions/connectionKeyPairActions.js
@@ -251,10 +251,6 @@ export const updateConnectionKeyPairs = (
           payload: DECRYPTED,
         });
       }
-      await dispatch({
-        type: UPDATE_WALLET_STATE,
-        payload: DECRYPTED,
-      });
     }
 
     if (oldConnectionsCount > 0 || (currentConnectionsCount - connectionIdentityKeys.length) > 0) {
@@ -265,6 +261,11 @@ export const updateConnectionKeyPairs = (
     }
 
     await dispatch(updateConnectionsAction(walletId));
+
+    await dispatch({
+      type: UPDATE_WALLET_STATE,
+      payload: DECRYPTED,
+    });
 
     return Promise.resolve(true);
   };

--- a/src/screens/PinCodeUnlock/PinCodeUnlock.js
+++ b/src/screens/PinCodeUnlock/PinCodeUnlock.js
@@ -55,8 +55,8 @@ class PinCodeUnlock extends React.Component<Props> {
 
   componentDidMount() {
     addAppStateChangeListener(this.handleAppStateChange);
-    const { useBiometrics, connectionKeyPairs: { data, lastConnectionKeyIndex } } = this.props;
-    if (useBiometrics && !this.errorMessage && data.length > 20 && lastConnectionKeyIndex > -1) {
+    const { useBiometrics } = this.props;
+    if (useBiometrics && !this.errorMessage) {
       this.showBiometricLogin();
     }
   }
@@ -73,13 +73,15 @@ class PinCodeUnlock extends React.Component<Props> {
   };
 
   showBiometricLogin() {
-    const { login } = this.props;
-    TouchID.authenticate('Biometric login')
-      .then(() => {
-        removeAppStateChangeListener(this.handleAppStateChange);
-        login('', true);
-      })
-      .catch(() => null);
+    const { login, connectionKeyPairs: { data, lastConnectionKeyIndex } } = this.props;
+    if (data.length > 20 && lastConnectionKeyIndex > -1) {
+      TouchID.authenticate('Biometric login')
+        .then(() => {
+          removeAppStateChangeListener(this.handleAppStateChange);
+          login('', true);
+        })
+        .catch(() => null);
+    }
   }
 
   handlePinSubmit = (pin: string) => {

--- a/src/utils/keyPairGenerator.js
+++ b/src/utils/keyPairGenerator.js
@@ -68,10 +68,10 @@ const threadJobWorkerSeed = (
 ) => {
   return () => {
     return new Promise((resolve, reject) => {
-      let count = 20;
-      let lastCount = connectionsCount + (threadIndex * 20);
+      let count = 10;
+      let lastCount = lastConnectionKeyIndex + (threadIndex * count);
       if (lastConnectionKeyIndex < 0) {
-        count = Math.ceil((100 + connectionsCount) / 5);
+        count = Math.ceil((50 + connectionsCount) / 5);
         lastCount = threadIndex * count;
       }
       try {


### PR DESCRIPTION
Check if key need to be generated on login w/o biometrics