### PR TITLE
Change hockey app branch trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,14 +817,14 @@ workflows:
           filters:
             branches:
               only:
-                  - develop
+                  - feature/smart-wallet-sdk
       - dev_build_android:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - develop
+                  - feature/smart-wallet-sdk
       - stage_ios:
           requires:
             - build-and-test


### PR DESCRIPTION
Since we need hockey builds for this week out of the smart-wallet feature branch, I am changing this in develop as well so we don't get any discrepancies and different versions in hockey.