### PR TITLE
Fix/sliding modal tab overlap

### DIFF
--- a/src/actions/__tests__/onboardingActions.test.js
+++ b/src/actions/__tests__/onboardingActions.test.js
@@ -26,6 +26,7 @@ import {
   GENERATING,
   ENCRYPTING,
   REGISTERING,
+  DECRYPTED,
 } from 'constants/walletConstants';
 import { SET_INITIAL_ASSETS, UPDATE_ASSETS } from 'constants/assetsConstants';
 import { UPDATE_CONTACTS } from 'constants/contactsConstants';
@@ -132,6 +133,7 @@ describe('Wallet actions', () => {
       { type: UPDATE_SESSION, payload: { isSignalInitiated: true } },
       { type: UPDATE_RATES, payload: mockExchangeRates },
       { type: SET_INITIAL_ASSETS, payload: transformAssetsToObject(mockInitialAssets) },
+      { type: UPDATE_WALLET_STATE, payload: DECRYPTED },
     ];
 
     // $FlowFixMe
@@ -172,6 +174,7 @@ describe('Wallet actions', () => {
       { type: UPDATE_SESSION, payload: { isSignalInitiated: true } },
       { type: UPDATE_RATES, payload: mockExchangeRates },
       { type: SET_INITIAL_ASSETS, payload: transformAssetsToObject(mockInitialAssets) },
+      { type: UPDATE_WALLET_STATE, payload: DECRYPTED },
     ];
 
     return store.dispatch(registerWalletAction())

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -36,6 +36,7 @@ import {
   SET_API_USER,
   INAPPROPRIATE_USERNAME,
   INVALID_USERNAME,
+  DECRYPTED,
 } from 'constants/walletConstants';
 import { APP_FLOW, NEW_WALLET, ASSETS } from 'constants/navigationConstants';
 import { SET_INITIAL_ASSETS, UPDATE_ASSETS } from 'constants/assetsConstants';
@@ -134,6 +135,11 @@ const finishRegistration = async (
 
   // restore access tokens
   await dispatch(restoreAccessTokensAction(userInfo.walletId)); // eslint-disable-line
+
+  await dispatch({
+    type: UPDATE_WALLET_STATE,
+    payload: DECRYPTED,
+  });
 };
 
 const navigateToAppFlow = (isWalletBackedUp: boolean) => {

--- a/src/components/BottomSheet/BottomSheet.js
+++ b/src/components/BottomSheet/BottomSheet.js
@@ -87,6 +87,18 @@ const FloatingHeader = styled.View`
   top: 0;
   left: 0;
   z-index: 10;
+  background-color: transparent;
+  border-top-left-radius: 30px;
+  border-top-right-radius: 30px;
+  min-height: 80px;
+`;
+
+const Cover = styled.View`
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
   background-color: white;
   border-top-left-radius: 30px;
   border-top-right-radius: 30px;
@@ -309,6 +321,7 @@ export default class BottomSheet extends React.Component<Props, State> {
         useNativeDriver
       >
         <FloatingHeader>
+          <Cover />
           {floatingHeaderContent}
         </FloatingHeader>
         <ModalWrapperAnimated style={{ height: animatedHeight }}>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -34,7 +34,7 @@ type Props = {
   onNextPress?: ?Function,
   onTitlePress?: Function,
   nextText?: string,
-  nextIcon?: string,
+  nextIcon?: ?string,
   title?: string,
   fullWidthTitle?: boolean,
   noBlueDotOnTitle?: boolean,

--- a/src/components/Layout/ContainerWithBottomSheet.js
+++ b/src/components/Layout/ContainerWithBottomSheet.js
@@ -69,7 +69,7 @@ export default class ContainerWithBottomSheet extends React.Component<Props, Sta
     const { screenHeight } = this.state;
     const bottomPadding = !hideSheet && screenHeight && Object.keys(bottomSheetProps).length
     && !!bottomSheetProps.initialSheetHeight
-      ? bottomSheetProps.initialSheetHeight - 20
+      ? bottomSheetProps.initialSheetHeight - 30
       : 0;
 
     return (

--- a/src/components/ListItem/ListItemWithImage.js
+++ b/src/components/ListItem/ListItemWithImage.js
@@ -18,7 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import styled from 'styled-components/native';
 import { CachedImage } from 'react-native-cached-image';
 import isEqualWith from 'lodash.isequalwith';
@@ -63,6 +63,7 @@ type Props = {
   imageAddonUrl?: string,
   imageAddonName?: string,
   imageUpdateTimeStamp?: number,
+  rightColumnInnerStyle?: Object,
 }
 
 const ItemWrapper = styled.TouchableOpacity`
@@ -204,6 +205,7 @@ const ItemValueStatus = styled(Icon)`
 
 const IndicatorsRow = styled.View`
   flex-direction: row;
+  padding-left: 8px;
 `;
 
 const ActionLabel = styled.View`
@@ -456,6 +458,7 @@ class ListItemWithImage extends React.Component<Props, {}> {
       imageAddonUrl,
       imageAddonIconName,
       imageAddonName,
+      rightColumnInnerStyle,
     } = this.props;
 
     const type = getType(this.props);
@@ -502,9 +505,11 @@ class ListItemWithImage extends React.Component<Props, {}> {
             }
           </Column>
           <Column rightColumn type={type}>
-            <Addon {...this.props} type={type} />
-            {customAddon}
-            {children}
+            <View style={rightColumnInnerStyle}>
+              {customAddon}
+              <Addon {...this.props} type={type} />
+              {children}
+            </View>
           </Column>
         </InfoWrapper>
       </ItemWrapper>

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -6,8 +6,6 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
   hardwareAccelerated={false}
   hideModalContentWhileAnimating={false}
   onModalHide={[Function]}
-  onModalWillHide={[Function]}
-  onModalWillShow={[Function]}
   onRequestClose={[Function]}
   onSwipe={[Function]}
   scrollOffset={0}
@@ -49,8 +47,6 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
   <View
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
-    onModalWillHide={[Function]}
-    onModalWillShow={[Function]}
     onMoveShouldSetResponder={[Function]}
     onMoveShouldSetResponderCapture={[Function]}
     onResponderEnd={[Function]}

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -6,6 +6,8 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
   hardwareAccelerated={false}
   hideModalContentWhileAnimating={false}
   onModalHide={[Function]}
+  onModalWillHide={[Function]}
+  onModalWillShow={[Function]}
   onRequestClose={[Function]}
   onSwipe={[Function]}
   scrollOffset={0}
@@ -47,6 +49,8 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
   <View
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onMoveShouldSetResponder={[Function]}
     onMoveShouldSetResponderCapture={[Function]}
     onResponderEnd={[Function]}

--- a/src/navigation/appNavigation.js
+++ b/src/navigation/appNavigation.js
@@ -38,7 +38,7 @@ import AssetScreen from 'screens/Asset';
 import MarketScreen from 'screens/Market';
 import ProfileScreen from 'screens/Profile';
 import PeopleScreen from 'screens/People';
-import ContactScreen from 'screens/Contact/ContactDetails';
+import ContactScreen from 'screens/Contact';
 import ConnectionRequestsScreen from 'screens/ConnectionRequests';
 import ChangePinCurrentPinScreen from 'screens/ChangePin/CurrentPin';
 import ChangePinNewPinScreen from 'screens/ChangePin/NewPin';

--- a/src/screens/Contact/Contact.js
+++ b/src/screens/Contact/Contact.js
@@ -340,7 +340,7 @@ class Contact extends React.Component<Props, State> {
           onBack={() => navigation.goBack(null)}
           showRight
           onNextPress={this.showManageContactModalTrigger}
-          nextIcon="more"
+          nextIcon={displayContact.status ? 'more' : null}
         />
         <ScrollWrapper
           refreshControl={

--- a/src/screens/Contact/ContactDetails.js
+++ b/src/screens/Contact/ContactDetails.js
@@ -314,7 +314,7 @@ class Contact extends React.Component<Props, State> {
           showRight
           onNextPress={this.showManageContactModalTrigger}
           onTitlePress={this.handleUsernameTap}
-          nextIcon="more"
+          nextIcon={displayContact.status ? 'more' : null}
         />
         {!tabActiveTap &&
         <ScrollWrapper

--- a/src/screens/Contact/ManageContactModal.js
+++ b/src/screens/Contact/ManageContactModal.js
@@ -32,7 +32,7 @@ type Props = {
 };
 
 const buttonStyle = {
-  marginBottom: 13,
+  marginBottom: 12,
 };
 
 const manageModalButtons = [
@@ -41,14 +41,14 @@ const manageModalButtons = [
     primaryInverted: true,
     title: 'Mute',
     icon: 'mute',
-    style: { ...buttonStyle, marginTop: 23 },
+    style: { ...buttonStyle, marginTop: 12 },
   },
   {
     manageType: DISCONNECT,
     primaryInverted: true,
     title: 'Disconnect',
     icon: 'remove',
-    style: { ...buttonStyle, marginTop: 23, marginBottom: 58 },
+    style: { ...buttonStyle },
   },
   {
     manageType: BLOCK,

--- a/src/screens/People/People.js
+++ b/src/screens/People/People.js
@@ -34,7 +34,8 @@ import orderBy from 'lodash.orderby';
 import isEqual from 'lodash.isequal';
 import capitalize from 'lodash.capitalize';
 import styled from 'styled-components/native';
-import { Icon } from 'native-base';
+import { Icon as NIcon } from 'native-base';
+import Icon from 'components/Icon';
 import {
   searchContactsAction,
   resetSearchContactsStateAction,
@@ -77,7 +78,7 @@ const ConnectionRequestBannerText = styled(BaseText)`
   font-size: ${fontSizes.medium};
 `;
 
-const ConnectionRequestBannerIcon = styled(Icon)`
+const ConnectionRequestBannerIcon = styled(NIcon)`
   font-size: ${fontSizes.medium};
   color: ${baseColors.darkGray};
   margin-left: auto;
@@ -96,6 +97,24 @@ const EmptyStateBGWrapper = styled.View`
   left: 0;
   width: 100%;
   padding: 0 20px 20px;
+`;
+
+const ItemBadge = styled.View`
+  height: 20px;
+  width: 20px;
+  border-radius: 10px;
+  background-color: ${baseColors.electricBlue}
+  padding: 3px 0;
+  margin-top: 2px;
+  margin-right: 1px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const BadgeIcon = styled(Icon)`
+  font-size: ${fontSizes.extraExtraSmall};
+  line-height: ${fontSizes.extraExtraSmall};
+  color: ${baseColors.white};
 `;
 
 const MIN_QUERY_LENGTH = 2;
@@ -118,6 +137,10 @@ type Props = {
   chats: Object[],
 }
 
+type ConnectionStatusProps = {
+  status: string,
+}
+
 type State = {
   query: string,
   showConfirmationModal: boolean,
@@ -125,6 +148,25 @@ type State = {
   manageContactId: string,
   forceHideRemoval: boolean,
 }
+
+const ConnectionStatus = (props: ConnectionStatusProps) => {
+  let iconName = '';
+  switch (props.status) {
+    case 'blocked':
+      iconName = 'warning';
+      break;
+    case 'muted':
+      iconName = 'mute';
+      break;
+    default:
+      break;
+  }
+  return (
+    <ItemBadge>
+      <BadgeIcon name={iconName} />
+    </ItemBadge>
+  );
+};
 
 class PeopleScreen extends React.Component<Props, State> {
   didBlur: NavigationEventSubscription;
@@ -243,9 +285,7 @@ class PeopleScreen extends React.Component<Props, State> {
   };
 
   renderContact = ({ item }) => {
-    // please refer to https://www.pivotaltracker.com/story/show/163147492
-    // to understand the reason for the temporary disabling of swipeout feature
-    const { unread = 0 } = item;
+    const { unread = 0, status = '' } = item;
     const unreadCount = unread > 9 ? '9+' : unread;
     return (
       <Swipeout
@@ -262,6 +302,8 @@ class PeopleScreen extends React.Component<Props, State> {
           navigateToProfile={this.handleContactCardPress(item)}
           imageUpdateTimeStamp={item.lastUpdateTime}
           unreadCount={unreadCount}
+          customAddon={(status === 'muted' || status === 'blocked') ? <ConnectionStatus status={status} /> : null}
+          rightColumnInnerStyle={{ flexDirection: 'row' }}
         />
       </Swipeout>
     );


### PR DESCRIPTION
- Fixed tab overlap in the Sliding modal
- 'More' icon removed from non-contacts details
- Fixed stuck spinner after wallet locks
- Added icons for muted/blocked connections