### PR TITLE
rn-signal-protocol-messaging version 1.0.212

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "redux-async-queue": "^1.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
-    "rn-signal-protocol-messaging": "1.0.209",
+    "rn-signal-protocol-messaging": "1.0.212",
     "shuffle-array": "^1.0.1",
     "stream-browserify": "^1.0.0",
     "string_decoder": "~0.10.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12994,10 +12994,10 @@ rn-nodeify@^10.0.1:
     semver "^5.0.1"
     xtend "^4.0.0"
 
-rn-signal-protocol-messaging@1.0.209:
-  version "1.0.209"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.209.tgz#8c1158091f313e0851a4a961873a59774a004016"
-  integrity sha1-jBFYCR8xPghRpKlhhzpZd0oAQBY=
+rn-signal-protocol-messaging@1.0.212:
+  version "1.0.212"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/rn-signal-protocol-messaging/-/rn-signal-protocol-messaging-1.0.212.tgz#10c6b8d2bfa11cd6510779516962b3404c5f2134"
+  integrity sha1-EMa40r+hHNZRB3lRaWKzQExfITQ=
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
This includes fix for issue that was in Signal client for iOS.

The RN bridge method that was used to build payload for WS message was setting `silent: true` and on Signal back-end notifications are not delivered only if message is marked as silent or has `tx-note` tag, however, this case messages sent from iOS were already marked as silent and weren't going through Push Notification flow.

Changed Signal client `prepareApiBody` RN bridge method `silent` param to `false` as this method is used for WebSocket messaging only and Push Notification sending for chat tag messages is done on Signal back-end side.