### PR TITLE
Configure gym command throughout all ios jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,19 @@ aliases:
     restore_cache:
       keys:
         - ios-pods-{{ checksum "./ios/Podfile.lock" }}
+  - &fetch_pods
+    run:
+      name: Fetch CocoaPods
+      command: |
+        Y | sudo gem uninstall cocoapods
+        sudo gem install cocoapods -v 1.5.3
+        curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
   - &install_pods
     run:
       name: Install CocoaPods
-      command: cd ios && bundle exec pod check || ((curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf) && bundle exec pod repo update && bundle exec pod install)
+      command: |
+        cd ios
+        pod install --verbose
   - &save_pod_cache
     save_cache:
       key: ios-pods-{{ checksum "./ios/Podfile.lock" }}
@@ -188,6 +197,7 @@ jobs:
       - *save_gems_cache_ios
 
       - *restore_pod_cache
+      - *fetch_pods
       - *install_pods
       - *save_pod_cache
 
@@ -217,7 +227,7 @@ jobs:
           name: prepare to archive ipa file
           command: |
             mkdir -p ./toArchive
-            cp ./ios/pillarwallet-staging.ipa ./toArchive
+            cp ./ios/output/gym/pillarwallet-staging.ipa ./toArchive
       - store_artifacts:
           path: ./toArchive
           destination: app_build
@@ -602,12 +612,11 @@ jobs:
           command: |
             Y | sudo gem uninstall cocoapods
             sudo gem install cocoapods -v 1.5.3
-            pod --version
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run:
           name: Install CocoaPods
           command: |
             cd ios
-            pod repo update
             pod install --verbose
       - save_cache:
           key: ios-pods-{{ checksum "./ios/Podfile.lock" }}
@@ -645,10 +654,15 @@ jobs:
             aws s3 cp pillarwallet.ipa $PILLAR_PROD_ARTIFACTS_BUCKET/pillarwallet-ios-prod-$APP_BUILD_NUMBER.ipa --region eu-west-2
             aws s3 presign $PILLAR_PROD_ARTIFACTS_BUCKET/pillarwallet-ios-prod-$APP_BUILD_NUMBER.ipa --expires-in 604800 --region eu-west-2 > ios-s3-URL-prod.txt
       - run:
-           name: Announce Deployment
+           name: Announce Prod Builds
            command: |
              chmod +x .circleci/announceProdBuilds.sh
              .circleci/announceProdBuilds.sh "Pillar Wallet" "Production TestFlight" "$(cat /tmp/workspace/build-num/app_build_number.txt)"
+      - run:
+           name: Announce Deployment
+           command: |
+             chmod +x .circleci/announceDeployment.sh
+             .circleci/announceDeployment.sh "Pillar Wallet" "Production TestFlight" "$(cat /tmp/workspace/build-num/app_build_number.txt)"
       - run:
           name: Announce production iOS URL
           command: |
@@ -787,11 +801,16 @@ jobs:
             aws s3 cp app-prod-release.apk $PILLAR_PROD_ARTIFACTS_BUCKET/pillarwallet-android-prod-$APP_BUILD_NUMBER.apk --region eu-west-2
             aws s3 presign $PILLAR_PROD_ARTIFACTS_BUCKET/pillarwallet-android-prod-$APP_BUILD_NUMBER.apk --expires-in 604800 --region eu-west-2 > android-s3-URL-prod.txt
       - run:
-          name: Announce Deployment
+          name: Announce Prod Builds
           command: |
             cd ~/pillarwallet
             chmod +x .circleci/announceProdBuilds.sh
             .circleci/announceProdBuilds.sh "Pillar Wallet" "Production Google Play Store" "$(cat /tmp/workspace/build-num/app_build_number.txt)"
+      - run:
+           name: Announce Deployment
+           command: |
+             chmod +x .circleci/announceDeployment.sh
+             .circleci/announceDeployment.sh "Pillar Wallet" "Production Google Play Store" "$(cat /tmp/workspace/build-num/app_build_number.txt)"
       - run:
           name: Announce Prod Android URL
           command: |
@@ -826,14 +845,14 @@ workflows:
           filters:
             branches:
               only:
-                  - feature/smart-wallet-sdk
+                  - develop
       - hockeyapp_android:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - feature/smart-wallet-sdk
+                  - develop
       - stage_ios:
           requires:
             - build-and-test

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,12 +13,16 @@ platform :ios do
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
+    MY_APP_ID = "com.pillarproject.wallet"
+    MY_PROFILE = "match AppStore com.pillarproject.wallet"
+
     match(type: "appstore",
           readonly: true,
           git_branch: "master",
           app_identifier: "com.pillarproject.wallet",
           team_id: "J9DEY3FGPD"
         )
+
     #sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration release -scheme pillarwallet -derivedDataPath ../build"
     #sh "mkdir -p ../build/pillarwallet/Payload && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet.ipa *"
 
@@ -26,14 +30,25 @@ platform :ios do
       workspace: "pillarwallet.xcworkspace",
       configuration: "Release",
       scheme: "pillarwallet",
+      xcargs: "-UseModernBuildSystem='NO' BUNDLE_IDENTIFIER='com.pillarproject.wallet' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.pillarproject.wallet' DEVELOPMENT_TEAM='J9DEY3FGPD'",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: { 
+            MY_APP_ID => MY_PROFILE
+        }
+      },
       clean: true,
       derived_data_path: "build",
-      xcargs: "-UseModernBuildSystem=NO"
     )
 
-    sigh(force: true)
+    # xcargs arguments, especially PROVISIONING_PROFILE_SPECIFIER need to be checked when the current Distribution cert. & prov. profile expire. Steps that should be done:
+    # 1. Delete the expired prov. profile.
+    # 2. Run match with readonly set to false in order for match to create a new Distribution certificate and a new provisioning profile.
+    # When the new one is created, using match, it should be created with the same name, so we should expect no changes/problems to occure in the gym stage.
 
-    sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.mobileprovision'"
+    #sigh(force: true)
+
+    #sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.mobileprovision'"
 
     commit = last_git_commit
     upload_to_testflight(changelog: commit[:message],
@@ -50,7 +65,10 @@ platform :ios do
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
     # ensure we don't have automatic code signing set up
-    disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
+    #disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
+
+    MY_APP_ID = "com.pillarproject.wallet.staging"
+    MY_PROFILE = "match AppStore com.pillarproject.wallet.staging"
 
     # get our provisioning profile
     match(type: "appstore",
@@ -61,7 +79,7 @@ platform :ios do
     )
 
     # get our push-notification cert
-    get_push_certificate(
+    pem(
       force: false,
       app_identifier: "com.pillarproject.wallet.staging",
       team_id: "J9DEY3FGPD",
@@ -71,9 +89,15 @@ platform :ios do
       workspace: "pillarwallet.xcworkspace",
       configuration: "Staging.Release",
       scheme: "Staging",
+      xcargs: "-UseModernBuildSystem='NO' BUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.pillarproject.wallet.staging' DEVELOPMENT_TEAM='J9DEY3FGPD'",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: { 
+            MY_APP_ID => MY_PROFILE
+        }
+      },
       clean: true,
-      derived_data_path: "build",
-      xcargs: "-UseModernBuildSystem=NO"
+      derived_data_path: "build"
     )
 
     # trigger the build
@@ -83,13 +107,13 @@ platform :ios do
     #sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
 
     # download the signing cert
-    sigh(
-      app_identifier: "com.pillarproject.wallet.staging",
-      force: true
-    )
+    #sigh(
+      #app_identifier: "com.pillarproject.wallet.staging",
+      #force: true
+    #)
 
     # apply the signing certs to the build
-    sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.staging.mobileprovision'"
+    #sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.staging.mobileprovision'"
 
     # questions remaining:
     # 1. do we need to download certs, then build, then download more certs and re-sign? sounds like at least one step doesnt' need doing
@@ -135,13 +159,16 @@ platform :ios do
   desc "Release to adhoc TestFlight"
   lane :deploy_ios_hockeyapp do |options|
 
+    MY_APP_ID = "com.pillarproject.wallet.staging"
+    MY_PROFILE = "match AdHoc com.pillarproject.wallet.staging 1557933129"
+
     # insert circleCI's build number as our build number
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
 
     # ensure we don't have automatic code signing set up
-    disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
+    #disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
 
     #register_devices(devices_file: "./devices.txt")
     register_devices(
@@ -154,37 +181,50 @@ platform :ios do
           git_branch: "develop",
           app_identifier: "com.pillarproject.wallet.staging",
           team_id: "J9DEY3FGPD",
-          force_for_new_devices: true)
+          force_for_new_devices: true
+          )
 
     # get our appstore provisioning profile
-    match(type: "appstore",
-      readonly: true,
-      git_branch: "develop",
-      app_identifier: "com.pillarproject.wallet.staging",
-      team_id: "J9DEY3FGPD",
-    )
-    # get our push-notification cert
-    get_push_certificate(
-      force: false,
-      app_identifier: "com.pillarproject.wallet.staging",
-      team_id: "J9DEY3FGPD",
-    )
-
-    # trigger the build
-    sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration Staging.Release -scheme Staging -derivedDataPath ../build -verbose "
-
-    # manually zip the results into an ipa
-    sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
-
-    #resign(
-    #  ipa: "pillarwallet-staging.ipa",
-    #  signing_identity: "iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)",
-    #  provisioning_profile: {
-    #    "com.pillarproject.wallet.staging" => ENV["sigh_com.pillarproject.wallet.staging_adhoc_profile-path"]
-    #  }
+    #match(type: "appstore",
+      #readonly: true,
+      #git_branch: "develop",
+      #app_identifier: "com.pillarproject.wallet.staging",
+      #team_id: "J9DEY3FGPD",
     #)
 
-    sh "fastlane sigh resign ../pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '" + ENV["sigh_com.pillarproject.wallet.staging_adhoc_profile-path"] + "'"
+    gym(
+      workspace: "pillarwallet.xcworkspace",
+      configuration: "Staging.Release",
+      scheme: "Staging",
+      xcargs: "-UseModernBuildSystem='NO' BUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AdHoc com.pillarproject.wallet.staging 1557933129' DEVELOPMENT_TEAM='J9DEY3FGPD'",
+      export_method: "ad-hoc",
+      export_options: {
+        provisioningProfiles: { 
+            MY_APP_ID => MY_PROFILE
+        }
+      },
+      clean: true,
+      derived_data_path: "build"
+    )
+
+    # Gym command xcargs will have to be reviewed and changed at the point when the current Distribution cert. and prov. profile expire.
+    # Especially the PROVISIONING_PROFILE_SPECIFIER set in there since it is hardcoded to a prov. profile that is specific, we need to change it to a standard match AdHoc com.pillarproject.wallet.staging
+    # withouth the numbers created at the end, which have been added by match command back when the profile was created.
+
+    # get our push-notification cert
+    #get_push_certificate(
+      #force: false,
+      #app_identifier: "com.pillarproject.wallet.staging",
+      #team_id: "J9DEY3FGPD",
+    #)
+
+    # trigger the build
+    #sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration Staging.Release -scheme Staging -derivedDataPath ../build -verbose "
+
+    # manually zip the results into an ipa
+    #sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
+
+    #sh "fastlane sigh resign ../pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '" + ENV["sigh_com.pillarproject.wallet.staging_adhoc_profile-path"] + "'"
     changelog = build_custom_changelog
     commit = last_git_commit
 
@@ -193,7 +233,7 @@ platform :ios do
       notes: changelog,
       commit_sha: commit[:commit_hash],
       notify: "1",
-      ipa: "pillarwallet-staging.ipa"
+      ipa: "/Users/distiller/pillarwallet/ios/output/gym/pillarwallet-staging.ipa"
     )
 
   end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -233,7 +233,7 @@ platform :ios do
       notes: changelog,
       commit_sha: commit[:commit_hash],
       notify: "1",
-      ipa: "/Users/distiller/pillarwallet/ios/output/gym/pillarwallet-staging.ipa"
+      ipa: "./output/gym/pillarwallet-staging.ipa"
     )
 
   end


### PR DESCRIPTION
Changes in this PR are:

1. Unify using of `gym` command in all 3 ios jobs (hockey, staging and prod),
2. iOS **gym** build jobs will be used to build **and** sign the app - the resign commands have been removed,
3. Prod. build will use the new distribution certificate and prov. profile created and valid until May 2020,
4. Cleanup and reconfiguring of the circleci config file to address the Fastfile changes,
5. Change in hockeyapp builds to have the same cocoapods commands as stage and prod.