### PR TITLE
set incoming wallet connect default value to 0 if none provided

### DIFF
--- a/src/screens/WalletConnect/WalletConnectCallRequest.js
+++ b/src/screens/WalletConnect/WalletConnectCallRequest.js
@@ -117,7 +117,7 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
   } => {
     const { supportedAssets, gasInfo } = this.props;
 
-    const { value, data } = payload.params[0];
+    const { value = 0, data } = payload.params[0];
     let { to } = payload.params[0];
 
     let symbol = 'ETH';


### PR DESCRIPTION
Some platforms doesn't provide default value, this will happen on data transaction so we can set it to default 0 in such cases.