### PR TITLE
fix/166546060_remove-sentry-info-restoreAccess-error

### DIFF
--- a/src/actions/oldInvitationsActions.js
+++ b/src/actions/oldInvitationsActions.js
@@ -55,7 +55,6 @@ export const fetchOldInviteNotificationsAction = (theWalletId?: string = '') => 
     } = getState();
 
     if (accessTokens === undefined || !accessTokens.length) {
-      Sentry.captureMessage('Empty connection access tokens, dispatching restoreAccessTokensAction', { level: 'info' });
       await dispatch(restoreAccessTokensAction(walletId));
       const {
         accessTokens: { data: updatedAccessTokens },


### PR DESCRIPTION
Remove sentry message on an empty access token for a connection