### PR TITLE
modal hide listeners for forum login

### DIFF
--- a/src/components/QRCodeScanner/QRCodeScanner.js
+++ b/src/components/QRCodeScanner/QRCodeScanner.js
@@ -41,6 +41,7 @@ type Props = {
   dataFormatter: Function,
   rectangleColor: string,
   isActive: boolean,
+  onModalHide?: Function,
 };
 
 type State = {
@@ -196,7 +197,7 @@ export default class QRCodeScanner extends React.Component<Props, State> {
   }
 
   render() {
-    const { isActive } = this.props;
+    const { isActive, onModalHide } = this.props;
     const { authorizationState } = this.state;
 
     if (authorizationState === PENDING) {
@@ -221,6 +222,7 @@ export default class QRCodeScanner extends React.Component<Props, State> {
           margin: 0,
           justifyContent: 'flex-start',
         }}
+        onModalHide={onModalHide}
       >
         {content}
       </Modal>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166871723

This issue was actually something from `react-native-modal` side, but it was happening only on iOS and it started when we merged QR scanner Camera modal to Home screen.

The problem was that modals can't be shown if one is not fully closed. In this case it was happening when QR scanner Camera modal is not yet fully closed and confirm login modal is already set to be visible. Same issue appeared for add email modal so this also includes fix for it More about the issue – https://github.com/react-native-community/react-native-modal#i-cant-show-multiple-modals-one-after-another.