### PR TITLE
added tr data to wallet providers eth transfer methods

### DIFF
--- a/src/services/walletProviders/keyBasedWallet.js
+++ b/src/services/walletProviders/keyBasedWallet.js
@@ -79,6 +79,7 @@ export default class KeyBasedWalletProvider {
       gasLimit,
       gasPrice,
       signOnly = false,
+      data,
     } = transaction;
     const from = getAccountAddress(account);
     const { nonce, transactionCount } = await this.calculateNonce(from, state, signOnly);
@@ -90,6 +91,7 @@ export default class KeyBasedWalletProvider {
       wallet: this.wallet,
       nonce,
       signOnly,
+      data,
     })
       .then(result => {
         if (!signOnly) return { ...result, transactionCount };

--- a/src/services/walletProviders/smartWallet.js
+++ b/src/services/walletProviders/smartWallet.js
@@ -50,7 +50,7 @@ export default class SmartWalletProvider {
       return Promise.reject(new Error('SDK is not initialized'));
     }
 
-    const { to, amount } = transaction;
+    const { to, amount, data: transactionData } = transaction;
     const transactionSpeed = this.mapTransactionSpeed(transaction.txSpeed);
     const from = getAccountAddress(account);
     const value = ethToWei(amount);
@@ -59,7 +59,7 @@ export default class SmartWalletProvider {
       .transferAsset({
         recipient: to,
         value,
-        data: '',
+        data: transactionData || '',
         transactionSpeed,
       })
       .then(hash => ({


### PR DESCRIPTION
After merging Smart Wallet work transaction `data` parameter is no longer passed to key based ether transaction. 

This PR in includes the fix and also added `data` to Smart Wallet provider ether transaction.