### PR TITLE
Refactor token price calculation

### DIFF
--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -271,13 +271,14 @@ class AssetScreen extends React.Component<Props, State> {
     const { assetData } = this.props.navigation.state.params;
     const { token } = assetData;
     const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
+    const tokenRate = getRate(rates, token, fiatCurrency);
     const balance = getBalance(balances, token);
     const isWalletEmpty = balance <= 0;
-    const totalInFiat = balance * getRate(rates, token, fiatCurrency);
+    const totalInFiat = isWalletEmpty ? 0 : (balance * tokenRate);
     const formattedBalanceInFiat = formatMoney(totalInFiat);
     const paymentNetworkBalance = getBalance(paymentNetworkBalances, token);
     const paymentNetworkBalanceFormatted = formatMoney(paymentNetworkBalance, 4);
-    const paymentNetworkBalanceInFiat = paymentNetworkBalance * getRate(rates, token, fiatCurrency);
+    const paymentNetworkBalanceInFiat = paymentNetworkBalance * tokenRate;
     const formattedPaymentNetworkBalanceInFiat = formatMoney(paymentNetworkBalanceInFiat);
     const displayAmount = formatMoney(balance, 4);
     const currencySymbol = getCurrencySymbol(fiatCurrency);

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -257,7 +257,8 @@ export function fetchAssetBalances(assets: Asset[], walletAddress: string): Prom
 
 export function getExchangeRates(assets: string[]): Promise<?Object> {
   if (!assets.length) return Promise.resolve({});
-  return cryptocompare.priceMulti(assets, supportedFiatCurrencies).catch(() => ({}));
+  const targetCurrencies = supportedFiatCurrencies.concat(ETH);
+  return cryptocompare.priceMulti(assets, targetCurrencies).catch(() => ({}));
 }
 
 // from the getTransaction() method you'll get the the basic tx info without the status

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -34,7 +34,32 @@ export function getBalance(balances: Balances = {}, asset: string = ''): number 
 }
 
 export function getRate(rates: Rates = {}, token: string, fiatCurrency: string): number {
-  return rates[token] && rates[token][fiatCurrency] ? Number(rates[token][fiatCurrency]) : 0;
+  const tokenRates = rates[token];
+  const ethRate = rates[ETH];
+
+  if (!tokenRates) {
+    return 0;
+  }
+
+  if (!ethRate) {
+    return tokenRates[fiatCurrency] || 0;
+  }
+
+  const ethToFiat = ethRate[fiatCurrency];
+  if (!ethToFiat) {
+    return 0;
+  }
+
+  if (token === ETH) {
+    return ethToFiat;
+  }
+
+  const tokenToETH = tokenRates[ETH];
+  if (!tokenToETH) {
+    return tokenRates[fiatCurrency] || 0;
+  }
+
+  return ethToFiat * tokenToETH;
 }
 
 export function calculateMaxAmount(token: string, balance: number | string, txFeeInWei: BigNumber): number {


### PR DESCRIPTION
Pivotal cad: https://www.pivotaltracker.com/n/projects/2223806/stories/164056062

We want to calculate the token values using ethereum value as reference, instead of relying on token price directly. This changes the `getRate` to do the calculation taking that into account.