### PR TITLE
rename exchange set allowance to asset enable

### DIFF
--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -326,7 +326,7 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
           </Paragraph>
           {(setTokenAllowance &&
             <LabeledRow>
-              <Label>Enable asset</Label>
+              <Label>Asset to enable</Label>
               <Value>{fromAssetCode}</Value>
             </LabeledRow>
           ) ||

--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -286,13 +286,13 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
         <ScrollWrapper regularPadding>
           <Paragraph style={{ marginBottom: 30 }}>
             {setTokenAllowance
-              ? 'Review the details and confirm token allowance set as well as the cost of data transaction.'
+              ? 'Review the details and enable asset as well as the cost of data transaction.'
               : 'Review the details and confirm the exchange rate as well as the cost of transaction.'
             }
           </Paragraph>
           {(setTokenAllowance &&
             <LabeledRow>
-              <Label>Set token allowance</Label>
+              <Label>Enable asset</Label>
               <Value>{fromAssetCode}</Value>
             </LabeledRow>
           ) ||
@@ -332,7 +332,7 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
             <Button
               disabled={!session.isOnline || !!errorMessage}
               onPress={() => this.onConfirmTransactionPress(offerOrder)}
-              title={setTokenAllowance ? 'Set Token Allowance' : 'Confirm exchange'}
+              title={setTokenAllowance ? 'Enable Asset' : 'Confirm exchange'}
             />
           </FooterWrapper>
         </Footer>


### PR DESCRIPTION
Renamed "token set allowance" display texts to "asset enable" in order to make less confusion for app user.

Note: still keeping the allowance naming in the app code as exchange back-end still uses this naming.