### PR TITLE
added ethers js gas estimate to exchange transactions

### DIFF
--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -51,11 +51,10 @@ export type OfferOrder = {
   payToAddress: string,
   transactionObj?: {
     data: string,
-    gasLimit: number,
-    gasPrice: number,
   },
   setTokenAllowance?: boolean,
   provider?: string,
+  gasLimit: number,
 }
 
 export type ExchangeSearchRequest = {

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -492,11 +492,10 @@ class ExchangeScreen extends React.Component<Props, State> {
       takeOffer(fromAssetCode, toAssetCode, amountToSell, provider, order => {
         this.setState({ pressedOfferId: '' }); // reset offer card button loading spinner
         if (!order || !Object.keys(order).length) return;
-        const { data: offerOrderData } = order;
         setExecutingTransaction();
         navigation.navigate(EXCHANGE_CONFIRM, {
           offerOrder: {
-            ...offerOrderData,
+            ...order,
             receiveAmount: amountToBuy,
             provider,
           },
@@ -520,16 +519,12 @@ class ExchangeScreen extends React.Component<Props, State> {
       setTokenAllowance(fromAssetCode, provider, (response) => {
         this.setState({ pressedTokenAllowanceId: '' }); // reset set allowance button to be enabled
         if (!response || !Object.keys(response).length) return;
-        const { data: { to: payToAddress, data } } = response;
         setExecutingTransaction();
         navigation.navigate(EXCHANGE_CONFIRM, {
           offerOrder: {
+            ...response,
             provider,
             fromAssetCode,
-            payToAddress,
-            transactionObj: {
-              data,
-            },
             setTokenAllowance: true,
           },
         });

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -287,3 +287,24 @@ export function waitForTransaction(hash: string) {
   const provider = getEthereumProvider(NETWORK_PROVIDER);
   return provider.waitForTransaction(hash);
 }
+
+export async function calculateGasEstimate(transction: Object) {
+  const {
+    from,
+    to,
+    amount,
+    symbol,
+    data,
+  } = transction;
+  const provider = getEthereumProvider(NETWORK_PROVIDER);
+  const value = symbol === ETH
+    ? utils.parseEther(amount.toString())
+    : '0x';
+  // all parameters are required in order to estimate gas limit precisely
+  return provider.estimateGas({
+    from,
+    to,
+    data,
+    value,
+  });
+}


### PR DESCRIPTION
Added new method to calculate gas limit estimate with ethers js library and based on transaction data. This happens to be very precise and most of transactions confirm time gets to less than 30s. This gas limit estimate is only added to Exchange feature transactions and has 1 issue which is described in the code comments: if we build token to token transfer transaction data parameter and we try to estimate this transaction then it provides gas limit that is too low – this happens to be only for Shapeshift provider. This issue is solved by returning our app gas limit of 500k if no transaction data parameter is present.