### PR TITLE
Allow gif images on collectibles

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,6 +155,12 @@ android {
 
 
 dependencies {
+  // For animated GIF support
+  compile 'com.facebook.fresco:animated-gif:1.10.0'
+  // For WebP support, including animated WebP
+  compile 'com.facebook.fresco:animated-webp:1.10.0'
+  compile 'com.facebook.fresco:webpsupport:1.10.0'
+
   implementation project(':react-native-extra-dimensions-android')
   implementation project(':react-native-touch-id')
   implementation project(':react-native-color-matrix-image-filters')

--- a/src/actions/collectiblesActions.js
+++ b/src/actions/collectiblesActions.js
@@ -47,6 +47,7 @@ export const fetchCollectiblesAction = () => {
         name,
         description,
         image_preview_url: image,
+        image_thumbnail_url: thumbnail,
       } = collectible;
       const { name: category, address: contractAddress } = assetContract;
       const collectibleName = name || `${category} ${id}`;
@@ -56,7 +57,8 @@ export const fetchCollectiblesAction = () => {
         category,
         name: collectibleName,
         description,
-        icon: (/\.(png)$/i).test(image) ? image : '',
+        thumbnail,
+        icon: (/\.(png|gif)$/i).test(image) ? image : '',
         contractAddress,
         assetContract: category,
         tokenType: COLLECTIBLES,

--- a/src/screens/Assets/CollectiblesList.js
+++ b/src/screens/Assets/CollectiblesList.js
@@ -103,6 +103,7 @@ class CollectiblesList extends React.Component<Props> {
     return (
       <AssetCardMinimized
         {...item}
+        icon={item.thumbnail || item.icon}
         smallScreen={smallScreen()}
         onPress={() => { this.handleCardTap(item); }}
         isCollectible


### PR DESCRIPTION
Fix issue that prevented gif images to be shown on collectibles.

![android-2-1](https://user-images.githubusercontent.com/263335/60836803-e5918480-a19c-11e9-99e7-73939cdc84c1.png)
![android-2-2](https://user-images.githubusercontent.com/263335/60836806-e6c2b180-a19c-11e9-8478-8efd940a6c2b.png)
![android-2-3](https://user-images.githubusercontent.com/263335/60836808-e88c7500-a19c-11e9-913e-68c4b4036602.png)
