### PR TITLE
Fix/hockeyapp changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -843,14 +843,14 @@ workflows:
           filters:
             branches:
               only:
-                  - develop
+                  - fix/hockeyapp_changelog
       - hockeyapp_android:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - develop
+                  - fix/hockeyapp_changelog
       - stage_ios:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -843,14 +843,14 @@ workflows:
           filters:
             branches:
               only:
-                  - fix/hockeyapp_changelog
+                  - develop
       - hockeyapp_android:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - fix/hockeyapp_changelog
+                  - develop
       - stage_ios:
           requires:
             - build-and-test

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -93,7 +93,8 @@ platform :android do
   desc "Build custom changelog"
   lane :build_custom_changelog do
     changelog_notes = changelog_from_git_commits(
-      merge_commit_filtering: "only_include_merges"
+      merge_commit_filtering: "only_include_merges",
+      commits_count: "40"
     )
 
     custom_changelog = ""

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -94,7 +94,7 @@ platform :android do
   lane :build_custom_changelog do
     changelog_notes = changelog_from_git_commits(
       merge_commit_filtering: "only_include_merges",
-      commits_count: "40"
+      commits_count: "500"
     )
 
     custom_changelog = ""

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -132,7 +132,7 @@ platform :ios do
   lane :build_custom_changelog do
     changelog_notes = changelog_from_git_commits(
       merge_commit_filtering: "only_include_merges",
-      commits_count: "40"
+      commits_count: "500"
     )
     custom_changelog = ""
     pr_merges = changelog_notes.split(/Merge/)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -131,7 +131,8 @@ platform :ios do
 
   lane :build_custom_changelog do
     changelog_notes = changelog_from_git_commits(
-      merge_commit_filtering: "only_include_merges"
+      merge_commit_filtering: "only_include_merges",
+      commits_count: "40"
     )
     custom_changelog = ""
     pr_merges = changelog_notes.split(/Merge/)


### PR DESCRIPTION
This will manually set the number of commits that will be fetched for the hockeyapp builds. 

It should be a temporary solution until we have a new public prod release for which we must do a git release since hockey is set to get all the commits from the last **git release** up until the last one.
This caused us to have a **changelog** so big, that the upload to hockey ios was failing.