### PR TITLE
Change the ios adhoc prov. profile and set force_new_devices to false

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -161,7 +161,7 @@ platform :ios do
   lane :deploy_ios_hockeyapp do |options|
 
     MY_APP_ID = "com.pillarproject.wallet.staging"
-    MY_PROFILE = "match AdHoc com.pillarproject.wallet.staging 1560284712"
+    MY_PROFILE = "match AdHoc com.pillarproject.wallet.staging 1563899180"
 
     # insert circleCI's build number as our build number
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
@@ -182,7 +182,7 @@ platform :ios do
           git_branch: "develop",
           app_identifier: "com.pillarproject.wallet.staging",
           team_id: "J9DEY3FGPD",
-          force_for_new_devices: true
+          force_for_new_devices: false
           )
 
     # get our appstore provisioning profile
@@ -197,7 +197,7 @@ platform :ios do
       workspace: "pillarwallet.xcworkspace",
       configuration: "Staging.Release",
       scheme: "Staging",
-      xcargs: "-UseModernBuildSystem='NO' BUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AdHoc com.pillarproject.wallet.staging 1560284712' DEVELOPMENT_TEAM='J9DEY3FGPD'",
+      xcargs: "-UseModernBuildSystem='NO' BUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AdHoc com.pillarproject.wallet.staging 1563899180' DEVELOPMENT_TEAM='J9DEY3FGPD'",
       export_method: "ad-hoc",
       export_options: {
         provisioningProfiles: { 


### PR DESCRIPTION
Changing the prov profile set in the adhoc lane to latest one and setting the **force_for_new_devices** flag to false so we don't force creating a new provisioning profile when we add a new device in devices.txt