### PR TITLE
add source asset quantity param to offers request endpoint call

### DIFF
--- a/src/actions/exchangeActions.js
+++ b/src/actions/exchangeActions.js
@@ -151,7 +151,7 @@ export const searchOffersAction = (fromAssetCode: string, toAssetCode: string, f
         .map((offer: Offer) => dispatch({ type: ADD_OFFER, payload: offer })),
     );
     // we're requesting although it will start delivering when connection is established
-    const { error } = await exchangeService.requestOffers(fromAssetCode, toAssetCode);
+    const { error } = await exchangeService.requestOffers(fromAssetCode, toAssetCode, fromAmount);
 
     const { isAllowed = false, alpha2 = '' } = await exchangeService.getIPInformation();
 

--- a/src/services/exchange.js
+++ b/src/services/exchange.js
@@ -120,8 +120,8 @@ export default class ExchangeService {
     this.io.off('offers');
   }
 
-  requestOffers(fromAssetCode: string, toAssetCode: string) {
-    const urlPath = `offers?name=${fromAssetCode}-${toAssetCode}`;
+  requestOffers(fromAssetCode: string, toAssetCode: string, quantity: number) {
+    const urlPath = `offers?name=${fromAssetCode}-${toAssetCode}&quantity=${quantity}`;
     return fetch(buildApiUrl(urlPath), this.apiConfig)
       .then(response => response.text())
       .then(response => response.toLowerCase() === 'ok' ? {} : JSON.parse(response))


### PR DESCRIPTION
Add quantity amount when requesting offers for better askRate calculation in Exchange back-end side.