### PR TITLE
fix sentry issue for selector undefined

### DIFF
--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -246,8 +246,10 @@ const generateFormStructure = (balances: Balances) => {
   let amount;
 
   const FromOption = t.refinement(t.Object, ({ selector, input }) => {
-    if (!Object.keys(selector).length || !input) return false;
-    if (!isValidNumber(input)) return false;
+    if (!selector
+      || !Object.keys(selector).length
+      || !input
+      || !isValidNumber(input)) return false;
 
     const { symbol, decimals } = selector;
 


### PR DESCRIPTION
Fixes Sentry issue https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1133117260/?environment=production&project=1294444.

Though it's not sure why `selector` reached as undefined on this flow and this issue was logged with old version so might be outdated, but added the check to prevent crashes.