### PR TITLE
extra check asset symbol if there is no data during gas estimate calc

### DIFF
--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -323,7 +323,11 @@ export async function calculateGasEstimate(transaction: Object) {
       default:
         return DEFAULT_GAS_LIMIT;
     }
-  } else if (!data && contractAddress) {
+  } else if (!data && contractAddress && symbol !== ETH) {
+    /**
+     * we check `symbol !== ETH` because our assets list also includes ETH contract address
+     * so want to check if it's also not ETH send flow
+     */
     const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, provider);
     const contractAmount = defaultDecimals > 0
       ? utils.parseUnits(amount.toString(), defaultDecimals)


### PR DESCRIPTION
Added additional asset symbol check for ETH in gas estimate calculation method as our assets list includes contract address of ETH and during regular asset (ETH) send flow it used token transfer method calculation to calculate gas limit estimate for ETH transfer which resulted as wrong calculation for ETH transfers to smart contract addresses.

P. S. Current ETH send flow in production for regular addresses still works fine as it calculates gas limits slightly above default ETH gas limit of 21k.