### PR TITLE
Fix/get large amount balance improvements

### DIFF
--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -23,6 +23,7 @@ import { NETWORK_PROVIDER } from 'react-native-dotenv';
 import get from 'lodash.get';
 import type { Asset, Assets, Balances, Rates } from 'models/Asset';
 import { ETH } from 'constants/assetsConstants';
+import { formatAmount } from 'utils/common';
 
 export function transformAssetsToObject(assetsArray: Object[] = []): Object {
   return assetsArray.reduce((memo, asset) => {
@@ -33,7 +34,7 @@ export function transformAssetsToObject(assetsArray: Object[] = []): Object {
 
 export function getBalance(balances: Balances = {}, asset: string = ''): number {
   const number = balances[asset] ? new BigNumber(balances[asset].balance) : 0;
-  return +(number && number.toFixed(8, BigNumber.ROUND_DOWN)) || 0;
+  return +formatAmount(number.toString());
 }
 
 export function getRate(rates: Rates = {}, token: string, fiatCurrency: string): number {

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -32,7 +32,8 @@ export function transformAssetsToObject(assetsArray: Object[] = []): Object {
 }
 
 export function getBalance(balances: Balances = {}, asset: string = ''): number {
-  return balances[asset] ? Number(balances[asset].balance) : 0;
+  const number = balances[asset] ? new BigNumber(balances[asset].balance) : 0;
+  return +(number && number.toFixed(8, BigNumber.ROUND_DOWN)) || 0;
 }
 
 export function getRate(rates: Rates = {}, token: string, fiatCurrency: string): number {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2223806/stories/166862495

Solves an issue where large balances were being rounded incorrectly when parsing it from string as JavaScript number. Such failing values include `875.488999999999999835` or `347.799999999999999768`.