### PR TITLE
wallet connect check if token transfer before extracting data params,…

### DIFF
--- a/src/screens/WalletConnect/WalletConnectCallRequest.js
+++ b/src/screens/WalletConnect/WalletConnectCallRequest.js
@@ -141,7 +141,8 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
     const asset = supportedAssets.find(
       ({ address: assetAddress = '' }) => assetAddress.toLowerCase() === to.toLowerCase(),
     );
-    if (asset) {
+    const isTokenTransfer = data.toLowerCase() !== '0x' && data.toLowerCase().startsWith(TOKEN_TRANSFER);
+    if (asset && isTokenTransfer) {
       const iface = new Interface(ERC20_CONTRACT_ABI);
       const parsedTransaction = iface.parseTransaction({ data, value }) || {};
       const {
@@ -162,6 +163,7 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
       contractAddress: asset ? asset.address : '',
       decimals: asset ? asset.decimals : 18,
       note: this.state.note,
+      isTokenTransfer,
     };
   };
 
@@ -172,9 +174,7 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
     const { gasInfo } = this.props;
     const { gasLimit } = this.state;
     const transaction = this.parseTransaction(payload);
-    const { data, contractAddress } = transaction;
-
-    const isTokenTransfer = data.toLowerCase() !== '0x' && data.toLowerCase().startsWith(TOKEN_TRANSFER);
+    const { contractAddress, isTokenTransfer } = transaction;
 
     /**
      *  we're using our wallet avg gas price and gas limit
@@ -279,7 +279,6 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
             amount,
             symbol,
             txFeeInWei,
-            contractAddress,
           },
         } = this.getTokenTransactionPayload(payload);
 
@@ -346,7 +345,7 @@ class WalletConnectCallRequestScreen extends React.Component<Props, State> {
                 || <Spinner style={{ marginTop: 5 }} width={20} height={20} />
               }
             </LabeledRow>
-            {data.toLowerCase() !== '0x' && !contractAddress && (
+            {data.toLowerCase() !== '0x' && (
               <LabeledRow>
                 <Label>Data</Label>
                 <Value>{data}</Value>


### PR DESCRIPTION
This PR includes:
1. Additional check for incoming Wallet Connect `data` param type if it is token transfer or not and act accordingly.
2. Make Wallet Connect `data` param content always visible to user.