### PR TITLE
fix/assets_search_scroll

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -53,7 +53,7 @@ type ScrollWrapperProps = {
   contentContainerStyle?: Object,
   keyboardShouldPersistTaps?: string,
   onScroll?: Function,
-  stickyHeaderIndices?: number[],
+  stickyHeaderIndices?: ?number[],
   scrollEnabled?: boolean,
   refreshControl?: React.Node,
 };

--- a/src/screens/Assets/WalletView.js
+++ b/src/screens/Assets/WalletView.js
@@ -157,9 +157,10 @@ const CustomKAWrapper = (props) => {
   const {
     children,
     refreshControl,
+    hasStickyTabs,
   } = props;
   const scrollWrapperProps = {
-    stickyHeaderIndices: [2],
+    stickyHeaderIndices: hasStickyTabs ? [2] : null,
     style: { backgroundColor: baseColors.white },
     contentContainerStyle: {
       backgroundColor: baseColors.white,
@@ -417,6 +418,7 @@ class WalletView extends React.Component<Props, State> {
 
     return (
       <CustomKAWrapper
+        hasStickyTabs={!isInSearchMode && !blockAssetsView && !!collectibles.length}
         refreshControl={
           <RefreshControl
             refreshing={false}


### PR DESCRIPTION
This PR includes a fix for ScrollView.
Now no element is acting as sticky if Tabs are not present.