### PR TITLE
Add RootReducerState to enforce state typing

### DIFF
--- a/App.js
+++ b/App.js
@@ -42,6 +42,8 @@ import { Container } from 'components/Layout';
 import Root from 'components/Root';
 import Toast from 'components/Toast';
 import Spinner from 'components/Spinner';
+import type { RootReducerState } from 'reducers/rootReducer';
+
 import configureStore from './src/configureStore';
 
 export const LoadingSpinner = styled(Spinner)`
@@ -152,7 +154,7 @@ class App extends React.Component<Props, *> {
   }
 }
 
-const mapStateToProps = ({ appSettings: { isFetched } }) => ({
+const mapStateToProps = ({ appSettings: { isFetched } }: RootReducerState) => ({
   isFetched,
 });
 

--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -45,6 +45,9 @@ import { migrateCollectiblesHistoryToAccountsFormat } from 'services/dataMigrati
 import { getActiveAccountType, getActiveAccountId } from 'utils/accounts';
 import { BLOCKCHAIN_NETWORK_TYPES, SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
 import { sdkConstants } from '@archanova/sdk';
+
+import type { RootReducerState } from 'reducers/rootReducer';
+
 import { setActiveBlockchainNetworkAction } from './blockchainNetworkActions';
 
 const storage = Storage.getInstance('db');
@@ -164,7 +167,7 @@ export const addNewAccountAction = (
 };
 
 export const setActiveAccountAction = (accountId: string) => {
-  return async (dispatch: Function, getState: Function) => {
+  return async (dispatch: Function, getState: () => RootReducerState) => {
     const {
       accounts: { data: accounts },
       smartWallet: {
@@ -205,7 +208,7 @@ export const setActiveAccountAction = (accountId: string) => {
 };
 
 export const switchAccountAction = (accountId: string, privateKey?: string) => {
-  return async (dispatch: Function, getState: Function) => {
+  return async (dispatch: Function, getState: () => RootReducerState) => {
     const {
       accounts: { data: accounts },
       assets: { data: assets },
@@ -227,7 +230,7 @@ export const switchAccountAction = (accountId: string, privateKey?: string) => {
 };
 
 export const initOnLoginSmartWalletAccountAction = (privateKey: string) => {
-  return async (dispatch: Function, getState: Function) => {
+  return async (dispatch: Function, getState: () => RootReducerState) => {
     const {
       appSettings: { data: { blockchainNetwork } },
       accounts: {

--- a/src/reducers/accountsReducer.js
+++ b/src/reducers/accountsReducer.js
@@ -2,7 +2,7 @@
 import { ADD_ACCOUNT, UPDATE_ACCOUNTS } from 'constants/accountsConstants';
 import type { Accounts } from 'models/Account';
 
-export type AccountsState = {
+export type AccountsReducerState = {
   data: Accounts,
 };
 
@@ -16,9 +16,9 @@ export const initialState = {
 };
 
 export default function accountsReducer(
-  state: AccountsState = initialState,
+  state: AccountsReducerState = initialState,
   action: AccountsAction,
-): AccountsState {
+): AccountsReducerState {
   switch (action.type) {
     case UPDATE_ACCOUNTS:
       return { ...state, data: action.payload };

--- a/src/reducers/balancesReducer.js
+++ b/src/reducers/balancesReducer.js
@@ -20,7 +20,7 @@
 import { UPDATE_BALANCES } from 'constants/assetsConstants';
 import type { BalancesStore } from 'models/Asset';
 
-export type BalancesState = {
+export type BalancesReducerState = {
   data: BalancesStore,
 };
 
@@ -34,9 +34,9 @@ const initialState = {
 };
 
 export default function balancesReducer(
-  state: BalancesState = initialState,
+  state: BalancesReducerState = initialState,
   action: BalancesAction,
-): BalancesState {
+): BalancesReducerState {
   switch (action.type) {
     case UPDATE_BALANCES:
       return { ...state, data: action.payload };

--- a/src/reducers/blockchainNetworkReducer.js
+++ b/src/reducers/blockchainNetworkReducer.js
@@ -4,7 +4,7 @@ import {
   SET_ACTIVE_NETWORK,
 } from 'constants/blockchainNetworkConstants';
 
-export type NetworkState = {
+export type BlockchainNetworkReducerState = {
   data: Object[],
 };
 
@@ -29,9 +29,9 @@ const initialState = {
 };
 
 export default function blockchainNetworkReducer(
-  state: NetworkState = initialState,
+  state: BlockchainNetworkReducerState = initialState,
   action: NetworkAction,
-): NetworkState {
+): BlockchainNetworkReducerState {
   switch (action.type) {
     case SET_ACTIVE_NETWORK:
       return {

--- a/src/reducers/chatReducer.js
+++ b/src/reducers/chatReducer.js
@@ -57,7 +57,7 @@ type Chat = {
   },
 }
 
-export type ChateducerState = {
+export type ChatReducerState = {
   data: {
     chats: Chat[],
     messages: {
@@ -73,7 +73,7 @@ export type ChateducerState = {
   draft: ?string,
 }
 
-export type ChateducerAction = {
+export type ChatReducerAction = {
   type: string,
   payload: any,
 }
@@ -93,9 +93,9 @@ const initialState = {
 };
 
 export default function chatReducer(
-  state: ChateducerState = initialState,
-  action: ChateducerAction,
-): ChateducerState {
+  state: ChatReducerState = initialState,
+  action: ChatReducerAction,
+): ChatReducerState {
   switch (action.type) {
     case ADD_MESSAGE:
       const { username, message } = action.payload;

--- a/src/reducers/collectiblesReducer.js
+++ b/src/reducers/collectiblesReducer.js
@@ -26,7 +26,7 @@ import {
 import type { CollectiblesStore, CollectiblesHistoryStore } from 'models/Collectible';
 
 
-export type CollectiblesState = {
+export type CollectiblesReducerState = {
   data: CollectiblesStore,
   transactionHistory: CollectiblesHistoryStore,
 };
@@ -43,9 +43,9 @@ const initialState = {
 
 
 export default function collectiblesReducer(
-  state: CollectiblesState = initialState,
+  state: CollectiblesReducerState = initialState,
   action: CollectiblesAction,
-): CollectiblesState {
+): CollectiblesReducerState {
   switch (action.type) {
     case UPDATE_COLLECTIBLES:
       return {

--- a/src/reducers/deepLinkReducer.js
+++ b/src/reducers/deepLinkReducer.js
@@ -19,11 +19,11 @@
 */
 import { ADD_DEEP_LINK_DATA, RESET_DEEP_LINK_DATA } from 'constants/deepLinkConstants';
 
-export type DeepLinkRecucerState = {
+export type DeepLinkReducerState = {
   data: Object,
 }
 
-export type DeepLinkRecucerAction = {
+export type DeepLinkReducerAction = {
   type: string,
   payload: any,
 }
@@ -33,8 +33,8 @@ const initialState = {
 };
 
 export default function appSettingsReducer(
-  state: DeepLinkRecucerState = initialState,
-  action: DeepLinkRecucerAction,
+  state: DeepLinkReducerState = initialState,
+  action: DeepLinkReducerAction,
 ) {
   switch (action.type) {
     case ADD_DEEP_LINK_DATA:

--- a/src/reducers/historyReducer.js
+++ b/src/reducers/historyReducer.js
@@ -23,7 +23,7 @@ import { SET_HISTORY, ADD_TRANSACTION, SET_GAS_INFO } from 'constants/historyCon
 import type { TransactionsStore } from 'models/Transaction';
 import type { GasInfo } from 'models/GasInfo';
 
-export type HistoryState = {
+export type HistoryReducerState = {
   data: TransactionsStore,
   gasInfo: GasInfo,
   isFetched: boolean,
@@ -44,9 +44,9 @@ export const initialState = {
 };
 
 export default function historyReducer(
-  state: HistoryState = initialState,
+  state: HistoryReducerState = initialState,
   action: HistoryAction,
-): HistoryState {
+): HistoryReducerState {
   switch (action.type) {
     case REHYDRATE:
       return {

--- a/src/reducers/notificationsReducer.js
+++ b/src/reducers/notificationsReducer.js
@@ -25,7 +25,7 @@ import {
 } from 'constants/notificationConstants';
 import type { Notification } from 'models/Notification';
 
-type NotificationReducerState = {
+export type NotificationsReducerState = {
   data: Notification[],
   intercomNotificationsCount: number,
   homeNotifications: [],
@@ -33,7 +33,7 @@ type NotificationReducerState = {
   hasUnreadChatNotifications: boolean,
 }
 
-type NotificationReducerAction = {
+type NotificationsReducerAction = {
   type: string,
   payload: Notification,
 }
@@ -47,8 +47,8 @@ const initialState = {
 };
 
 export default function notificationsReducer(
-  state: NotificationReducerState = initialState,
-  action: NotificationReducerAction,
+  state: NotificationsReducerState = initialState,
+  action: NotificationsReducerAction,
 ) {
   switch (action.type) {
     case UPDATE_INTERCOM_NOTIFICATIONS_COUNT:

--- a/src/reducers/offlineQueueReducer.js
+++ b/src/reducers/offlineQueueReducer.js
@@ -38,7 +38,7 @@ const initialState = {
   isConnected: true,
 };
 
-type OfflineQueueReducerState = {
+export type OfflineQueueReducerState = {
   queue: any,
   isConnected: boolean,
 };

--- a/src/reducers/paymentNetworkReducer.js
+++ b/src/reducers/paymentNetworkReducer.js
@@ -34,7 +34,7 @@ import {
 import type { TopUpFee, SettleTxFee } from 'models/PaymentNetwork';
 import type { Balances } from 'models/Asset';
 
-export type PaymentNetworkState = {
+export type PaymentNetworkReducerState = {
   availableStake: string,
   balances: Balances,
   topUpFee: TopUpFee,
@@ -72,9 +72,9 @@ const initialState = {
 };
 
 export default function paymentNetworkReducer(
-  state: PaymentNetworkState = initialState,
+  state: PaymentNetworkReducerState = initialState,
   action: PaymentNetworkAction,
-): PaymentNetworkState {
+): PaymentNetworkReducerState {
   switch (action.type) {
     case UPDATE_PAYMENT_NETWORK_BALANCES:
       return merge({}, state, { balances: action.payload });

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -54,6 +54,71 @@ import paymentNetworkReducer from './paymentNetworkReducer';
 import featureFlagsReducer from './featureFlagsReducer';
 import blockchainNetworkReducer from './blockchainNetworkReducer';
 
+// types
+import type { OfflineQueueReducerState } from './offlineQueueReducer';
+import type { WalletReducerState } from './walletReducer';
+import type { SmartWalletReducerState } from './smartWalletReducer';
+import type { WalletConnectReducerState } from './walletConnectReducer';
+import type { AssetsReducerState } from './assetsReducer';
+import type { AppSettingsReducerState } from './appSettingsReducer';
+import type { RatesReducerState } from './ratesReducer';
+import type { UserReducerState } from './userReducer';
+import type { HistoryReducerState } from './historyReducer';
+import type { NotificationsReducerState } from './notificationsReducer';
+import type { ContactsReducerState } from './contactsReducer';
+import type { InvitationsReducerState } from './invitationsReducer';
+import type { ChatReducerState } from './chatReducer';
+import type { AccessTokensReducerState } from './accessTokensReducer';
+import type { SessionReducerState } from './sessionReducer';
+import type { ICOsReducerState } from './icosReducer';
+import type { TxNoteReducerState } from './txNoteReducer';
+import type { OAuthReducerState } from './oAuthReducer';
+import type { TxCountReducerState } from './txCountReducer';
+import type { ConnectionKeyPairsReducerState } from './connectionKeyPairsReducer';
+import type { CollectiblesReducerState } from './collectiblesReducer';
+import type { DeepLinkReducerState } from './deepLinkReducer';
+import type { ConnectionIdentityKeysReducerState } from './connectionIdentityKeysReducer';
+import type { BadgesReducerState } from './badgesReducer';
+import type { ExchangeReducerState } from './exchangeReducer';
+import type { AccountsReducerState } from './accountsReducer';
+import type { BalancesReducerState } from './balancesReducer';
+import type { PaymentNetworkReducerState } from './paymentNetworkReducer';
+import type { FeatureFlagsReducerState } from './featureFlagsReducer';
+import type { BlockchainNetworkReducerState } from './blockchainNetworkReducer';
+
+export type RootReducerState = {|
+  offlineQueue: OfflineQueueReducerState,
+  wallet: WalletReducerState,
+  smartWallet: SmartWalletReducerState,
+  walletConnect: WalletConnectReducerState,
+  assets: AssetsReducerState,
+  appSettings: AppSettingsReducerState,
+  rates: RatesReducerState,
+  user: UserReducerState,
+  history: HistoryReducerState,
+  notifications: NotificationsReducerState,
+  contacts: ContactsReducerState,
+  invitations: InvitationsReducerState,
+  chat: ChatReducerState,
+  accessTokens: AccessTokensReducerState,
+  session: SessionReducerState,
+  icos: ICOsReducerState,
+  txNotes: TxNoteReducerState,
+  oAuthTokens: OAuthReducerState,
+  txCount: TxCountReducerState,
+  connectionKeyPairs: ConnectionKeyPairsReducerState,
+  collectibles: CollectiblesReducerState,
+  deepLink: DeepLinkReducerState,
+  connectionIdentityKeys: ConnectionIdentityKeysReducerState,
+  badges: BadgesReducerState,
+  exchange: ExchangeReducerState,
+  accounts: AccountsReducerState,
+  balances: BalancesReducerState,
+  paymentNetwork: PaymentNetworkReducerState,
+  featureFlags: FeatureFlagsReducerState,
+  blockchainNetwork: BlockchainNetworkReducerState,
+|};
+
 const appReducer = combineReducers({
   offlineQueue: offlineQueueReducer,
   wallet: walletReducer,
@@ -89,7 +154,7 @@ const appReducer = combineReducers({
 
 const initialState = appReducer(undefined, {});
 
-const rootReducer = (state: Object, action: Object) => {
+const rootReducer = (state: RootReducerState, action: Object) => {
   if (action.type === LOG_OUT) {
     return initialState;
   }

--- a/src/reducers/smartWalletReducer.js
+++ b/src/reducers/smartWalletReducer.js
@@ -61,7 +61,7 @@ export type SmartWalletReducerState = {
     recoveryAgents: RecoveryAgent[],
   },
   lastSyncedHash: ?string,
-}
+};
 
 export type SmartWalletReducerAction = {
   type: string,

--- a/src/selectors/paymentNetwork.js
+++ b/src/selectors/paymentNetwork.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect';
 import { getBalance } from 'utils/assets';
 import type { Balances } from 'models/Asset';
-import type { PaymentNetworkState } from 'reducers/paymentNetworkReducer';
+import type { PaymentNetworkReducerState } from 'reducers/paymentNetworkReducer';
 import { activeAccountIdSelector, paymentNetworkBalancesSelector } from './selectors';
 
 export const paymentNetworkAccountBalancesSelector: ((state: Object) => Balances) = createSelector(
@@ -15,7 +15,7 @@ export const paymentNetworkAccountBalancesSelector: ((state: Object) => Balances
 );
 
 export const availableStakeSelector =
-  ({ paymentNetwork }: {paymentNetwork: PaymentNetworkState}) => Number(paymentNetwork.availableStake);
+  ({ paymentNetwork }: {paymentNetwork: PaymentNetworkReducerState}) => Number(paymentNetwork.availableStake);
 
 export const paymentNetworkNonZeroBalancesSelector: ((state: Object) => Balances) = createSelector(
   paymentNetworkAccountBalancesSelector,

--- a/src/selectors/selectors.js
+++ b/src/selectors/selectors.js
@@ -1,27 +1,27 @@
 // @flow
 import { createSelector } from 'reselect';
-import type { AccountsState } from 'reducers/accountsReducer';
-import type { BalancesState } from 'reducers/balancesReducer';
-import type { CollectiblesState } from 'reducers/collectiblesReducer';
-import type { HistoryState } from 'reducers/historyReducer';
-import type { PaymentNetworkState } from 'reducers/paymentNetworkReducer';
+import type { AccountsReducerState } from 'reducers/accountsReducer';
+import type { BalancesReducerState } from 'reducers/balancesReducer';
+import type { CollectiblesReducerState } from 'reducers/collectiblesReducer';
+import type { HistoryReducerState } from 'reducers/historyReducer';
+import type { PaymentNetworkReducerState } from 'reducers/paymentNetworkReducer';
 import { getAccountAddress } from 'utils/accounts';
 
 //
 // Global selectors here
 //
 
-export const balancesSelector = ({ balances }: {balances: BalancesState}) => balances.data;
-export const collectiblesSelector = ({ collectibles }: {collectibles: CollectiblesState}) => collectibles.data;
+export const balancesSelector = ({ balances }: {balances: BalancesReducerState}) => balances.data;
+export const collectiblesSelector = ({ collectibles }: {collectibles: CollectiblesReducerState}) => collectibles.data;
 export const collectiblesHistorySelector =
-  ({ collectibles }: {collectibles: CollectiblesState}) => collectibles.transactionHistory;
-export const historySelector = ({ history }: {history: HistoryState}) => history.data;
+  ({ collectibles }: {collectibles: CollectiblesReducerState}) => collectibles.transactionHistory;
+export const historySelector = ({ history }: {history: HistoryReducerState}) => history.data;
 
 export const paymentNetworkBalancesSelector =
-  ({ paymentNetwork }: {paymentNetwork: PaymentNetworkState}) => paymentNetwork.balances;
+  ({ paymentNetwork }: {paymentNetwork: PaymentNetworkReducerState}) => paymentNetwork.balances;
 
 export const activeAccountSelector =
-  ({ accounts }: {accounts: AccountsState}) => accounts.data.find(({ isActive }) => isActive);
+  ({ accounts }: {accounts: AccountsReducerState}) => accounts.data.find(({ isActive }) => isActive);
 
 export const activeAccountIdSelector = createSelector(
   activeAccountSelector,


### PR DESCRIPTION
This will allow us to rely on flow for detecting attributes and types
for data that comes from the state, instead of having to hold that
information in our heads permanently, which could lead to unexpected
behaviour.