### PR TITLE
Improve support for multiple networks on Accounts

### DIFF
--- a/src/actions/appSettingsActions.js
+++ b/src/actions/appSettingsActions.js
@@ -18,24 +18,28 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import { UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
+import { BLOCKCHAIN_NETWORK_TYPES } from 'constants/blockchainNetworkConstants';
+import { ACCOUNT_TYPES } from 'constants/accountsConstants';
+
 import set from 'lodash.set';
 import firebase from 'react-native-firebase';
 
 import Toast from 'components/Toast';
 import { logUserPropertyAction, logEventAction } from 'actions/analyticsActions';
-import { BLOCKCHAIN_NETWORK_TYPES } from 'constants/blockchainNetworkConstants';
-import { ACCOUNT_TYPES } from 'constants/accountsConstants';
 import {
   setKeychainDataObject,
   resetKeychainDataObject,
 } from 'utils/keychain';
+
+import type { Dispatch, GetState } from 'reducers/rootReducer';
+
 import { saveDbAction } from './dbActions';
 import { setActiveBlockchainNetworkAction } from './blockchainNetworkActions';
 import { switchAccountAction } from './accountsActions';
 
 
 export const saveOptOutTrackingAction = (status: boolean) => {
-  return async (dispatch: Function) => {
+  return async (dispatch: Dispatch) => {
     const settings = { optOutTracking: status };
 
     if (status) {
@@ -49,7 +53,7 @@ export const saveOptOutTrackingAction = (status: boolean) => {
 };
 
 export const saveBaseFiatCurrencyAction = (currency: string) => {
-  return (dispatch: Function) => {
+  return (dispatch: Dispatch) => {
     const settings = { baseFiatCurrency: currency };
 
     dispatch(saveDbAction('app_settings', { appSettings: settings }));
@@ -59,8 +63,8 @@ export const saveBaseFiatCurrencyAction = (currency: string) => {
 };
 
 export const updateAppSettingsAction = (path: string, fieldValue: any) => {
-  return (dispatch: Function) => {
-    const settings = set({}, path, fieldValue);
+  return (dispatch: Dispatch) => {
+    const settings: Object = set({}, path, fieldValue);
 
     dispatch(saveDbAction('app_settings', { appSettings: settings }));
     dispatch({ type: UPDATE_APP_SETTINGS, payload: settings });
@@ -68,7 +72,7 @@ export const updateAppSettingsAction = (path: string, fieldValue: any) => {
 };
 
 export const updateAssetsLayoutAction = (layoutId: string) => {
-  return (dispatch: Function) => {
+  return (dispatch: Dispatch) => {
     const settings = { appearanceSettings: { assetsLayout: layoutId } };
 
     dispatch(saveDbAction('app_settings', { appSettings: settings }));
@@ -79,7 +83,7 @@ export const updateAssetsLayoutAction = (layoutId: string) => {
 };
 
 export const handleImagePickAction = (isPickingImage: boolean) => {
-  return (dispatch: Function) => {
+  return (dispatch: Dispatch) => {
     dispatch({
       type: UPDATE_APP_SETTINGS,
       payload: {
@@ -97,7 +101,7 @@ export const setBrowsingWebViewAction = (isBrowsingWebView: boolean) => ({
 });
 
 export const changeUseBiometricsAction = (value: boolean, privateKey?: string) => {
-  return async (dispatch: Function) => {
+  return async (dispatch: Dispatch) => {
     let message;
     if (value) {
       await setKeychainDataObject({ privateKey });
@@ -122,7 +126,7 @@ export const changeUseBiometricsAction = (value: boolean, privateKey?: string) =
 };
 
 export const setFirebaseAnalyticsCollectionEnabled = (enabled: boolean) => {
-  return (dispatch: Function) => {
+  return (dispatch: Dispatch) => {
     firebase.analytics().setAnalyticsCollectionEnabled(enabled);
     dispatch(saveDbAction('app_settings', { appSettings: { firebaseAnalyticsConnectionEnabled: enabled } }));
     dispatch({
@@ -135,7 +139,7 @@ export const setFirebaseAnalyticsCollectionEnabled = (enabled: boolean) => {
 };
 
 export const setUserJoinedBetaAction = (userJoinedBeta: boolean, ignoreSuccessToast: boolean = false) => {
-  return async (dispatch: Function, getState: Function, api: Object) => {
+  return async (dispatch: Dispatch, getState: GetState, api: Object) => {
     const {
       user: { data: { username, walletId } },
       accounts: { data: accounts },

--- a/src/actions/blockchainNetworkActions.js
+++ b/src/actions/blockchainNetworkActions.js
@@ -17,21 +17,22 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-
 import { SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
-import { UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
-import { saveDbAction } from './dbActions';
+
+import type { Dispatch, GetState } from 'reducers/rootReducer';
+import { updateAppSettingsAction } from 'actions/appSettingsActions';
 
 export const setActiveBlockchainNetworkAction = (id: string) => {
-  return async (dispatch: Function) => {
-    dispatch({
-      type: SET_ACTIVE_NETWORK,
-      payload: id,
-    });
-    dispatch(saveDbAction('app_settings', { appSettings: { blockchainNetwork: id } }));
-    dispatch({
-      type: UPDATE_APP_SETTINGS,
-      payload: { blockchainNetwork: id },
-    });
+  return async (dispatch: Dispatch, getState: GetState) => {
+    const { blockchainNetwork: { data: networks } } = getState();
+    const network = networks.find(({ id: networkId }) => networkId === id);
+
+    if (!(network && network.isAvailable)) {
+      console.error('Trying to activate an unavailable network'); // eslint-disable-line no-console
+      return;
+    }
+
+    dispatch({ type: SET_ACTIVE_NETWORK, payload: id });
+    dispatch(updateAppSettingsAction('blockchainNetwork', id));
   };
 };

--- a/src/actions/dbActions.js
+++ b/src/actions/dbActions.js
@@ -20,16 +20,20 @@
 import Storage from 'services/storage';
 import { UPDATE_DB } from 'constants/dbConstants';
 
+import type { DbAction } from 'models/DbAction';
+
 const storage = Storage.getInstance('db');
 
-export const saveDbAction = (key: string, data: any, forceRewrite: boolean = false) => {
-  return {
-    queue: 'db',
-    type: UPDATE_DB,
-    callback: (next: Function) => {
-      storage.save(key, data, forceRewrite).then(() => {
-        next(); // eslint-disable-line
-      }).catch(() => {});
-    },
-  };
-};
+export const saveDbAction = (
+  key: string,
+  data: any,
+  forceRewrite: boolean = false,
+): DbAction => ({
+  type: UPDATE_DB,
+  queue: 'db',
+  callback: (next: () => void) => {
+    storage.save(key, data, forceRewrite)
+      .then(() => next()) // eslint-disable-line
+      .catch(() => {});
+  },
+});

--- a/src/components/ListItem/NetworkListCard.js
+++ b/src/components/ListItem/NetworkListCard.js
@@ -1,0 +1,77 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+import * as React from 'react';
+import styled from 'styled-components/native';
+
+import { baseColors, spacing } from 'utils/variables';
+import { ListCard } from 'components/ListItem/ListCard';
+import Icon from 'components/Icon';
+import { responsiveSize } from 'utils/ui';
+
+type Props = {|
+  iconSource: string,
+  title: string,
+  subtitle: string,
+  noteText: string,
+  noteIcon: string,
+  isActive: boolean,
+  isInitialised: boolean,
+  action: () => void,
+  initialiseAction: () => void,
+|};
+
+const CheckIcon = styled(Icon)`
+  font-size: ${responsiveSize(14)}px;
+  color: ${baseColors.electricBlue};
+  position: absolute;
+  top: ${spacing.mediumLarge}px;
+  right: ${spacing.mediumLarge}px;
+`;
+
+export const NetworkListCard = (props: Props) => {
+  const {
+    iconSource,
+    title,
+    subtitle,
+    isActive,
+    isInitialised,
+    action,
+    initialiseAction,
+    noteText,
+    noteIcon,
+  } = props;
+
+  return (
+    <ListCard
+      title={title}
+      subtitle={subtitle}
+      action={isInitialised ? action : initialiseAction}
+      note={{ note: noteText, emoji: noteIcon }}
+      iconSource={iconSource}
+      contentWrapperStyle={{
+        borderWidth: 2,
+        borderColor: isActive ? baseColors.electricBlue : baseColors.white,
+        borderRadius: 6,
+      }}
+    >
+      {isActive && <CheckIcon name="check" />}
+    </ListCard>
+  );
+};

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -11,7 +11,6 @@ export type Account = {
   extra?: AccountExtra,
   isActive: boolean,
   walletId: string,
-  privateKey?: any,
 };
 
 export type Accounts = Account[];

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -11,6 +11,7 @@ export type Account = {
   extra?: AccountExtra,
   isActive: boolean,
   walletId: string,
+  privateKey?: any,
 };
 
 export type Accounts = Account[];

--- a/src/models/BlockchainNetwork.js
+++ b/src/models/BlockchainNetwork.js
@@ -17,9 +17,9 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-export const BLOCKCHAIN_NETWORK_TYPES = {
-  ETHEREUM: 'ETHEREUM',
-  PILLAR_NETWORK: 'PILLAR_NETWORK',
-  BITCOIN: 'BITCOIN',
-};
-export const SET_ACTIVE_NETWORK = 'SET_ACTIVE_NETWORK';
+export type BlockchainNetwork = {|
+  id: string,
+  title: string,
+  isActive: boolean,
+  isAvailable: boolean,
+|};

--- a/src/models/DbAction.js
+++ b/src/models/DbAction.js
@@ -17,9 +17,9 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-export const BLOCKCHAIN_NETWORK_TYPES = {
-  ETHEREUM: 'ETHEREUM',
-  PILLAR_NETWORK: 'PILLAR_NETWORK',
-  BITCOIN: 'BITCOIN',
-};
-export const SET_ACTIVE_NETWORK = 'SET_ACTIVE_NETWORK';
+
+export type DbAction = {|
+  type: 'UPDATE_DB', // no other values available
+  queue: 'db', // no other values available
+  callback: (next: () => void) => any,
+|};

--- a/src/reducers/appSettingsReducer.js
+++ b/src/reducers/appSettingsReducer.js
@@ -24,12 +24,12 @@ import merge from 'lodash.merge';
 export type AppSettingsReducerState = {
   data: Object,
   isFetched: boolean,
-}
+};
 
 export type AppSettingsReducerAction = {
   type: string,
-  payload: any
-}
+  payload: Object,
+};
 
 export const initialState = {
   data: {
@@ -42,10 +42,10 @@ export const initialState = {
   isFetched: false,
 };
 
-export default function appSettingsReducer(
+const appSettingsReducer = (
   state: AppSettingsReducerState = initialState,
   action: AppSettingsReducerAction,
-) {
+): AppSettingsReducerState => {
   switch (action.type) {
     case UPDATE_APP_SETTINGS:
       const updatedState = { data: action.payload, isFetched: true };
@@ -57,4 +57,6 @@ export default function appSettingsReducer(
     default:
       return state;
   }
-}
+};
+
+export default appSettingsReducer;

--- a/src/reducers/blockchainNetworkReducer.js
+++ b/src/reducers/blockchainNetworkReducer.js
@@ -1,44 +1,71 @@
 // @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+import type { BlockchainNetwork } from 'models/BlockchainNetwork';
 import {
   BLOCKCHAIN_NETWORK_TYPES,
   SET_ACTIVE_NETWORK,
 } from 'constants/blockchainNetworkConstants';
 
 export type BlockchainNetworkReducerState = {
-  data: Object[],
+  data: BlockchainNetwork[],
 };
 
-export type NetworkAction = {
+export type BlockchainNetworkAction = {
   type: string,
-  payload: any,
+  payload: string,
 };
 
-const initialState = {
+const initialState: BlockchainNetworkReducerState = {
   data: [
     {
       id: BLOCKCHAIN_NETWORK_TYPES.ETHEREUM,
       title: 'Ethereum',
       isActive: true,
+      isAvailable: true,
     },
     {
       id: BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK,
       title: 'Pillar network',
       isActive: false,
+      isAvailable: true,
     },
   ],
 };
 
-export default function blockchainNetworkReducer(
+const blockchainNetworkReducer = (
   state: BlockchainNetworkReducerState = initialState,
-  action: NetworkAction,
-): BlockchainNetworkReducerState {
+  action: BlockchainNetworkAction,
+): BlockchainNetworkReducerState => {
   switch (action.type) {
     case SET_ACTIVE_NETWORK:
+      const activatedId = action.payload;
+
       return {
         ...state,
-        data: state.data.map(({ id, ...rest }) => ({ id, ...rest, isActive: id === action.payload })),
+        data: state.data.map(
+          ({ id, ...rest }) => ({ id, ...rest, isActive: id === activatedId }),
+        ),
       };
     default:
       return state;
   }
-}
+};
+
+export default blockchainNetworkReducer;

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -21,6 +21,7 @@ import { combineReducers } from 'redux';
 
 // constants
 import { LOG_OUT } from 'constants/authConstants';
+import type { DbAction } from 'models/DbAction';
 
 // reducers
 import offlineQueueReducer from './offlineQueueReducer';
@@ -60,7 +61,7 @@ import type { WalletReducerState } from './walletReducer';
 import type { SmartWalletReducerState } from './smartWalletReducer';
 import type { WalletConnectReducerState } from './walletConnectReducer';
 import type { AssetsReducerState } from './assetsReducer';
-import type { AppSettingsReducerState } from './appSettingsReducer';
+import type { AppSettingsReducerAction, AppSettingsReducerState } from './appSettingsReducer';
 import type { RatesReducerState } from './ratesReducer';
 import type { UserReducerState } from './userReducer';
 import type { HistoryReducerState } from './historyReducer';
@@ -84,7 +85,7 @@ import type { AccountsReducerState } from './accountsReducer';
 import type { BalancesReducerState } from './balancesReducer';
 import type { PaymentNetworkReducerState } from './paymentNetworkReducer';
 import type { FeatureFlagsReducerState } from './featureFlagsReducer';
-import type { BlockchainNetworkReducerState } from './blockchainNetworkReducer';
+import type { BlockchainNetworkAction, BlockchainNetworkReducerState } from './blockchainNetworkReducer';
 
 export type RootReducerState = {|
   offlineQueue: OfflineQueueReducerState,
@@ -118,6 +119,20 @@ export type RootReducerState = {|
   featureFlags: FeatureFlagsReducerState,
   blockchainNetwork: BlockchainNetworkReducerState,
 |};
+
+type RootReducerAction =
+    BlockchainNetworkAction
+  | AppSettingsReducerAction
+  | DbAction;
+
+export type GetState = () => RootReducerState;
+export type ThunkAction = (
+  dispatch: Dispatch, // eslint-disable-line no-use-before-define
+  getState: GetState,
+) => any;
+export type Dispatch = (
+  action: RootReducerAction | Promise<RootReducerAction> | ThunkAction,
+) => void;
 
 const appReducer = combineReducers({
   offlineQueue: offlineQueueReducer,
@@ -154,7 +169,7 @@ const appReducer = combineReducers({
 
 const initialState = appReducer(undefined, {});
 
-const rootReducer = (state: RootReducerState, action: Object) => {
+const rootReducer = (state: RootReducerState, action: RootReducerAction) => {
   if (action.type === LOG_OUT) {
     return initialState;
   }

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -238,7 +238,7 @@ class AccountsScreen extends React.Component<Props, State> {
     }
   };
 
-  switchToSmartWalletAccount = async (_: string, wallet: Account) => {
+  switchToSmartWalletAccount = async (_: string, wallet: Object) => {
     this.setState({ showPinModal: false, changingAccount: true });
     const { navigation, switchAccount } = this.props;
     if (!this.switchToWallet) return;

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -199,7 +199,7 @@ class AccountsScreen extends React.Component<Props, State> {
     }
   };
 
-  switchToSmartWalletAndGoToPPN = async (_: string, wallet: Account) => {
+  switchToSmartWalletAndGoToPPN = async (_: string, wallet: Object) => {
     const {
       accounts,
       setActiveBlockchainNetwork,
@@ -249,10 +249,8 @@ class AccountsScreen extends React.Component<Props, State> {
   };
 
   initialisePPN = () => {
-    const { navigation } = this.props;
-
-    navigation.navigate(PILLAR_NETWORK_INTRO);
-  }
+    this.props.navigation.navigate(PILLAR_NETWORK_INTRO);
+  };
 
   renderNetwork(item: NetworkItem) {
     const {

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -26,20 +26,19 @@ import { createStructuredSelector } from 'reselect';
 
 // components
 import ContainerWithHeader from 'components/Layout/ContainerWithHeader';
-import { ListCard } from 'components/ListItem/ListCard';
+import { NetworkListCard } from 'components/ListItem/NetworkListCard';
 import SlideModal from 'components/Modals/SlideModal';
 import CheckPin from 'components/CheckPin';
 import Spinner from 'components/Spinner';
 import { SettingsItemCarded } from 'components/ListItem/SettingsItemCarded';
-import Icon from 'components/Icon';
 
 // configs
 import { PPN_TOKEN } from 'configs/assetsConfig';
 
 // utils
 import { getActiveAccount } from 'utils/accounts';
-import { formatMoney, formatFiat } from 'utils/common';
-import { getSmartWalletStatus } from 'utils/smartWallet';
+import { formatFiat, formatMoney } from 'utils/common';
+import { userHasSmartWallet } from 'utils/smartWallet';
 import { responsiveSize } from 'utils/ui';
 import { baseColors, spacing } from 'utils/variables';
 import { calculatePortfolioBalance } from 'utils/assets';
@@ -48,8 +47,8 @@ import { calculatePortfolioBalance } from 'utils/assets';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { Assets, Balances, Rates } from 'models/Asset';
 import type { Accounts, Account } from 'models/Account';
-import type { SmartWalletStatus } from 'models/SmartWalletStatus';
-import type { SmartWalletReducerState } from 'reducers/smartWalletReducer';
+import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
+import type { BlockchainNetwork } from 'models/BlockchainNetwork';
 
 // constants
 import {
@@ -70,11 +69,45 @@ import { resetIncorrectPasswordAction } from 'actions/authActions';
 // selectors
 import { availableStakeSelector } from 'selectors/paymentNetwork';
 
+type NetworkItem = {|
+  id: string,
+  type: 'NETWORK',
+  network: BlockchainNetwork,
+  isInitialised: boolean,
+  action: () => void,
+  initialiseAction: () => void,
+  noteText: string,
+  noteIcon: string,
+  iconSource: string,
+  isInitialised: boolean,
+  formattedStakeAmount: string,
+|};
 
-type Props = {
+type AccountInteraction = {|
+  isActiveWallet: boolean,
+  isSmartWallet: boolean,
+  walletBalance: number,
+  onMainPress: () => void,
+  onSettingsPress?: () => void,
+|};
+
+type NewItem = {| type: 'NEW_SMART_WALLET', interaction: AccountInteraction |};
+
+type AccountItem = {|
+  id: string,
+  type: 'ACCOUNT',
+  interaction: AccountInteraction,
+  account: Account,
+|};
+
+type ListItem = NetworkItem | AccountItem | NewItem;
+
+type ListElement = {| item: ListItem |};
+
+type Props = {|
   navigation: NavigationScreenProp<*>,
   setActiveBlockchainNetwork: Function,
-  blockchainNetworks: Object[],
+  blockchainNetworks: BlockchainNetwork[],
   assets: Assets,
   baseFiatCurrency: string,
   smartWalletFeatureEnabled: boolean,
@@ -83,15 +116,14 @@ type Props = {
   accounts: Accounts,
   resetIncorrectPassword: Function,
   switchAccount: Function,
-  smartWalletState: SmartWalletReducerState,
   balances: Balances,
   rates: Rates,
-}
+|};
 
-type State = {
+type State = {|
   showPinModal: boolean,
   changingAccount: boolean,
-}
+|};
 
 const Wrapper = styled.View`
   flex: 1;
@@ -126,14 +158,6 @@ const WalletIcon = styled.View`
         border-bottom-left-radius: 6px;`
     : `height: ${iconSide}px;
         width: ${iconSide}px;`}
-`;
-
-const CheckIcon = styled(Icon)`
-  font-size: ${responsiveSize(14)}px;
-  color: ${baseColors.electricBlue};
-  position: absolute;
-  top: ${spacing.mediumLarge}px;
-  right: ${spacing.mediumLarge}px;
 `;
 
 const pillarNetworkIcon = require('assets/icons/icon_PPN.png');
@@ -175,7 +199,7 @@ class AccountsScreen extends React.Component<Props, State> {
     }
   };
 
-  switchToSmartWalletAndGoToPPN = async (_: string, wallet: Object) => {
+  switchToSmartWalletAndGoToPPN = async (_: string, wallet: Account) => {
     const {
       accounts,
       setActiveBlockchainNetwork,
@@ -191,7 +215,7 @@ class AccountsScreen extends React.Component<Props, State> {
     navigation.navigate(ASSETS);
   };
 
-  switchWallet = (wallet) => {
+  switchWallet = (wallet: Account) => {
     const {
       switchAccount,
       navigation,
@@ -214,7 +238,7 @@ class AccountsScreen extends React.Component<Props, State> {
     }
   };
 
-  switchToSmartWalletAccount = async (_: string, wallet: Object) => {
+  switchToSmartWalletAccount = async (_: string, wallet: Account) => {
     this.setState({ showPinModal: false, changingAccount: true });
     const { navigation, switchAccount } = this.props;
     if (!this.switchToWallet) return;
@@ -224,68 +248,62 @@ class AccountsScreen extends React.Component<Props, State> {
     navigation.navigate(ASSETS);
   };
 
-  renderNetworks = ({ item }: Object) => {
-    const {
-      navigation,
-      baseFiatCurrency,
-      availableStake,
-      isTankInitialised,
-      smartWalletFeatureEnabled,
-      blockchainNetworks,
-    } = this.props;
+  initialisePPN = () => {
+    const { navigation } = this.props;
 
+    navigation.navigate(PILLAR_NETWORK_INTRO);
+  }
+
+  renderNetwork(item: NetworkItem) {
     const {
-      type = '',
-      balance = {},
-      id,
+      network: { isActive, title },
       action,
+      initialiseAction,
+      formattedStakeAmount,
+      noteText,
+      noteIcon,
+      iconSource,
+      isInitialised,
     } = item;
 
-    const activeBNetwork = blockchainNetworks.find((network) => network.isActive) || { id: '' };
-    const { id: activeBNetworkID } = activeBNetwork;
+    return (
+      <NetworkListCard
+        title={title}
+        subtitle={`Balance: ${formattedStakeAmount}`}
+        noteText={noteText}
+        noteIcon={noteIcon}
+        iconSource={iconSource}
+        isActive={isActive}
+        isInitialised={isInitialised}
+        action={action}
+        initialiseAction={initialiseAction}
+      />
+    );
+  }
 
-    if (id === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK) {
-      const availableStakeFormattedAmount = formatMoney(availableStake, 4);
+  accountSettings = (wallet: Account) => {
+    const { navigation } = this.props;
 
-      if (!smartWalletFeatureEnabled) return null;
-      return (
-        <ListCard
-          {...item}
-          subtitle={`Balance: ${availableStakeFormattedAmount} ${PPN_TOKEN}`}
-          action={isTankInitialised
-            ? this.setPPNAsActiveNetwork
-            : () => navigation.navigate(PILLAR_NETWORK_INTRO)}
-          note={{
-            note: 'Instant, free and private transactions',
-            emoji: 'sunglasses',
-          }}
-          iconSource={pillarNetworkIcon}
-          contentWrapperStyle={{
-            borderWidth: 2,
-            borderColor: activeBNetworkID === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK
-              ? baseColors.electricBlue
-              : baseColors.white,
-            borderRadius: 6,
-          }}
-        >
-          {activeBNetworkID === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK && <CheckIcon name="check" />}
-        </ListCard>
-      );
-    }
+    navigation.navigate(WALLET_SETTINGS, { wallet });
+  }
 
-    const isSmartWallet = type === ACCOUNT_TYPES.SMART_WALLET || type === 'SMART_WALLET_INIT';
-    const isActiveWallet = !!item.isActive && activeBNetworkID === BLOCKCHAIN_NETWORK_TYPES.ETHEREUM;
-    const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
-    const balanceInFiat = Object.keys(balance).length ? balance[fiatCurrency] : 0;
-    const walletBalance = formatFiat(balanceInFiat || 0, baseFiatCurrency);
+  renderAccount(interaction: AccountInteraction) {
+    const {
+      walletBalance,
+      onMainPress,
+      onSettingsPress,
+      isActiveWallet,
+      isSmartWallet,
+    } = interaction;
+
+    const { baseFiatCurrency } = this.props;
+
     return (
       <SettingsItemCarded
         title={isSmartWallet ? 'Ethereum Smart Wallet' : 'Ethereum Key Wallet'}
-        subtitle={walletBalance}
-        onMainPress={action ? () => action() : () => this.switchWallet(item)}
-        onSettingsPress={type === 'SMART_WALLET_INIT'
-          ? null
-          : () => navigation.navigate(WALLET_SETTINGS, { wallet: item })}
+        subtitle={formatFiat(walletBalance, baseFiatCurrency)}
+        onMainPress={onMainPress}
+        onSettingsPress={onSettingsPress}
         isActive={isActiveWallet}
         customIcon={(
           <IconWrapper>
@@ -294,39 +312,132 @@ class AccountsScreen extends React.Component<Props, State> {
         )}
       />
     );
+  }
+
+  renderListItem = ({ item }: ListElement) => {
+    switch (item.type) {
+      case 'NETWORK':
+        return this.renderNetwork(item);
+
+      case 'ACCOUNT':
+      case 'NEW_SMART_WALLET':
+        return this.renderAccount(item.interaction);
+
+      default:
+        return null;
+    }
   };
 
-  render() {
-    const { showPinModal, changingAccount } = this.state;
+  visibleAccounts(accounts: Accounts, smartWalletFeatureEnabled: boolean): Accounts {
+    if (smartWalletFeatureEnabled) {
+      return accounts;
+    }
+
+    return accounts.filter(({ type }) => type !== ACCOUNT_TYPES.SMART_WALLET);
+  }
+
+  wallets(activeNetwork?: BlockchainNetwork): ListItem[] {
     const {
       accounts,
-      blockchainNetworks,
-      smartWalletFeatureEnabled,
-      smartWalletState,
       navigation,
       balances,
       assets,
       rates,
+      smartWalletFeatureEnabled,
+      baseFiatCurrency,
     } = this.props;
-    const ppnNetwork = blockchainNetworks.find((network) => network.id === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK);
-    const smartWalletStatus: SmartWalletStatus = getSmartWalletStatus(accounts, smartWalletState);
-    const showSmartWalletInitButton = !smartWalletStatus.hasAccount && smartWalletFeatureEnabled;
-    const visibleAccounts = smartWalletFeatureEnabled
-      ? accounts
-      : accounts.filter(({ type }) => type !== ACCOUNT_TYPES.SMART_WALLET);
 
-    const visibleAccountsWithBalance = visibleAccounts.map((acc) => {
-      const accountBalances = balances[acc.id] || {};
-      const balance = calculatePortfolioBalance(assets, rates, accountBalances);
-      return { ...acc, balance };
+    const visibleAccounts = this.visibleAccounts(accounts, smartWalletFeatureEnabled);
+    const hasAccount = userHasSmartWallet(accounts);
+    const showSmartWalletInitButton = !hasAccount && smartWalletFeatureEnabled;
+    const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
+
+    const isEthereumActive = !!activeNetwork && (
+      activeNetwork.id === BLOCKCHAIN_NETWORK_TYPES.ETHEREUM
+    );
+
+    const wallets = visibleAccounts.map((account: Account): ListItem => {
+      const { id, isActive, type } = account;
+      const accountBalances = balances[id];
+      const isActiveWallet = !!isActive && isEthereumActive;
+      const isSmartWallet = type === ACCOUNT_TYPES.SMART_WALLET;
+      let walletBalance = 0;
+
+      if (accountBalances) {
+        // TODO: improve balance calculation?
+        const balance = calculatePortfolioBalance(assets, rates, accountBalances);
+        walletBalance = balance && balance[fiatCurrency];
+      }
+
+      const accountItem = {
+        id: `ACCOUNT_${id}`,
+        account,
+        type: 'ACCOUNT',
+        interaction: {
+          walletBalance,
+          onMainPress: () => this.switchWallet(account),
+          onSettingsPress: () => this.accountSettings(account),
+          isActiveWallet,
+          isSmartWallet,
+        },
+      };
+
+      return accountItem;
     });
 
-    const walletsToShow = showSmartWalletInitButton
-      ? [
-        ...visibleAccountsWithBalance,
-        { type: 'SMART_WALLET_INIT', action: () => navigation.navigate(SMART_WALLET_INTRO) },
-      ]
-      : visibleAccountsWithBalance;
+    if (showSmartWalletInitButton) {
+      wallets.push({
+        type: 'NEW_SMART_WALLET',
+        interaction: {
+          isSmartWallet: true,
+          walletBalance: 0,
+          isActiveWallet: false,
+          onMainPress: () => { navigation.navigate(SMART_WALLET_INTRO); },
+        },
+      });
+    }
+
+    return wallets;
+  }
+
+  networks(): ListItem[] {
+    const networks: ListItem[] = [];
+
+    const {
+      blockchainNetworks,
+      availableStake,
+      isTankInitialised,
+      smartWalletFeatureEnabled,
+    } = this.props;
+
+    const ppnNetwork = blockchainNetworks.find((network) => network.id === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK);
+    const availableStakeFormattedAmount = formatMoney(availableStake);
+
+    if (smartWalletFeatureEnabled && ppnNetwork) {
+      networks.push({
+        id: `NETWORK_${ppnNetwork.id}`,
+        type: 'NETWORK',
+        isInitialised: isTankInitialised,
+        network: ppnNetwork,
+        formattedStakeAmount: `${availableStakeFormattedAmount} ${PPN_TOKEN}`,
+        noteText: 'Instant, free and private transactions',
+        noteIcon: 'sunglasses',
+        iconSource: pillarNetworkIcon,
+        action: this.setPPNAsActiveNetwork,
+        initialiseAction: this.initialisePPN,
+      });
+    }
+
+    return networks;
+  }
+
+  render() {
+    const { showPinModal, changingAccount } = this.state;
+    const { blockchainNetworks } = this.props;
+
+    const activeNetwork = blockchainNetworks.find((net) => net.isActive);
+    const walletsToShow = this.wallets(activeNetwork);
+    const networksToShow = this.networks();
 
     return (
       <ContainerWithHeader
@@ -340,14 +451,13 @@ class AccountsScreen extends React.Component<Props, State> {
       >
         {!changingAccount &&
         <FlatList
-          data={smartWalletFeatureEnabled && ppnNetwork
-            ? [...walletsToShow, ppnNetwork]
-            : walletsToShow}
+          data={[...walletsToShow, ...networksToShow]}
           keyExtractor={(item) => item.id || item.type}
           style={{ width: '100%' }}
           contentContainerStyle={{ width: '100%', padding: 20 }}
-          renderItem={this.renderNetworks}
+          renderItem={this.renderListItem}
         />}
+
         {changingAccount &&
         <Wrapper>
           <Spinner />
@@ -379,17 +489,15 @@ const mapStateToProps = ({
   paymentNetwork: { isTankInitialised },
   featureFlags: { data: { SMART_WALLET_ENABLED: smartWalletFeatureEnabled } },
   appSettings: { data: { baseFiatCurrency } },
-  smartWallet: smartWalletState,
   balances: { data: balances },
   rates: { data: rates },
-}) => ({
+}: RootReducerState) => ({
   accounts,
   blockchainNetworks,
   assets,
   isTankInitialised,
   smartWalletFeatureEnabled,
   baseFiatCurrency,
-  smartWalletState,
   balances,
   rates,
 });
@@ -398,12 +506,12 @@ const structuredSelector = createStructuredSelector({
   availableStake: availableStakeSelector,
 });
 
-const combinedMapStateToProps = (state) => ({
+const combinedMapStateToProps = (state: RootReducerState) => ({
   ...structuredSelector(state),
   ...mapStateToProps(state),
 });
 
-const mapDispatchToProps = (dispatch: Function) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
   setActiveBlockchainNetwork: (id: string) => dispatch(setActiveBlockchainNetworkAction(id)),
   resetIncorrectPassword: () => dispatch(resetIncorrectPasswordAction()),
   switchAccount: (accountId: string, privateKey?: string) => dispatch(switchAccountAction(accountId, privateKey)),

--- a/src/utils/__tests__/smartWallet.test.js
+++ b/src/utils/__tests__/smartWallet.test.js
@@ -1,0 +1,59 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+import { userHasSmartWallet } from 'utils/smartWallet';
+import { ACCOUNT_TYPES } from 'constants/accountsConstants';
+
+import type { Accounts } from 'models/Account';
+
+describe('Smartwallet utils', () => {
+  describe('userHasSmartWallet', () => {
+    it('returns false when user does not have a smart wallet', () => {
+      const accounts: Accounts = [
+        {
+          id: '',
+          type: ACCOUNT_TYPES.KEY_BASED,
+          walletId: '',
+          isActive: true,
+        },
+      ];
+
+      expect(userHasSmartWallet(accounts)).toBe(false);
+    });
+
+    it('returns true when user has a smart wallet', () => {
+      const accounts: Accounts = [
+        {
+          id: '',
+          type: ACCOUNT_TYPES.KEY_BASED,
+          walletId: '',
+          isActive: true,
+        },
+        {
+          id: '',
+          type: ACCOUNT_TYPES.SMART_WALLET,
+          walletId: '',
+          isActive: false,
+        },
+      ];
+
+      expect(userHasSmartWallet(accounts)).toBe(true);
+    });
+  });
+});

--- a/src/utils/smartWallet.js
+++ b/src/utils/smartWallet.js
@@ -28,19 +28,19 @@ import type { SmartWalletReducerState } from 'reducers/smartWalletReducer';
 import { getActiveAccount } from './accounts';
 
 const getMessage = (
-  status: string,
-  activeAccountType: string,
+  status: ?string,
+  isSmartWalletActive: boolean,
   smartWalletState: SmartWalletReducerState,
 ) => {
   switch (status) {
     case SMART_WALLET_UPGRADE_STATUSES.ACCOUNT_CREATED:
-      if (activeAccountType !== ACCOUNT_TYPES.SMART_WALLET) return {};
+      if (!isSmartWalletActive) return {};
       return {
         title: 'To send assets, deploy Smart Wallet first',
         message: 'You will have to pay a small fee',
       };
     case SMART_WALLET_UPGRADE_STATUSES.DEPLOYING:
-      if (activeAccountType !== ACCOUNT_TYPES.SMART_WALLET) return {};
+      if (!isSmartWalletActive) return {};
       // TODO: get average time
       return {
         title: 'Smart Wallet is being deployed now',
@@ -54,7 +54,7 @@ const getMessage = (
       return {
         title: 'Assets are being transferred to Smart Wallet',
         message: 'You will be able to send assets once submitted transfer is complete' +
-          `${activeAccountType === ACCOUNT_TYPES.SMART_WALLET ? ' and Smart Wallet is deployed' : ''}.` +
+          `${isSmartWalletActive ? ' and Smart Wallet is deployed' : ''}.` +
           `\nCurrently ${complete} of ${total} assets are transferred.`,
       };
     default:
@@ -62,25 +62,29 @@ const getMessage = (
   }
 };
 
-export function getSmartWalletStatus(accounts: Accounts, smartWalletState: Object): SmartWalletStatus {
-  const account = accounts.find(acc => acc.type === ACCOUNT_TYPES.SMART_WALLET);
-  const activeAccount = getActiveAccount(accounts) || {};
+export const userHasSmartWallet = (accounts: Accounts = []): boolean => {
+  return accounts.some(acc => acc.type === ACCOUNT_TYPES.SMART_WALLET);
+};
+
+export const getSmartWalletStatus = (
+  accounts: Accounts,
+  smartWalletState: SmartWalletReducerState,
+): SmartWalletStatus => {
+  const hasAccount = userHasSmartWallet(accounts);
+  const activeAccount = getActiveAccount(accounts);
+  const isSmartWalletActive = !!activeAccount && activeAccount.type === ACCOUNT_TYPES.SMART_WALLET;
+
   const { upgrade: { status } } = smartWalletState;
-  const sendingBlockedMessage = getMessage(status, activeAccount.type, smartWalletState);
+  const sendingBlockedMessage = getMessage(status, isSmartWalletActive, smartWalletState);
   return {
-    hasAccount: !!account,
+    hasAccount,
     status,
     sendingBlockedMessage,
   };
-}
+};
 
 export function isConnectedToSmartAccount(connectedAccountRecord: ?Object) {
   return connectedAccountRecord && Object.keys(connectedAccountRecord).length;
-}
-
-export function userHasSmartWallet(accounts: Accounts = []) {
-  const smartAccount = accounts.find(acc => acc.type === ACCOUNT_TYPES.SMART_WALLET);
-  return !!smartAccount;
 }
 
 export function getDeployErrorMessage(errorType: string) {


### PR DESCRIPTION
This is an effort to simplify the Accounts screen in order to have an
easier way of adding netorks.

Now the Accounts screen will have explicit types for accounts, networks
and account creation items, which will help adding different networks
like BTC.