### PR TITLE
Fix/onboarding

### DIFF
--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -321,6 +321,7 @@ class ImportWallet extends React.Component<Props, State> {
       <ContainerWithHeader
         headerProps={({
           centerItems: [{ title: 'Restore wallet' }],
+          customOnBack: this.handleBackAction,
         })}
         backgroundColor={baseColors.white}
         keyboardAvoidFooter={(

--- a/src/screens/NewProfile/NewProfile.js
+++ b/src/screens/NewProfile/NewProfile.js
@@ -124,6 +124,7 @@ type Props = {
   apiUser: Object,
   retry?: boolean,
   registerOnBackend: Function,
+  importedWallet: ?Object,
 };
 
 type State = {
@@ -334,6 +335,7 @@ class NewProfile extends React.Component<Props, State> {
       retry,
       walletState,
       session,
+      importedWallet,
     } = this.props;
     const {
       hasAgreedToTerms,
@@ -377,37 +379,40 @@ class NewProfile extends React.Component<Props, State> {
             nextDisabled={!canGoNext}
             wrapperStyle={{ paddingBottom: 15, paddingTop: 15 }}
           >
-            <Checkbox
-              onPress={() => { this.setState({ hasAgreedToTerms: !hasAgreedToTerms }); }}
-              small
-              lightText
-              darkCheckbox
-              wrapperStyle={{ marginBottom: 16 }}
-            >
-              <CheckboxText>
-                {'I have read, understand, and agree to the '}
-                <StyledTextLink
-                  onPress={() => { this.setState({ visibleModal: TERMS_OF_USE_MODAL }); }}
-                >
-                  Terms of Use
-                </StyledTextLink>
-              </CheckboxText>
-            </Checkbox>
-            <Checkbox
-              onPress={() => { this.setState({ hasAgreedToPolicy: !hasAgreedToPolicy }); }}
-              small
-              lightText
-              darkCheckbox
-            >
-              <CheckboxText>
-                {'I have read, understand, and agree to the '}
-                <StyledTextLink
-                  onPress={() => { this.setState({ visibleModal: PRIVACY_POLICY_MODAL }); }}
-                >
-                  Privacy policy
-                </StyledTextLink>
-              </CheckboxText>
-            </Checkbox>
+            {!importedWallet &&
+            <React.Fragment>
+              <Checkbox
+                onPress={() => { this.setState({ hasAgreedToTerms: !hasAgreedToTerms }); }}
+                small
+                lightText
+                darkCheckbox
+                wrapperStyle={{ marginBottom: 16 }}
+              >
+                <CheckboxText>
+                  {'I have read, understand, and agree to the '}
+                  <StyledTextLink
+                    onPress={() => { this.setState({ visibleModal: TERMS_OF_USE_MODAL }); }}
+                  >
+                    Terms of Use
+                  </StyledTextLink>
+                </CheckboxText>
+              </Checkbox>
+              <Checkbox
+                onPress={() => { this.setState({ hasAgreedToPolicy: !hasAgreedToPolicy }); }}
+                small
+                lightText
+                darkCheckbox
+              >
+                <CheckboxText>
+                  {'I have read, understand, and agree to the '}
+                  <StyledTextLink
+                    onPress={() => { this.setState({ visibleModal: PRIVACY_POLICY_MODAL }); }}
+                  >
+                    Privacy policy
+                  </StyledTextLink>
+                </CheckboxText>
+              </Checkbox>
+            </React.Fragment>}
           </NextFooter>
         )}
       >
@@ -434,11 +439,12 @@ class NewProfile extends React.Component<Props, State> {
 }
 
 const mapStateToProps = ({
-  wallet: { walletState, onboarding: { apiUser } },
+  wallet: { walletState, onboarding: { apiUser, importedWallet } },
   session: { data: session },
 }) => ({
   walletState,
   apiUser,
+  importedWallet,
   session,
 });
 

--- a/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
+++ b/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
@@ -81,7 +81,7 @@ class PinCodeConfirmation extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          centerItems: [{ title: 'Confirm PiN code' }],
+          centerItems: [{ title: 'Confirm PIN code' }],
         }}
         backgroundColor={baseColors.white}
       >

--- a/src/screens/SetWalletPinCode/SetWalletPinCode.js
+++ b/src/screens/SetWalletPinCode/SetWalletPinCode.js
@@ -70,7 +70,7 @@ class SetWalletPinCode extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          centerItems: [{ title: 'Create PiN code' }],
+          centerItems: [{ title: 'Create PIN code' }],
         }}
         backgroundColor={baseColors.white}
       >


### PR DESCRIPTION
This PR:
1. Hides legal checkboxes (repeated) on NewProfile screen for users that import wallet that is not yet registered.
2. Fixes ImportWallet back button action, so legged in users that attempts to restore wallet and cancels the action would get back to PIN screen rather than Welcome screen.