### PR TITLE
Fix/tx history

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -49,6 +49,7 @@ import { navigate, getNavigationState, getNavigationPathAndParamsState } from 's
 import ChatService from 'services/chat';
 import firebase from 'react-native-firebase';
 import Intercom from 'react-native-intercom';
+import { getActiveAccountAddress } from 'utils/accounts';
 import { toastWalletBackup } from 'utils/toasts';
 import { updateOAuthTokensCB, onOAuthTokensFailedCB } from 'utils/oAuth';
 import { getSaltedPin, normalizeWalletAddress } from 'utils/wallet';
@@ -241,7 +242,7 @@ export const loginAction = (
        * this is used only to avoid BCX fetching issues,
        * TODO: remove fetching from ethplorer when BCX is fixed or BCX2 is released
        */
-      dispatch(restoreTransactionHistoryAction(wallet.address, user.walletId));
+      dispatch(restoreTransactionHistoryAction(getActiveAccountAddress(accounts), user.walletId));
 
       navigate(navigateToAppAction);
     } catch (e) {

--- a/src/actions/historyActions.js
+++ b/src/actions/historyActions.js
@@ -80,7 +80,11 @@ export const fetchTransactionsHistoryAction = (asset: string = 'ALL', fromIndex:
 
     const { history: { data: currentHistory } } = getState();
     const accountHistory = currentHistory[accountId] || [];
-    const updatedAccountHistory = uniqBy([...history, ...accountHistory], 'hash');
+
+    const pendingTransactions = history.filter(tx => tx.status === TX_PENDING_STATUS);
+    const minedTransactions = history.filter(tx => tx.status !== TX_PENDING_STATUS);
+
+    const updatedAccountHistory = uniqBy([...minedTransactions, ...accountHistory, ...pendingTransactions], 'hash');
     const updatedHistory = updateAccountHistory(currentHistory, accountId, updatedAccountHistory);
     dispatch(saveDbAction('history', { history: updatedHistory }, true));
 

--- a/src/actions/historyActions.js
+++ b/src/actions/historyActions.js
@@ -243,8 +243,6 @@ export const updateTransactionStatusAction = (hash: string) => {
 
 export const restoreTransactionHistoryAction = (walletAddress: string, walletId: string) => {
   return async (dispatch: Function, getState: Function, api: Object) => {
-    const { accounts: { data: accounts } } = getState();
-
     const [allAssets, _erc20History, ethHistory] = await Promise.all([
       api.fetchSupportedAssets(walletId),
       api.importedErc20TransactionHistory(walletAddress),
@@ -258,8 +256,7 @@ export const restoreTransactionHistoryAction = (walletAddress: string, walletId:
     });
 
     const { history: { data: currentHistory } } = getState();
-    const accountId = getActiveAccountId(accounts);
-    const accountHistory = currentHistory[accountId] || [];
+    const accountHistory = currentHistory[walletAddress] || [];
 
     // 1) filter out records those exists in accountHistory
     const ethTransactions = ethHistory.filter(tx => {
@@ -311,7 +308,7 @@ export const restoreTransactionHistoryAction = (walletAddress: string, walletId:
     const sortedHistory = orderBy(updatedAccountHistory, ['createdAt'], ['asc']);
 
     // 6) update history in storage
-    const updatedHistory = updateAccountHistory(currentHistory, accountId, sortedHistory);
+    const updatedHistory = updateAccountHistory(currentHistory, walletAddress, sortedHistory);
 
     await dispatch(saveDbAction('history', { history: updatedHistory }, true));
     dispatch({

--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -173,6 +173,7 @@ type FeedItemConnection = {
 
 type FeedSection = {
   title: string,
+  date: string,
   data: Array<FeedItemTransaction | FeedItemConnection>,
 }
 
@@ -224,10 +225,11 @@ class ActivityFeed extends React.Component<Props, State> {
     }
 
     feedList.forEach(listItem => {
-      const formattedDate = formatDate(new Date(listItem.createdAt * 1000), 'MMM D');
-      const existingSection = dataSections.find(({ title }) => title === formattedDate);
+      const formattedDate = formatDate(new Date(listItem.createdAt * 1000), 'MMM D YYYY');
+      const sectionTitle = formatDate(new Date(listItem.createdAt * 1000), 'MMM D');
+      const existingSection = dataSections.find(({ date }) => date === formattedDate);
       if (!existingSection) {
-        dataSections.push({ title: formattedDate, data: [{ ...listItem }] });
+        dataSections.push({ title: sectionTitle, date: formattedDate, data: [{ ...listItem }] });
       } else {
         existingSection.data.push({ ...listItem });
       }

--- a/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
+++ b/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
@@ -33,6 +33,7 @@ exports[`ActivityFeed does not fail for invalid values 1`] = `
               "value": undefined,
             },
           ],
+          "date": "Invalid Date",
           "title": "Invalid Date",
         },
       ]
@@ -68,6 +69,7 @@ exports[`ActivityFeed does not fail for invalid values 1`] = `
               "value": undefined,
             },
           ],
+          "date": "Invalid Date",
           "title": "Invalid Date",
         },
       ]
@@ -433,6 +435,7 @@ exports[`ActivityFeed renders the Asset correctly 1`] = `
               "value": "0",
             },
           ],
+          "date": "Invalid Date",
           "title": "Invalid Date",
         },
       ]
@@ -468,6 +471,7 @@ exports[`ActivityFeed renders the Asset correctly 1`] = `
               "value": "0",
             },
           ],
+          "date": "Invalid Date",
           "title": "Invalid Date",
         },
       ]

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -334,9 +334,6 @@ export default class Tabs extends React.Component<Props, State> {
   render() {
     const { isFloating, tabs, coverColor } = this.props;
 
-
-    console.log('tabLengths ---->', { tabLengths: this.state.tabLengths });
-
     if (isFloating) {
       return (
         <FloatingHeader>

--- a/src/selectors/history.js
+++ b/src/selectors/history.js
@@ -7,6 +7,6 @@ export const accountHistorySelector = createSelector(
   activeAccountIdSelector,
   (history, activeAccountId) => {
     if (!activeAccountId) return [];
-    return history[activeAccountId] || [];
+    return (history[activeAccountId] || []).sort((a, b) => b.createdAt - a.createdAt);
   },
 );

--- a/src/selectors/history.js
+++ b/src/selectors/history.js
@@ -7,6 +7,6 @@ export const accountHistorySelector = createSelector(
   activeAccountIdSelector,
   (history, activeAccountId) => {
     if (!activeAccountId) return [];
-    return (history[activeAccountId] || []).sort((a, b) => b.createdAt - a.createdAt);
+    return history[activeAccountId] || [];
   },
 );


### PR DESCRIPTION
Multiple fixes for tx history:
1) when we call restoreTransactionHistoryAction() we could pass non-active wallet address, thus we need to save restored tx history data in the appropriate account
2) BCX could return the wrong status for the transaction, like it was already mined, but BCX still thinks it's pending
3) when we group events by date on the home screen, we need to avoid putting events from different years into one group