### PR TITLE
Fix/UI_fix_changing_between_wallets

### DIFF
--- a/src/components/CheckPin/CheckPin.js
+++ b/src/components/CheckPin/CheckPin.js
@@ -123,7 +123,7 @@ class CheckPin extends React.Component<Props, State> {
 
     if (walletState === DECRYPTING || isChecking || walletState === GENERATING_CONNECTIONS) {
       return (
-        <Container center color="transparent">
+        <Container style={{ flex: 1, width: '100%' }} center color="transparent">
           <Loader messages={['Checking']} />
         </Container>
       );

--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -29,6 +29,7 @@ import { baseColors, fontSizes } from 'utils/variables';
 
 type Props = {
   messages?: Array<string>,
+  noMessages?: boolean,
 };
 
 type State = {
@@ -66,6 +67,8 @@ export default class Loader extends React.Component<Props, State> {
   };
 
   componentDidMount() {
+    const { noMessages } = this.props;
+    if (noMessages) return;
     this.timerToChangeMessage = setInterval(() => this.changeMessages(), 4000);
     this.startTimeout = setTimeout(() => {
       this.showMessage();

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -29,7 +29,7 @@ import ContainerWithHeader from 'components/Layout/ContainerWithHeader';
 import { NetworkListCard } from 'components/ListItem/NetworkListCard';
 import SlideModal from 'components/Modals/SlideModal';
 import CheckPin from 'components/CheckPin';
-import Spinner from 'components/Spinner';
+import Loader from 'components/Loader';
 import { SettingsItemCarded } from 'components/ListItem/SettingsItemCarded';
 
 // configs
@@ -465,7 +465,7 @@ class AccountsScreen extends React.Component<Props, State> {
 
         {changingAccount &&
         <Wrapper>
-          <Spinner />
+          <Loader noMessages />
         </Wrapper>}
 
         <SlideModal


### PR DESCRIPTION
This PR unifies loaders on screens related to changing between wallets flow so spinner would stay on the left side