### PR TITLE
Fix assets list not showing low balance

### DIFF
--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -175,7 +175,7 @@ class AssetsList extends React.Component<Props> {
         label={name}
         avatarUrl={fullIconUrl}
         balance={{
-          balance: formatMoney(balance),
+          balance: formatMoney(balance, decimals),
           value: formattedBalanceInFiat,
           token: symbol,
         }}


### PR DESCRIPTION
When the asset balance is below two digits, the assets list shows 0,
passing the `decimals` to `formatMoney` should fix this problem.

# Example

On this case, the balance in ETH is `0.001`:

## Before

![assets-prev](https://user-images.githubusercontent.com/263335/64291411-776c0280-cf3e-11e9-9f04-c5bc2cc90a6a.png)

## After

![assets-after](https://user-images.githubusercontent.com/263335/64291455-9a96b200-cf3e-11e9-9c8c-136d79ec7cb0.png)
