### PR TITLE
Add initial tests for WalletConnect reducer

### DIFF
--- a/src/actions/walletConnectActions.js
+++ b/src/actions/walletConnectActions.js
@@ -49,11 +49,14 @@ import { WALLETCONNECT_SESSION_REQUEST_SCREEN, WALLETCONNECT_CALL_REQUEST_SCREEN
 import { navigate } from 'services/navigation';
 import Toast from 'components/Toast';
 import { logEventAction } from 'actions/analyticsActions';
+
+import type { Dispatch, GetState } from 'reducers/rootReducer';
+
 import { saveDbAction } from './dbActions';
 
 const storage = Storage.getInstance('db');
 
-async function getNativeOptions() {
+const getNativeOptions = async () => {
   // const language = DEVICE_LANGUAGE.replace(/[-_](\w?)+/gi, "").toLowerCase();
   // const token = await getFCMToken();
 
@@ -76,17 +79,17 @@ async function getNativeOptions() {
   };
 
   return nativeOptions;
-}
+};
 
-function updateSavedConnectors(connectors: WalletConnect[]) {
-  return async (dispatch: Function) => {
+const updateSavedConnectors = (connectors: WalletConnect[]) => {
+  return async (dispatch: Dispatch) => {
     const sessions = connectors.map(connector => connector.session);
     dispatch(saveDbAction('walletconnect', { sessions }, true));
   };
-}
+};
 
-export function onWalletConnectCallRequest(peerId: string, payload: Object) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectCallRequest = (peerId: string, payload: Object) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { connectors } = getState().walletConnect;
 
@@ -138,10 +141,10 @@ export function onWalletConnectCallRequest(peerId: string, payload: Object) {
       });
     }
   };
-}
+};
 
-export function killWalletConnectSession(peerId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const killWalletConnectSession = (peerId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { connectors } = getState().walletConnect;
 
@@ -181,10 +184,10 @@ export function killWalletConnectSession(peerId: string) {
       });
     }
   };
-}
+};
 
-export function killWalletConnectSessionByUrl(url: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const killWalletConnectSessionByUrl = (url: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { connectors } = getState().walletConnect;
 
@@ -222,10 +225,10 @@ export function killWalletConnectSessionByUrl(url: string) {
       });
     }
   };
-}
+};
 
-export function clearPendingWalletConnectSessionByUrl(url: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const clearPendingWalletConnectSessionByUrl = (url: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { pending } = getState().walletConnect;
 
@@ -245,10 +248,10 @@ export function clearPendingWalletConnectSessionByUrl(url: string) {
       });
     }
   };
-}
+};
 
-export function onWalletConnectDisconnect(peerId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectDisconnect = (peerId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { connectors } = getState().walletConnect;
 
@@ -272,10 +275,10 @@ export function onWalletConnectDisconnect(peerId: string) {
       });
     }
   };
-}
+};
 
-export function onWalletConnectSubscribeToEvents(peerId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectSubscribeToEvents = (peerId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { connectors } = getState().walletConnect;
 
@@ -328,10 +331,10 @@ export function onWalletConnectSubscribeToEvents(peerId: string) {
       });
     }
   };
-}
+};
 
-export function initWalletConnectSessions() {
-  return async (dispatch: Function) => {
+export const initWalletConnectSessions = () => {
+  return async (dispatch: Dispatch) => {
     try {
       const { sessions = [] } = await storage.get('walletconnect');
 
@@ -363,10 +366,10 @@ export function initWalletConnectSessions() {
       });
     }
   };
-}
+};
 
-export function onWalletConnectSubscribeToSessionRequestEvent(clientId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectSubscribeToSessionRequestEvent = (clientId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { pending } = getState().walletConnect;
 
@@ -407,10 +410,10 @@ export function onWalletConnectSubscribeToSessionRequestEvent(clientId: string) 
       });
     }
   };
-}
+};
 
-export function cancelWaitingRequest(clientId: string, timeout: boolean = false) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const cancelWaitingRequest = (clientId: string, timeout: boolean = false) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     const { pending, waitingRequest } = getState().walletConnect;
 
     if (waitingRequest !== clientId) {
@@ -441,10 +444,10 @@ export function cancelWaitingRequest(clientId: string, timeout: boolean = false)
       });
     }
   };
-}
+};
 
-export function requestWalletConnectSessionAction(uri: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const requestWalletConnectSessionAction = (uri: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { pending } = getState().walletConnect;
 
@@ -484,10 +487,10 @@ export function requestWalletConnectSessionAction(uri: string) {
       });
     }
   };
-}
+};
 
-export function onWalletConnectSessionApproval(peerId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectSessionApproval = (peerId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { pending, connectors } = getState().walletConnect;
 
@@ -538,10 +541,10 @@ export function onWalletConnectSessionApproval(peerId: string) {
       });
     }
   };
-}
+};
 
-export function onWalletConnectSessionRejection(peerId: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectSessionRejection = (peerId: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     try {
       const { pending } = getState().walletConnect;
 
@@ -577,10 +580,10 @@ export function onWalletConnectSessionRejection(peerId: string) {
       });
     }
   };
-}
+};
 
-export function onWalletConnectRejectCallRequest(peerId: string, callId: string, errorMsg?: string) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectRejectCallRequest = (peerId: string, callId: string, errorMsg?: string) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     const { connectors } = getState().walletConnect;
 
     const matchingConnectors = connectors.filter(c => c.peerId === peerId);
@@ -598,10 +601,10 @@ export function onWalletConnectRejectCallRequest(peerId: string, callId: string,
       });
     }
   };
-}
+};
 
-export function onWalletConnectApproveCallRequest(peerId: string, callId: string, result: any) {
-  return async (dispatch: Function, getState: () => Object) => {
+export const onWalletConnectApproveCallRequest = (peerId: string, callId: string, result: any) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
     if (!result) {
       dispatch(onWalletConnectRejectCallRequest(peerId, callId));
     }
@@ -624,4 +627,4 @@ export function onWalletConnectApproveCallRequest(peerId: string, callId: string
       });
     }
   };
-}
+};

--- a/src/reducers/__tests__/walletConnectReducer.test.js
+++ b/src/reducers/__tests__/walletConnectReducer.test.js
@@ -1,0 +1,264 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+import WalletConnect from '@walletconnect/react-native';
+import {
+  WALLETCONNECT_ERROR,
+  WALLETCONNECT_CLEAR_PENDING,
+  WALLETCONNECT_CANCEL_REQUEST,
+  WALLETCONNECT_INIT_SESSIONS,
+  WALLETCONNECT_SESSION_DISCONNECTED,
+  WALLETCONNECT_SESSION_KILLED,
+  WALLETCONNECT_SESSION_APPROVED,
+  WALLETCONNECT_SESSION_REQUEST,
+  WALLETCONNECT_SESSION_REJECTED,
+} from 'constants/walletConnectConstants';
+import reducer from 'reducers/walletConnectReducer';
+
+const mockConnector = (options = {}, params = {}) => {
+  return new WalletConnect(options, params);
+};
+
+describe('WalletConnect reducer', () => {
+  describe('WALLETCONNECT_INIT_SESSIONS', () => {
+    it('stores connectors', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      const result = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1, connector2],
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_SESSION_DISCONNECTED', () => {
+    it('stores new connectors', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      const state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const result = reducer(state, {
+        type: WALLETCONNECT_SESSION_DISCONNECTED,
+        payload: [connector1],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1],
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_SESSION_KILLED', () => {
+    it('stores new connectors', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      const state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const result = reducer(state, {
+        type: WALLETCONNECT_SESSION_KILLED,
+        payload: [connector1],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1],
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_SESSION_APPROVED', () => {
+    it('updates pending and connectors', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      const state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const result = reducer(state, {
+        type: WALLETCONNECT_SESSION_APPROVED,
+        payload: {
+          pending: [],
+          connectors: [connector1],
+        },
+        pending: 0,
+      });
+
+      expect(result).toMatchObject({
+        pending: [],
+        connectors: [connector1],
+        waitingRequest: null,
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_SESSION_REQUEST', () => {
+    it('updates pending', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      const state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const connector3 = mockConnector();
+      const result = reducer(state, {
+        type: WALLETCONNECT_SESSION_REQUEST,
+        payload: {
+          pending: [connector3],
+          clientId: 'client-n',
+        },
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1, connector2],
+        pending: [connector3],
+        waitingRequest: 'client-n',
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_CANCEL_REQUEST', () => {
+    it('updates pending', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      let state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const connector3 = mockConnector();
+      state = reducer(state, {
+        type: WALLETCONNECT_SESSION_REQUEST,
+        payload: {
+          pending: [connector3],
+          clientId: 'client-n',
+        },
+      });
+
+      const result = reducer(state, {
+        type: WALLETCONNECT_CANCEL_REQUEST,
+        payload: [],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1, connector2],
+        pending: [],
+        waitingRequest: null,
+      });
+    });
+  });
+
+  describe('WALLETCONNECT_SESSION_REJECTED', () => {
+    it('updates pending', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      let state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const connector3 = mockConnector();
+      state = reducer(state, {
+        type: WALLETCONNECT_SESSION_REQUEST,
+        payload: {
+          pending: [connector3],
+          clientId: 'client-n',
+        },
+      });
+
+      const result = reducer(state, {
+        type: WALLETCONNECT_SESSION_REJECTED,
+        payload: [],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1, connector2],
+        pending: [],
+        waitingRequest: null,
+      });
+    });
+  });
+
+  describe('handles WALLETCONNECT_CLEAR_PENDING', () => {
+    it('updates pending', () => {
+      const connector1 = mockConnector();
+      const connector2 = mockConnector();
+
+      let state = reducer(undefined, {
+        type: WALLETCONNECT_INIT_SESSIONS,
+        payload: [connector1, connector2],
+      });
+
+      const connector3 = mockConnector();
+      state = reducer(state, {
+        type: WALLETCONNECT_SESSION_REQUEST,
+        payload: {
+          pending: [connector3],
+          clientId: 'client-n',
+        },
+      });
+      const result = reducer(state, {
+        type: WALLETCONNECT_CLEAR_PENDING,
+        payload: [],
+      });
+
+      expect(result).toMatchObject({
+        connectors: [connector1, connector2],
+        pending: [],
+        waitingRequest: null,
+      });
+    });
+  });
+
+  describe('handles WALLETCONNECT_ERROR', () => {
+    it('stores error', () => {
+      const result = reducer(undefined, {
+        type: WALLETCONNECT_ERROR,
+        payload: {
+          code: 'error-code',
+          message: 'error-message',
+        },
+      });
+
+      expect(result).toMatchObject({
+        error: {
+          code: 'error-code',
+          message: 'error-message',
+        },
+      });
+    });
+  });
+});

--- a/src/reducers/walletConnectReducer.js
+++ b/src/reducers/walletConnectReducer.js
@@ -31,8 +31,8 @@ import {
 } from 'constants/walletConnectConstants';
 
 export type WalletConnectReducerState = {
-  connectors: Array<WalletConnect>,
-  pending: Array<WalletConnect>,
+  connectors: WalletConnect[],
+  pending: WalletConnect[],
   requests: Array<{
     peerId: string,
     peerMeta: Object,
@@ -45,10 +45,71 @@ export type WalletConnectReducerState = {
   waitingRequest: ?string,
 };
 
-export type WalletConnectReducerAction = {
-  type: string,
-  payload: any,
+type SessionApproved = {
+  type: 'WALLETCONNECT_SESSION_APPROVED',
+  payload: {
+    pending: WalletConnect[],
+    connectors: WalletConnect[],
+  },
+  pending: number,
 };
+
+type SessionRejected = {
+  type: 'WALLETCONNECT_SESSION_REJECTED',
+  payload: WalletConnect[],
+};
+
+type SessionKilled = {
+  type: 'WALLETCONNECT_SESSION_KILLED',
+  payload: WalletConnect[],
+};
+
+type SessionRequest = {
+  type: 'WALLETCONNECT_SESSION_REQUEST',
+  payload: {
+    pending: WalletConnect[],
+    clientId: string,
+  },
+};
+
+type InitSessions = {
+  type: 'WALLETCONNECT_INIT_SESSIONS',
+  payload: WalletConnect[],
+};
+
+type SessionDisconnected = {
+  type: 'WALLETCONNECT_SESSION_DISCONNECTED',
+  payload: WalletConnect[],
+};
+
+type SessionCancelRequest = {
+  type: 'WALLETCONNECT_CANCEL_REQUEST',
+  payload: WalletConnect[],
+};
+
+type WalletConnectClearPending = {
+  type: 'WALLETCONNECT_CLEAR_PENDING',
+  payload: WalletConnect[],
+};
+
+type WalletConnectError = {
+  type: 'WALLETCONNECT_ERROR',
+  payload: {
+    code: string,
+    message: string,
+  },
+};
+
+export type WalletConnectReducerAction =
+  | WalletConnectError
+  | SessionApproved
+  | WalletConnectClearPending
+  | InitSessions
+  | SessionRequest
+  | SessionCancelRequest
+  | SessionRejected
+  | SessionKilled
+  | SessionDisconnected;
 
 const initialState = {
   connectors: [],
@@ -58,34 +119,39 @@ const initialState = {
   waitingRequest: null,
 };
 
-export default function walletConnectReducer(
+const walletConnectReducer = (
   state: WalletConnectReducerState = initialState,
   action: WalletConnectReducerAction,
-) {
-  const { payload } = action;
-
+): WalletConnectReducerState => {
   switch (action.type) {
     case WALLETCONNECT_INIT_SESSIONS:
     case WALLETCONNECT_SESSION_DISCONNECTED:
     case WALLETCONNECT_SESSION_KILLED:
-      return { ...state, connectors: payload };
+      return { ...state, connectors: action.payload };
+
     case WALLETCONNECT_SESSION_APPROVED:
       return {
         ...state,
-        pending: payload.pending,
-        connectors: payload.connectors,
+        pending: action.payload.pending,
+        connectors: action.payload.connectors,
         waitingRequest: null,
       };
+
     case WALLETCONNECT_SESSION_REQUEST:
-      return { ...state, pending: payload.pending, waitingRequest: payload.clientId };
+      return { ...state, pending: action.payload.pending, waitingRequest: action.payload.clientId };
+
     case WALLETCONNECT_CANCEL_REQUEST:
-      return { ...state, pending: payload, waitingRequest: null };
+      return { ...state, pending: action.payload, waitingRequest: null };
+
     case WALLETCONNECT_SESSION_REJECTED:
     case WALLETCONNECT_CLEAR_PENDING:
-      return { ...state, pending: payload, waitingRequest: null };
+      return { ...state, pending: action.payload, waitingRequest: null };
+
     case WALLETCONNECT_ERROR:
-      return { ...state, error: payload, waitingRequest: null };
+      return { ...state, error: action.payload, waitingRequest: null };
+
     default:
       return state;
   }
-}
+};
+export default walletConnectReducer;

--- a/src/testUtils/jestSetup.js
+++ b/src/testUtils/jestSetup.js
@@ -24,6 +24,7 @@ import { View as mockView } from 'react-native';
 import { utils, HDNode } from 'ethers';
 import StorageMock from './asyncStorageMock';
 import FirebaseMock from './firebaseMock';
+import WalletConnectMock from './walletConnectMock';
 
 process.env.IS_TEST = 'TEST';
 
@@ -255,3 +256,5 @@ jest.setMock('react-native-keychain', {
     BIOMETRY_ANY: 'BIOMETRY_ANY',
   },
 });
+
+jest.setMock('@walletconnect/react-native', WalletConnectMock);

--- a/src/testUtils/walletConnectMock.js
+++ b/src/testUtils/walletConnectMock.js
@@ -1,0 +1,32 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+export default class WalletConnect {
+  static _nextId: number = 0;
+  peerId: string;
+
+  static nextId() {
+    return this._nextId++;
+  }
+
+  constructor() {
+    this.peerId = `peer-${WalletConnect.nextId()}`;
+  }
+}


### PR DESCRIPTION
This adds some simple tests for WalletConnect. These are intended to be
the initial step towards reworking WalletConnect actions and the reducer
itself.

Since this includes no functional changes, it's a low risk
changeset, which should speed up review discussions and leave the
discussion for the refactor isolated from this.