### PR TITLE
check on biometrics if app is in bg before pin unlock screen mounts

### DIFF
--- a/src/screens/PinCodeUnlock/PinCodeUnlock.js
+++ b/src/screens/PinCodeUnlock/PinCodeUnlock.js
@@ -77,12 +77,15 @@ class PinCodeUnlock extends React.Component<Props, State> {
   componentDidMount() {
     addAppStateChangeListener(this.handleAppStateChange);
     const { useBiometrics } = this.props;
+    const { lastAppState } = this.state;
 
     if (!this.errorMessage && DEFAULT_PIN) {
       this.handlePinSubmit(DEFAULT_PIN);
     }
 
-    if (useBiometrics && !this.errorMessage) {
+    if (useBiometrics
+      && !this.errorMessage
+      && lastAppState !== BACKGROUND_APP_STATE) {
       this.showBiometricLogin();
     }
 


### PR DESCRIPTION
This includes small fix that checks if app is in background before showing biometrics prompt once pin code unlock screen mounts. The fix was needed because on Android if the biometrics were shown while app is in background then it was reporting fatal crash although app was still present. We could have this fixed in lib's native side, but this front-end approach is cleaner.

Fixes `https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1223252199/?project=1294444&query=is%3Aunresolved&statsPeriod=14d` and similar where `IllegalStateException: Can not perform this action after onSaveInstanceState`.