### PR TITLE
Fix/unsettled item to settled pending status

### DIFF
--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -631,7 +631,9 @@ export const syncVirtualAccountTransactionsAction = (manageTankInitFlag?: boolea
       const senderAddress = get(payment, 'sender.account.address');
       const recipientAddress = get(payment, 'recipient.account.address');
       const stateInPPN = get(payment, 'state');
-
+      const paymentHash = get(payment, 'hash');
+      const existingTransaction = accountHistory.find(({ hash }) => isCaseInsensitiveMatch(hash, paymentHash)) || {};
+      // if transaction exists this will update only its status and stateInPPN
       return buildHistoryTransaction({
         from: senderAddress,
         hash: payment.hash,
@@ -640,6 +642,7 @@ export const syncVirtualAccountTransactionsAction = (manageTankInitFlag?: boolea
         asset: tokenSymbol,
         isPPNTransaction: true,
         createdAt: +new Date(payment.updatedAt) / 1000,
+        ...existingTransaction,
         status: TX_CONFIRMED_STATUS,
         stateInPPN,
       });
@@ -1222,6 +1225,7 @@ export const settleTransactionsAction = (txToSettle: TxToSettle[]) => {
         type: PAYMENT_NETWORK_SUBSCRIBE_TO_TX_STATUS,
         payload: txHash,
       });
+
 
       const { history: { data: currentHistory } } = getState();
       dispatch(saveDbAction('history', { history: currentHistory }, true));

--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -63,7 +63,11 @@ import {
   TYPE_SENT,
 } from 'constants/invitationsConstants';
 import { COLLECTIBLE_TRANSACTION } from 'constants/collectiblesConstants';
-import { TRANSACTION_EVENT, CONNECTION_EVENT } from 'constants/historyConstants';
+import {
+  TRANSACTION_EVENT,
+  CONNECTION_EVENT,
+  TX_PENDING_STATUS,
+} from 'constants/historyConstants';
 import { CONTACT } from 'constants/navigationConstants';
 import { CHAT } from 'constants/chatConstants';
 import {
@@ -301,7 +305,7 @@ class ActivityFeed extends React.Component<Props, State> {
     } = this.props;
 
     const navigateToContact = partial(navigation.navigate, CONTACT, { contact: notification });
-    const itemStatusIcon = notificationStatus === 'pending' ? 'pending' : '';
+    const itemStatusIcon = notificationStatus === TX_PENDING_STATUS ? TX_PENDING_STATUS : '';
 
     if (type === TRANSACTION_EVENT) {
       const isReceived = addressesEqual(notification.to, activeAccountAddress);
@@ -339,7 +343,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onPress={() => this.selectEvent({ ...notification, value, contact }, type, notificationStatus)}
             type={feedType}
             asset={asset}
-            isPending={notificationStatus === 'pending'}
+            isPending={notificationStatus === TX_PENDING_STATUS}
           />
         );
       } else if (tag === PAYMENT_NETWORK_ACCOUNT_TOPUP) {

--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -339,6 +339,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onPress={() => this.selectEvent({ ...notification, value, contact }, type, notificationStatus)}
             type={feedType}
             asset={asset}
+            isPending={notificationStatus === 'pending'}
           />
         );
       } else if (tag === PAYMENT_NETWORK_ACCOUNT_TOPUP) {

--- a/src/components/ActivityFeed/SettlementItem.js
+++ b/src/components/ActivityFeed/SettlementItem.js
@@ -19,6 +19,8 @@
 */
 import * as React from 'react';
 import styled from 'styled-components/native';
+import isEmpty from 'lodash.isempty';
+
 import ListItemWithImage from 'components/ListItem/ListItemWithImage';
 import { BaseText } from 'components/Typography';
 import TankAssetBalance from 'components/TankAssetBalance';
@@ -38,6 +40,7 @@ type Props = {
   type?: string,
   asset?: string,
   onPress: Function,
+  isPending?: boolean,
 }
 
 const ListWrapper = styled.View`
@@ -57,6 +60,7 @@ export const SettlementItem = (props: Props) => {
     type,
     asset,
     onPress,
+    isPending,
   } = props;
   const ppnTransactions = asset
     ? settleData.filter(({ symbol }) => symbol === asset)
@@ -75,39 +79,53 @@ export const SettlementItem = (props: Props) => {
 
   const valuesArray = Object.keys(valueByAsset).map((key) => valueByAsset[key]);
 
+  const itemStatusIcon = (isPending && 'pending') || '';
+  const rightColumnInnerStyle = (isPending && { flexDirection: 'row', alignItems: 'center' }) || {};
+  const customAddonAlignLeft = !isEmpty(rightColumnInnerStyle);
+
   return (
     <React.Fragment>
-      {(!type || type === NONSYNTHETIC) && <ListItemWithImage
-        onPress={onPress}
-        label="Deposit"
-        itemImageSource={ppnIcon}
-        subtext="to Smart Wallet"
-        customAddon={(
-          <ListWrapper>
-            {valuesArray.map(({ symbol, value }) => <ItemValue key={symbol}>{`${value} ${symbol}`}</ItemValue>)}
-          </ListWrapper>)}
-        innerWrapperHorizontalAlign="flex-start"
-        noImageBorder
-      />}
-      {(!type || type === SYNTHETIC) && <ListItemWithImage
-        onPress={onPress}
-        label="Withdrawal"
-        itemImageSource={ppnIcon}
-        subtext="from PLR Network"
-        customAddon={(
-          <ListWrapper>
-            {ppnTransactions.map(({ symbol, value, hash }) => (
-              <TankAssetBalance
-                key={hash}
-                amount={`-${value} ${symbol}`}
-                monoColor
-                textStyle={{ color: baseColors.scarlet }}
-              />
-            ))}
-          </ListWrapper>)}
-        innerWrapperHorizontalAlign="flex-start"
-        noImageBorder
-      />}
+      {(!type || type === NONSYNTHETIC) &&
+        <ListItemWithImage
+          onPress={onPress}
+          label="Deposit"
+          itemImageSource={ppnIcon}
+          subtext="to Smart Wallet"
+          customAddon={(
+            <ListWrapper>
+              {valuesArray.map(({ symbol, value }) => <ItemValue key={symbol}>{`${value} ${symbol}`}</ItemValue>)}
+            </ListWrapper>)}
+          innerWrapperHorizontalAlign="flex-start"
+          noImageBorder
+          itemStatusIcon={itemStatusIcon}
+          customAddonAlignLeft={customAddonAlignLeft}
+          rightColumnInnerStyle={rightColumnInnerStyle}
+        />
+      }
+      {(!type || type === SYNTHETIC) &&
+        <ListItemWithImage
+          onPress={onPress}
+          label="Withdrawal"
+          itemImageSource={ppnIcon}
+          subtext="from PLR Network"
+          customAddon={(
+            <ListWrapper>
+              {ppnTransactions.map(({ symbol, value, hash }) => (
+                <TankAssetBalance
+                  key={hash}
+                  amount={`-${value} ${symbol}`}
+                  monoColor
+                  textStyle={{ color: baseColors.scarlet }}
+                />
+              ))}
+            </ListWrapper>)}
+          innerWrapperHorizontalAlign="flex-start"
+          noImageBorder
+          itemStatusIcon={itemStatusIcon}
+          customAddonAlignLeft={customAddonAlignLeft}
+          rightColumnInnerStyle={rightColumnInnerStyle}
+        />
+      }
     </React.Fragment>
   );
 };

--- a/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
+++ b/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
@@ -352,6 +352,7 @@ exports[`ActivityFeed does not fail for invalid values 1`] = `
                             "marginTop": 0,
                           },
                           Object {
+                            "alignItems": "center",
                             "flexWrap": "wrap",
                             "justifyContent": "flex-end",
                           },
@@ -759,6 +760,7 @@ exports[`ActivityFeed renders the Asset correctly 1`] = `
                             "marginTop": 0,
                           },
                           Object {
+                            "alignItems": "center",
                             "flexWrap": "wrap",
                             "justifyContent": "flex-end",
                           },

--- a/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
+++ b/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
@@ -333,7 +333,7 @@ exports[`ActivityFeed does not fail for invalid values 1`] = `
                   <View
                     style={
                       Array [
-                        undefined,
+                        Object {},
                         Object {
                           "flexWrap": "wrap",
                         },
@@ -740,7 +740,7 @@ exports[`ActivityFeed renders the Asset correctly 1`] = `
                   <View
                     style={
                       Array [
-                        undefined,
+                        Object {},
                         Object {
                           "flexWrap": "wrap",
                         },

--- a/src/components/ListItem/ListItemWithImage.js
+++ b/src/components/ListItem/ListItemWithImage.js
@@ -67,6 +67,7 @@ type Props = {
   imageUpdateTimeStamp?: number,
   rightColumnInnerStyle?: Object,
   customAddonFullWidth?: React.Node,
+  customAddonAlignLeft?: boolean,
   imageColorFill?: string,
   customImage?: React.Node,
   imageDiameter?: number,
@@ -417,16 +418,15 @@ const Addon = (props: Props) => {
     acceptInvitation,
     balance,
   } = props;
-
-  if (itemValue) {
+  if (itemValue || itemStatusIcon) {
     return (
       <Wrapper horizontal style={{ flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-        <ItemValue color={valueColor} numberOfLines={2} ellipsizeMode="tail">
-          {itemValue}
-        </ItemValue>
-        {!!itemStatusIcon &&
-          <ItemValueStatus name={itemStatusIcon} />
+        {!!itemValue &&
+          <ItemValue color={valueColor} numberOfLines={2} ellipsizeMode="tail">
+            {itemValue}
+          </ItemValue>
         }
+        {!!itemStatusIcon && <ItemValueStatus name={itemStatusIcon} />}
       </Wrapper>
     );
   }
@@ -547,6 +547,7 @@ class ListItemWithImage extends React.Component<Props, {}> {
       customAddonFullWidth,
       innerWrapperHorizontalAlign,
       wrapperOpacity,
+      customAddonAlignLeft,
     } = this.props;
 
     const type = getType(this.props);
@@ -581,8 +582,9 @@ class ListItemWithImage extends React.Component<Props, {}> {
               </Column>
               <Column rightColumn type={type} style={{ maxWidth: '50%' }}>
                 <View style={[rightColumnInnerStyle, { flexWrap: 'wrap' }]}>
+                  {!!customAddonAlignLeft && customAddon}
                   <Addon {...this.props} type={type} />
-                  {customAddon}
+                  {!customAddonAlignLeft && customAddon}
                   {children}
                 </View>
               </Column>

--- a/src/components/ListItem/ListItemWithImage.js
+++ b/src/components/ListItem/ListItemWithImage.js
@@ -420,7 +420,7 @@ const Addon = (props: Props) => {
   } = props;
   if (itemValue || itemStatusIcon) {
     return (
-      <Wrapper horizontal style={{ flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+      <Wrapper horizontal style={{ flexWrap: 'wrap', alignItems: 'center', justifyContent: 'flex-end' }}>
         {!!itemValue &&
           <ItemValue color={valueColor} numberOfLines={2} ellipsizeMode="tail">
             {itemValue}


### PR DESCRIPTION
PR includes:
- Fixes UI issues where status is not shown transactions that does not contain `itemValue` in `ListItemWithImage` component. 
- UI fix that was noticed before – if status is present for transaction then its icon was not vertically aligned inside list item.
- History sorting fix when PPN payment was being sorted ahead compared to its settled entry in history right after settlement was processed and this was because we were updating PPN payment create date every time when PPN state updates. Note: we map transaction history `createdAt` date top PPN payment `updatedAt` date because SDK doesn't provide `createdAt` value.