### PR TITLE
Fix android crash when we can't retrieve contact connection keys

### DIFF
--- a/src/actions/txNoteActions.js
+++ b/src/actions/txNoteActions.js
@@ -52,6 +52,16 @@ export const sendTxNoteByContactAction = (username: string, message: Object) => 
       username,
       ...connectionStateCheckParams,
     };
+
+    if (!addContactParams.userId) {
+      Toast.show({
+        message: 'Tx note send failed',
+        type: 'warning',
+        autoClose: false,
+      });
+      return;
+    }
+
     await chat.client.addContact(addContactParams, false).catch(e => {
       if (e.code === 'ERR_ADD_CONTACT_FAILED') {
         Toast.show({


### PR DESCRIPTION
This PR prevent android from crashing when we send tx with the note to contact with the broken connection keys.
[Sentry report](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1090159630/?project=1294444&query=is%3Aunresolved&statsPeriod=14d)