### PR TITLE
force retry btn on smart wallet sdk deploy error

### DIFF
--- a/src/components/DeploymentView/DeploymentView.js
+++ b/src/components/DeploymentView/DeploymentView.js
@@ -41,6 +41,7 @@ type Props = {
   buttonAction?: ?Function,
   smartWalletState: Object,
   accounts: Accounts,
+  forceRetry?: boolean,
 }
 
 const MessageTitle = styled(BoldText)`
@@ -67,6 +68,7 @@ class DeploymentView extends React.PureComponent<Props> {
       buttonAction,
       smartWalletState,
       accounts,
+      forceRetry,
     } = this.props;
     const { title, message: bodyText } = message;
 
@@ -85,16 +87,19 @@ class DeploymentView extends React.PureComponent<Props> {
         <MessageTitle>{title}</MessageTitle>
         <Message>{bodyText}</Message>
         <Wrapper style={{ margin: spacing.small, width: '100%', alignItems: 'center' }}>
-          {isDeploying &&
-          <SpinnerWrapper>
-            <Spinner />
-          </SpinnerWrapper>}
-          {!isDeploying && buttonAction && buttonLabel && <Button
-            marginTop={spacing.mediumLarge.toString()}
-            height={52}
-            title={buttonLabel}
-            onPress={buttonAction}
-          />}
+          {isDeploying && !forceRetry &&
+            <SpinnerWrapper>
+              <Spinner />
+            </SpinnerWrapper>
+          }
+          {(!isDeploying || forceRetry) && buttonAction && buttonLabel &&
+            <Button
+              marginTop={spacing.mediumLarge.toString()}
+              height={52}
+              title={buttonLabel}
+              onPress={buttonAction}
+            />
+          }
         </Wrapper>
       </Wrapper>
     );

--- a/src/screens/Assets/WalletView.js
+++ b/src/screens/Assets/WalletView.js
@@ -440,6 +440,8 @@ class WalletView extends React.Component<Props, State> {
         <DeploymentView
           message={deploymentData.error ? getDeployErrorMessage(deploymentData.error) : sendingBlockedMessage}
           buttonAction={deploymentData.error ? () => deploySmartWallet() : null}
+          buttonLabel="Retry"
+          forceRetry={!!deploymentData.error}
         />}
         {!blockAssetsView &&
         <SearchBlock

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -996,6 +996,8 @@ class ExchangeScreen extends React.Component<Props, State> {
         <DeploymentView
           message={deploymentData.error ? getDeployErrorMessage(deploymentData.error) : sendingBlockedMessage}
           buttonAction={deploymentData.error ? () => deploySmartWallet() : null}
+          buttonLabel="Retry"
+          forceRetry={!!deploymentData.error}
         />}
         {!blockView &&
         <ScrollWrapper


### PR DESCRIPTION
Forces to show retry button if Smart Wallet SDK error occurred during deployment.