### PR TITLE
Feature/168923294 nav bar update

### DIFF
--- a/src/components/HeaderBlock/HeaderActionButton.js
+++ b/src/components/HeaderBlock/HeaderActionButton.js
@@ -31,6 +31,7 @@ type Props = {
   onPress: Function,
   hasChevron?: boolean,
   isActive?: boolean,
+  wrapperStyle?: Object,
 }
 
 const HeaderButtonRounded = styled.TouchableOpacity`
@@ -108,10 +109,11 @@ export const HeaderActionButton = (props: Props) => {
     onPress,
     hasChevron,
     isActive,
+    wrapperStyle,
   } = props;
 
   return (
-    <HeaderButtonRounded onPress={onPress} theme={theme}>
+    <HeaderButtonRounded onPress={onPress} theme={theme} style={wrapperStyle}>
       {isActive !== undefined && <Status isActive={isActive} />}
       <RoundedButtonLabel theme={theme}>{label}</RoundedButtonLabel>
       {!!hasChevron && <ChevronIcon name="chevron-right" theme={theme} />}

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -18,7 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import * as React from 'react';
-import { StatusBar, View, FlatList, TouchableOpacity } from 'react-native';
+import { StatusBar, View, TouchableOpacity } from 'react-native';
 import { CachedImage } from 'react-native-cached-image';
 
 import { baseColors, fontSizes, spacing, UIColors } from 'utils/variables';
@@ -113,6 +113,14 @@ const LeftItems = styled.View`
   flex-wrap: wrap;
 `;
 
+const RightItems = styled.View`
+  flex: ${props => props.sideFlex || 1};
+  align-items: center;
+  justify-content: flex-end;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
 const BackIcon = styled(IconButton)`
   position: relative;
   height: 24px;
@@ -127,6 +135,12 @@ const ActionIcon = styled(IconButton)`
   height: 34px;
   width: 44px;
   padding: 5px 10px;
+`;
+
+const CloseIcon = styled(IconButton)`
+  position: relative;
+  align-self: center;
+  padding: 20px;
 `;
 
 const TextButton = styled.TouchableOpacity`
@@ -147,10 +161,6 @@ const ButtonLabel = styled(BaseText)`
   line-height: ${fontSizes.small};
   font-size: ${fontSizes.extraSmall}px;
   color: ${props => props.theme.rightActionLabelColor || baseColors.electricBlue};
-`;
-
-const Separator = styled.View`
-  width: ${spacing.small}px;
 `;
 
 const Indicator = styled.View`
@@ -262,41 +272,38 @@ class HeaderBlock extends React.Component<Props> {
         </CenterItems>
         }
         {(!!centerItems.length || !!rightItems.length) &&
-        <FlatList
-          keyExtractor={(item) => item.key || item.label || item.title || item.icon || 'close'}
-          data={rightItems}
-          renderItem={({ item }) => this.renderSideItems(item, theme, RIGHT)}
-          ItemSeparatorComponent={() => <Separator />}
-          horizontal
-          contentContainerStyle={{ justifyContent: 'flex-end', flexGrow: 1 }}
-          style={{ flex: sideFlex || 1 }}
-          scrollEnabled={false}
-        />}
+          <RightItems sideFlex={sideFlex}>
+            {rightItems.map((item) => this.renderSideItems(item, theme, RIGHT))}
+          </RightItems>
+        }
       </HeaderRow>
     );
   };
 
   renderSideItems = (item, theme, type = '') => {
     const { navigation } = this.props;
+    const commonStyle = {};
+    if (type === RIGHT) commonStyle.marginLeft = spacing.small;
     if (item.user || item.userIcon) {
       return this.renderUser(theme, !item.userIcon);
     }
     if (item.title) {
       return (
-        <HeaderTitle
-          theme={theme}
-          key={item.title}
-          style={item.color ? { color: item.color } : {}}
-          onPress={item.onPress}
-          centerText={type === CENTER}
-        >
-          {item.title}
-        </HeaderTitle>
+        <View style={commonStyle} key={item.title}>
+          <HeaderTitle
+            theme={theme}
+            style={item.color ? { color: item.color } : {}}
+            onPress={item.onPress}
+            centerText={type === CENTER}
+          >
+            {item.title}
+          </HeaderTitle>
+        </View>
       );
     }
     if (item.icon) {
       return (
-        <View style={{ marginRight: -10 }} key={item.icon}>
+        <View style={{ marginRight: -10, ...commonStyle }} key={item.icon}>
           <ActionIcon
             icon={item.icon}
             color={item.color || theme.rightActionIconColor || UIColors.defaultNavigationColor}
@@ -310,7 +317,7 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.iconSource) {
       return (
-        <TouchableOpacity onPress={item.onPress} key={item.key || item.iconSource}>
+        <TouchableOpacity onPress={item.onPress} key={item.key || item.iconSource} style={commonStyle}>
           <IconImage source={item.iconSource} />
           {!!item.indicator && <Indicator />}
         </TouchableOpacity>
@@ -318,7 +325,7 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.label) {
       return (
-        <TextButton onPress={item.onPress} key={item.label} bordered={item.bordered} theme={theme}>
+        <TextButton onPress={item.onPress} key={item.label} bordered={item.bordered} theme={theme} style={commonStyle}>
           <ButtonLabel theme={theme}>{item.label}</ButtonLabel>
           {item.addon}
         </TextButton>
@@ -326,12 +333,18 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.close) {
       const wrapperStyle = {};
-      if (type === LEFT) wrapperStyle.marginLeft = -16;
-      if (type === RIGHT) wrapperStyle.marginRight = -10;
+      if (type === LEFT) {
+        wrapperStyle.marginLeft = -20;
+        wrapperStyle.marginRight = -(20 - spacing.small);
+      }
+      if (type === RIGHT) {
+        wrapperStyle.marginRight = -20;
+        wrapperStyle.marginLeft = -(20 - spacing.small);
+      }
 
       return (
-        <View style={wrapperStyle} key="close">
-          <ActionIcon
+        <View style={{ ...wrapperStyle, marginTop: -20, marginBottom: -20 }} key="close">
+          <CloseIcon
             icon="close"
             color={baseColors.slateBlack}
             onPress={() => item.dismiss ? navigation.dismiss() : navigation.goBack()}
@@ -342,10 +355,10 @@ class HeaderBlock extends React.Component<Props> {
       );
     }
     if (item.actionButton) {
-      return (<HeaderActionButton {...item.actionButton} theme={theme} />);
+      return (<HeaderActionButton {...item.actionButton} theme={theme} wrapperStyle={commonStyle} />);
     }
     if (item.custom) {
-      return <View key={item.key || 'custom'}>{item.custom}</View>;
+      return <View key={item.key || 'custom'} style={commonStyle}>{item.custom}</View>;
     }
     return null;
   };

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -225,6 +225,10 @@ const getTheme = (props: Props) => {
   return themes().default;
 };
 
+const LEFT = 'LEFT';
+const CENTER = 'CENTER';
+const RIGHT = 'RIGHT';
+
 class HeaderBlock extends React.Component<Props> {
   renderHeaderContent = (theme: Object) => {
     const {
@@ -241,7 +245,7 @@ class HeaderBlock extends React.Component<Props> {
       <HeaderRow>
         <LeftItems sideFlex={sideFlex} style={!centerItems.length && !rightItems.length ? { flexGrow: 2 } : {}}>
           {(leftItems.length || !!noBack)
-            ? leftItems.map((item) => this.renderSideItems(item, theme))
+            ? leftItems.map((item) => this.renderSideItems(item, theme, LEFT))
             : (
               <BackIcon
                 icon="back"
@@ -254,14 +258,14 @@ class HeaderBlock extends React.Component<Props> {
         </LeftItems>
         {!!centerItems.length &&
         <CenterItems>
-          {centerItems.map((item) => this.renderSideItems(item, theme, 'CENTER'))}
+          {centerItems.map((item) => this.renderSideItems(item, theme, CENTER))}
         </CenterItems>
         }
         {(!!centerItems.length || !!rightItems.length) &&
         <FlatList
           keyExtractor={(item) => item.key || item.label || item.title || item.icon || 'close'}
           data={rightItems}
-          renderItem={({ item }) => this.renderSideItems(item, theme)}
+          renderItem={({ item }) => this.renderSideItems(item, theme, RIGHT)}
           ItemSeparatorComponent={() => <Separator />}
           horizontal
           contentContainerStyle={{ justifyContent: 'flex-end', flexGrow: 1 }}
@@ -284,7 +288,7 @@ class HeaderBlock extends React.Component<Props> {
           key={item.title}
           style={item.color ? { color: item.color } : {}}
           onPress={item.onPress}
-          centerText={type === 'CENTER'}
+          centerText={type === CENTER}
         >
           {item.title}
         </HeaderTitle>
@@ -292,9 +296,8 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.icon) {
       return (
-        <View style={{ marginRight: -10 }}>
+        <View style={{ marginRight: -10 }} key={item.icon}>
           <ActionIcon
-            key={item.icon}
             icon={item.icon}
             color={item.color || theme.rightActionIconColor || UIColors.defaultNavigationColor}
             onPress={item.onPress}
@@ -307,7 +310,7 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.iconSource) {
       return (
-        <TouchableOpacity onPress={item.onPress}>
+        <TouchableOpacity onPress={item.onPress} key={item.key || item.iconSource}>
           <IconImage source={item.iconSource} />
           {!!item.indicator && <Indicator />}
         </TouchableOpacity>
@@ -322,10 +325,13 @@ class HeaderBlock extends React.Component<Props> {
       );
     }
     if (item.close) {
+      const wrapperStyle = {};
+      if (type === LEFT) wrapperStyle.marginLeft = -16;
+      if (type === RIGHT) wrapperStyle.marginRight = -10;
+
       return (
-        <View style={{ marginRight: -10 }}>
+        <View style={wrapperStyle} key="close">
           <ActionIcon
-            key="close"
             icon="close"
             color={baseColors.slateBlack}
             onPress={() => item.dismiss ? navigation.dismiss() : navigation.goBack()}

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -444,8 +444,8 @@ class AccountsScreen extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          leftItems: [{ title: 'Accounts' }],
-          rightItems: [{ close: true, dismiss: true }],
+          centerItems: [{ title: 'Accounts' }],
+          leftItems: [{ close: true, dismiss: true }],
         }}
       >
         {!changingAccount &&

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -444,10 +444,7 @@ class AccountsScreen extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          leftItems: [
-            { userIcon: true },
-            { title: 'Accounts' },
-          ],
+          leftItems: [{ title: 'Accounts' }],
           rightItems: [{ close: true, dismiss: true }],
         }}
       >

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -151,114 +151,72 @@ exports[`Asset renders the Asset correctly 1`] = `
               ]
             }
           />
-          <RCTScrollView
-            ItemSeparatorComponent={[Function]}
-            contentContainerStyle={
-              Object {
-                "flexGrow": 1,
-                "justifyContent": "flex-end",
-              }
-            }
-            data={
+          <View
+            style={
               Array [
                 Object {
-                  "icon": "info-circle-inverse",
-                  "onPress": [Function],
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
                 },
+                undefined,
               ]
             }
-            disableVirtualization={false}
-            getItem={[Function]}
-            getItemCount={[Function]}
-            horizontal={true}
-            initialNumToRender={10}
-            keyExtractor={[Function]}
-            maxToRenderPerBatch={10}
-            numColumns={1}
-            onContentSizeChange={[Function]}
-            onEndReachedThreshold={2}
-            onLayout={[Function]}
-            onMomentumScrollEnd={[Function]}
-            onScroll={[Function]}
-            onScrollBeginDrag={[Function]}
-            onScrollEndDrag={[Function]}
-            removeClippedSubviews={false}
-            renderItem={[Function]}
-            scrollEnabled={false}
-            scrollEventThrottle={50}
-            stickyHeaderIndices={Array []}
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-            updateCellsBatchingPeriod={50}
-            viewabilityConfigCallbackPairs={Array []}
-            windowSize={21}
           >
-            <View>
+            <View
+              style={
+                Object {
+                  "marginLeft": 8,
+                  "marginRight": -10,
+                }
+              }
+            >
               <View
-                onLayout={[Function]}
+                accessible={true}
+                isTVSelectable={true}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "flexDirection": "row",
-                    },
-                    null,
-                  ]
+                  Object {
+                    "alignItems": "flex-start",
+                    "alignSelf": "center",
+                    "height": 34,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 5,
+                    "position": "relative",
+                    "width": 44,
+                  }
                 }
               >
                 <View
+                  name="info-circle-inverse"
                   style={
                     Object {
-                      "marginRight": -10,
+                      "color": "#007AFF",
+                      "fontSize": 24,
+                      "marginBottom": undefined,
+                      "marginLeft": undefined,
+                      "marginRight": undefined,
+                      "marginTop": undefined,
+                      "paddingTop": 0,
                     }
                   }
-                >
-                  <View
-                    accessible={true}
-                    isTVSelectable={true}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Object {
-                        "alignItems": "flex-start",
-                        "alignSelf": "center",
-                        "height": 34,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "paddingBottom": 5,
-                        "paddingLeft": 10,
-                        "paddingRight": 10,
-                        "paddingTop": 5,
-                        "position": "relative",
-                        "width": 44,
-                      }
-                    }
-                  >
-                    <View
-                      name="info-circle-inverse"
-                      style={
-                        Object {
-                          "color": "#007AFF",
-                          "fontSize": 24,
-                          "marginBottom": undefined,
-                          "marginLeft": undefined,
-                          "marginRight": undefined,
-                          "marginTop": undefined,
-                          "paddingTop": 0,
-                        }
-                      }
-                    />
-                  </View>
-                </View>
+                />
               </View>
             </View>
-          </RCTScrollView>
+          </View>
         </View>
       </View>
     </View>

--- a/src/screens/ConnectionRequests/ConnectionRequests.js
+++ b/src/screens/ConnectionRequests/ConnectionRequests.js
@@ -86,9 +86,7 @@ class ConnectionRequests extends React.Component<Props> {
     } = this.props;
 
     return (
-      <ContainerWithHeader
-        headerProps={{ centerItems: [{ title: 'Connection requests' }] }}
-      >
+      <ContainerWithHeader headerProps={{ centerItems: [{ title: 'Connection requests' }] }}>
         <FlatList
           data={invitations.filter(({ type }) => type === TYPE_RECEIVED)}
           extraData={invitations}

--- a/src/screens/ContactInfo/ContactInfo.js
+++ b/src/screens/ContactInfo/ContactInfo.js
@@ -154,10 +154,7 @@ export class ContactInfo extends React.Component<Props, State> {
       <ContainerWithHeader
         backgroundColor={baseColors.white}
         headerProps={{
-          leftItems: [
-            { userIcon: true },
-            { title: 'User info' },
-          ],
+          leftItems: [{ title: 'User info' }],
           rightItems: [{ close: true }],
         }}
       >

--- a/src/screens/ContactInfo/ContactInfo.js
+++ b/src/screens/ContactInfo/ContactInfo.js
@@ -154,7 +154,7 @@ export class ContactInfo extends React.Component<Props, State> {
       <ContainerWithHeader
         backgroundColor={baseColors.white}
         headerProps={{
-          leftItems: [{ title: 'User info' }],
+          centerItems: [{ title: 'User info' }],
           rightItems: [{ close: true }],
         }}
       >

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -386,9 +386,7 @@ class HomeScreen extends React.Component<Props, State> {
       <ContainerWithHeader
         backgroundColor={baseColors.white}
         headerProps={{
-          leftItems: [
-            { user: true },
-          ],
+          leftItems: [{ user: true }],
           rightItems: [
             {
               label: 'Settings',

--- a/src/screens/ManageWallets/WalletSettings/WalletSettings.js
+++ b/src/screens/ManageWallets/WalletSettings/WalletSettings.js
@@ -160,12 +160,7 @@ class WalletSettings extends React.PureComponent<Props> {
     return (
       <ContainerWithHeader
         color={baseColors.white}
-        headerProps={{
-          centerItems: [
-            { userIcon: true },
-            { title: `${user.username}'s ${accountType} wallet` },
-          ],
-        }}
+        headerProps={{ centerItems: [{ title: `${user.username}'s ${accountType} wallet` }] }}
         inset={{ bottom: 'never' }}
       >
         <FlatList

--- a/src/screens/People/People.js
+++ b/src/screens/People/People.js
@@ -460,9 +460,7 @@ class PeopleScreen extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         backgroundColor={baseColors.white}
-        headerProps={{
-          leftItems: [{ user: true }],
-        }}
+        headerProps={{ leftItems: [{ user: true }] }}
         inset={{ bottom: 0 }}
       >
         <ScrollView

--- a/src/screens/Permissions/Permissions.js
+++ b/src/screens/Permissions/Permissions.js
@@ -360,9 +360,7 @@ class Permissions extends React.Component<Props, State> {
 
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'Know how Pillar makes you safe' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'Know how Pillar makes you safe' }] }}
         backgroundColor={baseColors.white}
       >
         <ScrollView

--- a/src/screens/PillarNetwork/PillarNetworkIntro.js
+++ b/src/screens/PillarNetwork/PillarNetworkIntro.js
@@ -204,7 +204,6 @@ class PillarNetworkIntro extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          rightItems: [{ userIcon: true }],
           floating: true,
           transparent: true,
           light: true,

--- a/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
+++ b/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
@@ -80,9 +80,7 @@ class PinCodeConfirmation extends React.Component<Props, State> {
     const { errorMessage } = this.state;
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'Confirm PIN code' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'Confirm PIN code' }] }}
         backgroundColor={baseColors.white}
       >
         {!!errorMessage &&

--- a/src/screens/SetWalletPinCode/SetWalletPinCode.js
+++ b/src/screens/SetWalletPinCode/SetWalletPinCode.js
@@ -69,9 +69,7 @@ class SetWalletPinCode extends React.Component<Props, State> {
     const { error } = this.state;
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'Create PIN code' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'Create PIN code' }] }}
         backgroundColor={baseColors.white}
       >
         <ContentWrapper>

--- a/src/screens/Settings/Settings.js
+++ b/src/screens/Settings/Settings.js
@@ -397,9 +397,7 @@ class Settings extends React.Component<Props, State> {
 
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'General settings' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'General settings' }] }}
       >
         <ScrollView
           contentContainerStyle={{ padding: spacing.large, paddingTop: 0 }}

--- a/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
+++ b/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
@@ -131,7 +131,6 @@ class SmartWalletIntro extends React.PureComponent<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          rightItems: [{ userIcon: true }],
           floating: true,
           transparent: true,
         }}

--- a/src/screens/UpgradeToSmartWallet/UpgradeConfirmScreen/UpgradeConfirmScreen.js
+++ b/src/screens/UpgradeToSmartWallet/UpgradeConfirmScreen/UpgradeConfirmScreen.js
@@ -345,9 +345,7 @@ class UpgradeConfirmScreen extends React.PureComponent<Props, State> {
     const showSpinner = !gasInfo.isFetched || upgradeStarted;
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'Confirm' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'Confirm' }] }}
         backgroundColor={baseColors.white}
       >
         <ScrollView contentContainerStyle={{ flexGrow: 1 }} style={{ flexGrow: 1 }}>

--- a/src/screens/UpgradeToSmartWallet/UpgradeReviewScreen/UpgradeReviewScreen.js
+++ b/src/screens/UpgradeToSmartWallet/UpgradeReviewScreen/UpgradeReviewScreen.js
@@ -292,9 +292,7 @@ class UpgradeReviewScreen extends React.PureComponent<Props> {
 
     return (
       <ContainerWithHeader
-        headerProps={{
-          centerItems: [{ title: 'Review' }],
-        }}
+        headerProps={{ centerItems: [{ title: 'Review' }] }}
         backgroundColor={baseColors.white}
       >
         <ScrollView>

--- a/src/screens/Users/UserSettings.js
+++ b/src/screens/Users/UserSettings.js
@@ -98,12 +98,7 @@ class UserSettings extends React.PureComponent<Props> {
     return (
       <ContainerWithHeader
         color={baseColors.white}
-        headerProps={{
-          centerItems: [
-            { userIcon: true },
-            { title: 'User settings' },
-          ],
-        }}
+        headerProps={{ centerItems: [{ title: 'User settings' }] }}
         inset={{ bottom: 'never' }}
       >
         <FlatList

--- a/src/screens/Users/Users.js
+++ b/src/screens/Users/Users.js
@@ -119,8 +119,8 @@ class UsersScreen extends React.Component<Props> {
       <ContainerWithHeader
         color={baseColors.white}
         headerProps={{
-          leftItems: [{ title: 'Users' }],
-          rightItems: [{ close: true, dismiss: true }],
+          leftItems: [{ close: true, dismiss: true }],
+          centerItems: [{ title: 'Users' }],
         }}
       >
         <SectionList

--- a/src/screens/Users/Users.js
+++ b/src/screens/Users/Users.js
@@ -119,10 +119,7 @@ class UsersScreen extends React.Component<Props> {
       <ContainerWithHeader
         color={baseColors.white}
         headerProps={{
-          leftItems: [
-            { userIcon: true },
-            { title: 'Users' },
-          ],
+          leftItems: [{ title: 'Users' }],
           rightItems: [{ close: true, dismiss: true }],
         }}
       >


### PR DESCRIPTION
This PR includes changes on navigation bar based on feedback from Dmitry:
1. Remove all user avatars from all top navbar titles except 1st level screens (Home, Assets, People…).
2. Center all too navbar titles except 1st level screens.
3. Move ‘X’ close button from right to left in Users and Accounts screens.
4. Add sufficient safe zone around X close button everywhere (+20px padding)