### PR TITLE
Feature/buttons theme

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -57,10 +57,6 @@ type Props = {
   textStyle?: ?Object,
   style?: Object,
   isLoading?: boolean,
-  primarySquare?: boolean,
-  primarySquareDisabled?: boolean,
-  roundedCorners?: boolean,
-  roundedCornersDisabled?: boolean,
 };
 
 type State = {
@@ -72,39 +68,19 @@ type ButtonNextProps = {
   disabled?: boolean,
 };
 
-const primaryTheme = {
-  background: baseColors.electricBlue,
-  color: baseColors.white,
-  borderColor: UIColors.defaultBorderColor,
-  borderWidth: 0,
-  shadow: true,
-};
-
-const primaryInvertedTheme = {
-  background: baseColors.white,
-  color: baseColors.electricBlue,
-  borderColor: baseColors.veryLightBlue,
-  borderWidth: '1px',
-};
-
 const themes = {
-  primary: primaryTheme,
-  primarySquare: {
-    ...primaryTheme,
-    borderRadius: 6,
-  },
-  primarySquareDisabled: {
-    borderColor: baseColors.veryLightBlue,
-    background: 'rgba(0, 122, 255, 0.3)',
+  primary: {
+    background: baseColors.electricBlue,
     color: baseColors.white,
+    borderColor: UIColors.defaultBorderColor,
     borderWidth: 0,
-    shadow: false,
-    borderRadius: 6,
+    shadow: true,
   },
-  primaryInverted: primaryInvertedTheme,
-  primaryInvertedSquare: {
-    ...primaryInvertedTheme,
-    borderRadius: 6,
+  primaryInverted: {
+    background: baseColors.white,
+    color: baseColors.electricBlue,
+    borderColor: baseColors.veryLightBlue,
+    borderWidth: '1px',
   },
   dangerInverted: {
     background: baseColors.white,
@@ -178,24 +154,6 @@ const themes = {
     borderRadius: 0,
     iconHorizontalMargin: 0,
   },
-  roundedCorners: {
-    background: baseColors.electricBlue,
-    color: baseColors.white,
-    borderColor: 'transparent',
-    borderWidth: 0,
-    flexDirection: 'row',
-    borderRadius: 6,
-    iconHorizontalMargin: 0,
-  },
-  roundedCornersDisabled: {
-    background: baseColors.lightGray,
-    color: baseColors.darkGray,
-    borderColor: UIColors.defaultBorderColor,
-    borderWidth: 0,
-    flexDirection: 'row',
-    borderRadius: 6,
-    iconHorizontalMargin: 0,
-  },
 };
 
 const getButtonHeight = (props) => {
@@ -262,9 +220,7 @@ const ButtonWrapper = styled.TouchableOpacity`
   margin-bottom: ${props => props.marginBottom || '0px'};
   margin-left: ${props => props.marginLeft || '0px'};
   margin-right: ${props => props.marginRight || '0px'};
-  border-radius: ${props => props.theme.borderRadius || props.theme.borderRadius === 0
-    ? props.theme.borderRadius
-    : 40}px;
+  border-radius: ${props => props.theme.borderRadius || props.borderRadius || 0}px;
   width: ${props => getButtonWidth(props)};
   height: ${props => getButtonHeight(props)};
   align-self: ${props => props.flexRight ? 'flex-end' : 'auto'};
@@ -324,12 +280,6 @@ const getTheme = (props: Props) => {
   if (props.secondaryTransparent && props.disabled) {
     return themes.secondaryTransparentDisabled;
   }
-  if (props.primarySquare && props.disabled) {
-    return themes.primarySquareDisabled;
-  }
-  if (props.roundedCorners && props.disabled) {
-    return themes.roundedCornersDisabled;
-  }
 
   const propsKeys = Object.keys(props);
   const themesKeys = Object.keys(themes);
@@ -369,7 +319,7 @@ class Button extends React.Component<Props, State> {
     this.ignoreTapTimeout = setTimeout(() => {
       this.setState({ shouldIgnoreTap: false });
     }, 1000);
-  }
+  };
 
   render() {
     const theme = getTheme(this.props);
@@ -387,6 +337,7 @@ class Button extends React.Component<Props, State> {
         theme={theme}
         onPress={debounce(this.handlePress, this.props.debounceTime, { leading: true, trailing: false })}
         disabled={disabled || disabledTransparent || this.state.shouldIgnoreTap || isLoading}
+        borderRadius={this.props.small ? 3 : 6}
         style={isLoading ? { ...style, backgroundColor: 'transparent' } : style}
 
       >

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -2081,7 +2081,7 @@ exports[`Asset renders the Asset correctly 1`] = `
                           "alignSelf": "auto",
                           "backgroundColor": "#007AFF",
                           "borderColor": "rgba(0, 0, 0, 0.085)",
-                          "borderRadius": 40,
+                          "borderRadius": 6,
                           "borderStyle": "solid",
                           "borderWidth": 0,
                           "elevation": 1,

--- a/src/screens/Assets/PPNView.js
+++ b/src/screens/Assets/PPNView.js
@@ -380,7 +380,6 @@ class PPNView extends React.Component<Props, State> {
         {showSettleButton &&
           <FloatingButtonView>
             <Button
-              roundedCorners
               style={{ paddingLeft: spacing.rhythm, paddingRight: spacing.rhythm }}
               width="auto"
               title="Settle transactions"

--- a/src/screens/ForgotPin/ForgotPin.js
+++ b/src/screens/ForgotPin/ForgotPin.js
@@ -27,7 +27,7 @@ import Header from 'components/Header';
 import Button from 'components/Button';
 import styled from 'styled-components/native/index';
 import { spacing } from 'utils/variables';
-import { IMPORT_WALLET, FORGOT_PIN } from 'constants/navigationConstants';
+import { IMPORT_WALLET_LEGALS, FORGOT_PIN } from 'constants/navigationConstants';
 
 type Props = {
   checkPin: (pin: string, onValidPin: Function) => Function,
@@ -45,7 +45,7 @@ class ForgotPin extends React.Component<Props, {}> {
   };
 
   toImportWallet = () => {
-    this.props.navigation.navigate(IMPORT_WALLET, { navigateTo: FORGOT_PIN });
+    this.props.navigation.navigate(IMPORT_WALLET_LEGALS, { navigateTo: FORGOT_PIN });
   };
 
   render() {

--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -363,7 +363,7 @@ class ImportWallet extends React.Component<Props, State> {
         <ButtonsWrapper isRow>
           {!!showPrev &&
           <StyledButton
-            primaryInvertedSquare
+            primaryInverted
             onPress={this.showPrevWord}
           >
             <ButtonInner>
@@ -373,7 +373,6 @@ class ImportWallet extends React.Component<Props, State> {
           </StyledButton>}
           <StyledButton
             disabled={!currentBPWord}
-            primarySquare
             onPress={this.showNextWord}
           >
             <ButtonInner>
@@ -388,7 +387,6 @@ class ImportWallet extends React.Component<Props, State> {
         <ButtonsWrapper>
           <Button
             disabled={!tabsInfo[activeTab].value}
-            primarySquare
             title="Re-import"
             onPress={this.handleImportSubmit}
           />
@@ -403,7 +401,6 @@ class ImportWallet extends React.Component<Props, State> {
     return (
       <Button
         disabled={!tabsInfo[activeTab].value}
-        primarySquare
         title="Re-import"
         onPress={this.handleImportSubmit}
       />

--- a/src/screens/ImportWallet/ImportWalletLegals.js
+++ b/src/screens/ImportWallet/ImportWalletLegals.js
@@ -170,7 +170,6 @@ class ImportWalletLegals extends React.Component<Props, State> {
           <ButtonWrapper>
             <StyledButton
               disabled={!canGoNext}
-              primarySquare
               title="Proceed"
               onPress={() => navigation.navigate(IMPORT_WALLET)}
             />

--- a/src/screens/PillarNetwork/PillarNetworkIntro.js
+++ b/src/screens/PillarNetwork/PillarNetworkIntro.js
@@ -269,13 +269,11 @@ class PillarNetworkIntro extends React.Component<Props, State> {
               block
               title="Go to PLR Tank"
               onPress={() => this.setState({ showPinScreenForAction: true, processingCreate: true })}
-              roundedCorners
               style={{
                 backgroundColor: baseColors.pomegranate,
                 marginTop: 40,
                 marginBottom: 20,
                 opacity: needsSmartWallet ? 0.3 : 1,
-                borderRadius: 6,
               }}
               textStyle={{ color: baseColors.ultramarine }}
               isLoading={processingCreate}

--- a/src/screens/Settings/Settings.js
+++ b/src/screens/Settings/Settings.js
@@ -603,7 +603,6 @@ class Settings extends React.Component<Props, State> {
               via the &quot;System&quot; under Settings.
             </Description>
             <Button
-              roundedCorners
               title="Opt in"
               onPress={() => this.setState({ visibleModal: null, joinBetaPressed: true })}
               style={{
@@ -640,7 +639,6 @@ class Settings extends React.Component<Props, State> {
               </Description>
             </View>
             <Button
-              roundedCorners
               title="Leave Program"
               onPress={() => { this.setState({ visibleModal: null, leaveBetaPressed: true }); }}
               style={{ marginBottom: 13 }}

--- a/src/screens/Tank/SettleBalance/SettleBalance.js
+++ b/src/screens/Tank/SettleBalance/SettleBalance.js
@@ -264,7 +264,6 @@ class SettleBalance extends React.Component<Props, State> {
             {!!txToSettle.length && (
               <Button
                 small
-                roundedCorners
                 disabled={!session.isOnline}
                 title="Next"
                 onPress={this.goToConfirm}

--- a/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
+++ b/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
@@ -162,7 +162,6 @@ class SettleBalanceConfirm extends React.Component<Props, State> {
           <FooterWrapper>
             <Button
               disabled={submitButtonDisabled}
-              roundedCorners
               onPress={this.handleFormSubmit}
               title={submitButtonTitle}
             />

--- a/src/screens/UnsettledAssets/UnsettledAssets.js
+++ b/src/screens/UnsettledAssets/UnsettledAssets.js
@@ -120,7 +120,6 @@ class UnsettledAssets extends React.Component<Props> {
         />
         <FloatingButtonView>
           <Button
-            roundedCorners
             style={{ paddingLeft: spacing.rhythm, paddingRight: spacing.rhythm }}
             width="auto"
             title="Settle transactions"

--- a/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
+++ b/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
@@ -160,7 +160,6 @@ class SmartWalletIntro extends React.PureComponent<Props, State> {
               block
               title={isDeploy ? 'Deploy' : 'Proceed'}
               onPress={() => { this.setState({ showDeployPayOptions: true }); }}
-              roundedCorners
               style={{
                 backgroundColor: baseColors.persianBlue,
                 marginTop: 40,

--- a/src/screens/Welcome/WelcomeNew.js
+++ b/src/screens/Welcome/WelcomeNew.js
@@ -141,7 +141,7 @@ class Welcome extends React.Component<Props> {
         <Footer
           style={{ paddingBottom: 30 }}
         >
-          <Button roundedCorners marginBottom="20px" onPress={this.loginAction} title="Create account" width="auto" />
+          <Button marginBottom="20px" onPress={this.loginAction} title="Create account" width="auto" />
           <ButtonText
             buttonText="Restore wallet"
             onPress={this.navigateToWalletImportPage}


### PR DESCRIPTION
This PR includes changes on Button component to update border radius.
All Buttons (except for squared ones) should have border radius of 6px (small ones - 3px) to keep consistency across the app.

In this PR I've also updated "Forgot pin" navigation flow by making "Import wallet" button lead user to the first screen of wallet import (that was added after moving legal checkboxes into beginning of the flow).