### PR TITLE
Fix collectible image closing on iPhone X

### DIFF
--- a/src/screens/Collectible/Collectible.js
+++ b/src/screens/Collectible/Collectible.js
@@ -38,6 +38,7 @@ import { ScrollWrapper, Wrapper } from 'components/Layout';
 import { Paragraph } from 'components/Typography';
 import CircleButton from 'components/CircleButton';
 
+import { isIphoneX } from 'utils/common';
 import { baseColors, fontSizes, spacing } from 'utils/variables';
 import { mapOpenSeaAndBCXTransactionsHistory, mapTransactionsHistory } from 'utils/feedData';
 
@@ -98,6 +99,7 @@ const CollectibleImage = styled(CachedImage)`
 `;
 
 const IconWrapper = styled.View`
+  margin-top: ${isIphoneX() ? '10px' : '0'};
   padding: 6px;
   flex-direction: row;
   align-items: center;

--- a/src/screens/Collectible/Collectible.js
+++ b/src/screens/Collectible/Collectible.js
@@ -99,7 +99,8 @@ const CollectibleImage = styled(CachedImage)`
 `;
 
 const IconWrapper = styled.View`
-  margin-top: ${isIphoneX() ? '10px' : '0'};
+  margin-top: ${isIphoneX() ? '30px' : '0'};
+  margin-right: 6px;
   padding: 6px;
   flex-direction: row;
   align-items: center;

--- a/src/screens/Collectible/Collectible.js
+++ b/src/screens/Collectible/Collectible.js
@@ -99,7 +99,7 @@ const CollectibleImage = styled(CachedImage)`
 `;
 
 const IconWrapper = styled.View`
-  margin-top: ${isIphoneX() ? '30px' : '0'};
+  ${isIphoneX() && 'margin-top: 30px;'}
   margin-right: 6px;
   padding: 6px;
   flex-direction: row;


### PR DESCRIPTION
Fixes an issue where the close icon is not clickable on iPhone X.

# iPhone X

![collectible-ipX](https://user-images.githubusercontent.com/263335/67123096-b93aca80-f1c5-11e9-9446-509d54ef20fe.gif)

# iPhone 7

![collectible-ip7](https://user-images.githubusercontent.com/263335/67123108-c35cc900-f1c5-11e9-9725-67950bd4d476.gif)
