### PR TITLE
fixed token contract transfer amount parse to be in right format

### DIFF
--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -21,13 +21,16 @@ import { Contract, utils } from 'ethers';
 import { NETWORK_PROVIDER, COLLECTIBLES_NETWORK } from 'react-native-dotenv';
 import cryptocompare from 'cryptocompare';
 import { Sentry } from 'react-native-sentry';
+
 import { ETH, HOT, HOLO, supportedFiatCurrencies } from 'constants/assetsConstants';
-import type { Asset } from 'models/Asset';
+import { getEthereumProvider, parseTokenAmount } from 'utils/common';
+
 import ERC20_CONTRACT_ABI from 'abi/erc20.json';
 import ERC721_CONTRACT_ABI from 'abi/erc721.json';
 import ERC721_CONTRACT_ABI_SAFE_TRANSFER_FROM from 'abi/erc721_safeTransferFrom.json';
 import ERC721_CONTRACT_ABI_TRANSFER_FROM from 'abi/erc721_transferFrom.json';
-import { getEthereumProvider, parseTokenAmount } from 'utils/common';
+
+import type { Asset } from 'models/Asset';
 
 type Address = string;
 
@@ -87,7 +90,7 @@ export async function transferERC20(options: ERC20TransferOptions) {
   wallet.provider = getEthereumProvider(NETWORK_PROVIDER);
 
   const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, wallet);
-  const contractAmount = parseTokenAmount(amount, defaultDecimals);
+  const contractAmount = utils.hexlify(parseTokenAmount(amount, defaultDecimals));
 
   if (!data) {
     ({ data } = await contract.interface.functions.transfer.apply(null, [to, contractAmount]) || {});
@@ -343,7 +346,7 @@ export async function calculateGasEstimate(transaction: Object) {
      * so want to check if it's also not ETH send flow
      */
     const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, provider);
-    const contractAmount = parseTokenAmount(amount, defaultDecimals);
+    const contractAmount = utils.hexlify(parseTokenAmount(amount, defaultDecimals));
 
     ({ data } = await contract.interface.functions.transfer.apply(null, [to, contractAmount]) || {});
     to = contractAddress;

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -23,7 +23,7 @@ import cryptocompare from 'cryptocompare';
 import { Sentry } from 'react-native-sentry';
 
 import { ETH, HOT, HOLO, supportedFiatCurrencies } from 'constants/assetsConstants';
-import { getEthereumProvider, parseTokenAmount } from 'utils/common';
+import { getEthereumProvider, parseTokenBigNumberAmount } from 'utils/common';
 
 import ERC20_CONTRACT_ABI from 'abi/erc20.json';
 import ERC721_CONTRACT_ABI from 'abi/erc721.json';
@@ -90,7 +90,7 @@ export async function transferERC20(options: ERC20TransferOptions) {
   wallet.provider = getEthereumProvider(NETWORK_PROVIDER);
 
   const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, wallet);
-  const contractAmount = utils.hexlify(parseTokenAmount(amount, defaultDecimals));
+  const contractAmount = parseTokenBigNumberAmount(amount, defaultDecimals);
 
   if (!data) {
     ({ data } = await contract.interface.functions.transfer.apply(null, [to, contractAmount]) || {});
@@ -346,7 +346,7 @@ export async function calculateGasEstimate(transaction: Object) {
      * so want to check if it's also not ETH send flow
      */
     const contract = new Contract(contractAddress, ERC20_CONTRACT_ABI, provider);
-    const contractAmount = utils.hexlify(parseTokenAmount(amount, defaultDecimals));
+    const contractAmount = parseTokenBigNumberAmount(amount, defaultDecimals);
 
     ({ data } = await contract.interface.functions.transfer.apply(null, [to, contractAmount]) || {});
     to = contractAddress;

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -136,11 +136,15 @@ export const formatFullAmount = (amount: string | number): string => {
   return new BigNumber(amount).toFixed(); // strip trailing zeros
 };
 
-export const parseTokenAmount = (amount: number | string, decimals: number): number => {
+export const parseTokenBigNumberAmount = (amount: number | string, decimals: number): utils.BigNumber => {
   const formatted = amount.toString();
-  const parsed = decimals > 0
+  return decimals > 0
     ? utils.parseUnits(formatted, decimals)
     : utils.bigNumberify(formatted);
+};
+
+export const parseTokenAmount = (amount: number | string, decimals: number): number => {
+  const parsed = parseTokenBigNumberAmount(amount, decimals);
   return Math.floor(+parsed.toString());
 };
 


### PR DESCRIPTION
We recently changed contract transfer method amount parsing util and combined it with transaction estimate and send methods. This caused one issue as Ethers accept hexlified input which used to be result of parsing and after change it longer was.