### PR TITLE
Fix/format units util improvements

### DIFF
--- a/src/actions/__tests__/historyActions.test.js
+++ b/src/actions/__tests__/historyActions.test.js
@@ -354,7 +354,7 @@ describe('History Actions', () => {
       });
 
       it('should handle the 0.00104898 eth value that api could return', () => {
-        expect(parseEthValue(0.00104898)).toBe('1048979999999999');
+        expect(parseEthValue(0.00104898)).toBe('1048980000000000');
       });
 
       it('should handle the 1.0 eth value that api could return', () => {

--- a/src/actions/__tests__/historyActions.test.js
+++ b/src/actions/__tests__/historyActions.test.js
@@ -349,8 +349,24 @@ describe('History Actions', () => {
         });
       });
 
-      it('should handle the wrong eth value that api could return', () => {
+      it('should handle the wrong 1e-22 eth value that api could return', () => {
         expect(parseEthValue(1e-22)).toBe('100000000000000');
+      });
+
+      it('should handle the 0.00104898 eth value that api could return', () => {
+        expect(parseEthValue(0.00104898)).toBe('1048979999999999');
+      });
+
+      it('should handle the 1.0 eth value that api could return', () => {
+        expect(parseEthValue(1.0)).toBe('1000000000000000000');
+      });
+
+      it('should handle the 12.03 eth value that api could return', () => {
+        expect(parseEthValue(12.03)).toBe('12030000000000000000');
+      });
+
+      it('should handle the 0 eth value that api could return', () => {
+        expect(parseEthValue(0)).toBe('0');
       });
     });
 

--- a/src/services/EthplorerSdk.js
+++ b/src/services/EthplorerSdk.js
@@ -32,10 +32,8 @@ import type {
   GetTxInfoResponse,
 } from 'models/EthplorerSdkTypes';
 
-const parseAsBigNumber = (value) => new BigNumber(Math.floor(value * (10 ** 18)));
-
 export function parseEthValue(value: number): string {
-  let parsed = parseAsBigNumber(value);
+  let parsed = new BigNumber(value * (10 ** 18));
   /**
    * ethplorer might return number values in format such as `1e-22`
    * and this would result as number with decimals when converting to wei
@@ -43,12 +41,13 @@ export function parseEthValue(value: number): string {
    * convert the number again (can be 2 times)
    */
   if (parsed.lt(1)) {
-    parsed = parseAsBigNumber(parsed);
+    parsed = new BigNumber(parsed * (10 ** 18));
     if (parsed.lt(1)) {
-      parsed = parseAsBigNumber(parsed);
+      parsed = new BigNumber(parsed * (10 ** 18));
     }
   }
-  return parsed.toString();
+
+  return new BigNumber(Math.floor(+parsed.toString())).toString();
 }
 
 class EthplorerSdk {

--- a/src/services/EthplorerSdk.js
+++ b/src/services/EthplorerSdk.js
@@ -32,8 +32,10 @@ import type {
   GetTxInfoResponse,
 } from 'models/EthplorerSdkTypes';
 
+const parseAsBigNumber = (value) => new BigNumber(Math.floor(value * (10 ** 18)));
+
 export function parseEthValue(value: number): string {
-  let parsed = new BigNumber(value * (10 ** 18));
+  let parsed = parseAsBigNumber(value);
   /**
    * ethplorer might return number values in format such as `1e-22`
    * and this would result as number with decimals when converting to wei
@@ -41,9 +43,9 @@ export function parseEthValue(value: number): string {
    * convert the number again (can be 2 times)
    */
   if (parsed.lt(1)) {
-    parsed = new BigNumber(parsed * (10 ** 18));
+    parsed = parseAsBigNumber(parsed);
     if (parsed.lt(1)) {
-      parsed = new BigNumber(parsed * (10 ** 18));
+      parsed = parseAsBigNumber(parsed);
     }
   }
   return parsed.toString();

--- a/src/services/EthplorerSdk.js
+++ b/src/services/EthplorerSdk.js
@@ -33,7 +33,7 @@ import type {
 } from 'models/EthplorerSdkTypes';
 
 export function parseEthValue(value: number): string {
-  let parsed = new BigNumber(value * (10 ** 18));
+  let parsed = new BigNumber(10 ** 18).multipliedBy(value);
   /**
    * ethplorer might return number values in format such as `1e-22`
    * and this would result as number with decimals when converting to wei
@@ -41,9 +41,9 @@ export function parseEthValue(value: number): string {
    * convert the number again (can be 2 times)
    */
   if (parsed.lt(1)) {
-    parsed = new BigNumber(parsed * (10 ** 18));
+    parsed = new BigNumber(10 ** 18).multipliedBy(parsed);
     if (parsed.lt(1)) {
-      parsed = new BigNumber(parsed * (10 ** 18));
+      parsed = new BigNumber(10 ** 18).multipliedBy(parsed);
     }
   }
 

--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -187,6 +187,10 @@ describe('Common utils', () => {
       const result = formatUnits('0.0001', 18);
       expect(result).toEqual('0.0');
     });
+    it('should format error input 0.0001 correctly', () => {
+      const result = formatUnits('0.0001', 0);
+      expect(result).toEqual('0');
+    });
     it('should format 0xc420d9d8e4003a8000 correctly', () => {
       const result = formatUnits('0xc420d9d8e4003a8000', 18);
       expect(result).toEqual('3617.929');
@@ -201,7 +205,15 @@ describe('Common utils', () => {
     });
     it('should format 40000000 correctly with 0 decimals', () => {
       const result = formatUnits('40000000', 0);
-      expect(result).toEqual('40000000.0');
+      expect(result).toEqual('40000000');
+    });
+    it('should format 40000999.9 correctly with 0 decimals', () => {
+      const result = formatUnits('40000999.9', 0);
+      expect(result).toEqual('40000999');
+    });
+    it('should format 40000999.9 correctly with 18 decimals', () => {
+      const result = formatUnits('40000999.9', 18);
+      expect(result).toEqual('0.000000000040000999');
     });
   });
 

--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -215,6 +215,14 @@ describe('Common utils', () => {
       const result = formatUnits('40000999.9', 18);
       expect(result).toEqual('0.000000000040000999');
     });
+    it('should format 3.91071936104e+21 correctly with 18 decimals', () => {
+      const result = formatUnits('3.91071936104e+21', 18);
+      expect(result).toEqual('3910.71936104');
+    });
+    it('should format 3.91071936104e+21 correctly with 0 decimals', () => {
+      const result = formatUnits('3.91071936104e+21', 0);
+      expect(result).toEqual('3910719361040000000000');
+    });
   });
 
   describe('formatFiat', () => {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -364,9 +364,9 @@ export const formatUnits = (val: string = '0', decimals: number) => {
   let preparedValue = null; // null for sentry reports
   let valueWithoutDecimals = null; // null for sentry reports
   try {
-    // check if val is number or other format might be hex
+    // check if val is exact number or other format (might be hex, exponential, etc.)
     preparedValue = isValidNumber(val) ? Math.floor(+val) : val;
-    // parse number as BigNumber and string expresion without decimals
+    // parse number as BigNumber and get as string expresion without decimals
     valueWithoutDecimals = new BigNumber(preparedValue.toString()).toFixed();
     if (decimals === 0) {
       // check additionally if string contains decimal pointer

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -360,20 +360,24 @@ export const getGasPriceWei = (gasInfo: GasInfo): BigNumber => {
 };
 
 export const formatUnits = (val: string = '0', decimals: number) => {
-  let formattedUnits = '0.0';
+  let formattedUnits = decimals === 0 ? '0' : '0.0';
+  let preparedValue = null; // null for sentry reports
   try {
-    formattedUnits = utils.formatUnits(new BigNumber(val.toString()).toFixed(), decimals);
+    // check if val is number or other format might be hex
+    preparedValue = isValidNumber(val) ? Math.floor(+val).toString() : val;
+    formattedUnits = utils.formatUnits(preparedValue, decimals);
+    if (decimals === 0) return Math.floor(+formattedUnits).toString();
   } catch (e) {
     Sentry.captureMessage(e.message, {
       level: 'info',
       extra: {
         sourceFunction: 'formatUnits(value,decimals)',
         inputValue: val,
+        preparedValue,
         decimals,
       },
     });
   }
-
   return formattedUnits;
 };
 


### PR DESCRIPTION
This PR includes:
1. Fix for Ethplorer SDK parsed values to make them as BigNumber without decimals.
2. Fix for `formatUnits` method to not return `.0` decimal if value has 0 decimals.
3. Covered more values to be parseable using `formatUnits`, those include exponential values with 0 decimals and BigNumber that itself was passed with decimal pointer where it shouldn't but it can happen when converting numeric/string values back and forth.
4. Improved parsed value for Ethplorer service `parseEth` method.
5. Added more testable values for `formatUnits` unit test and Ethplorer service `parseEth` method of Ethplorer on history import unit test.

Related Sentry tickets can be found here – https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1217401677/events/d9d2d9862902499e820ee5a2f4ccdfa2/?project=1294444&query=is%3Aunresolved.