### PR TITLE
do not perform smart wallet reset if sdk is not initialized

### DIFF
--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -398,14 +398,12 @@ class SmartWallet {
   }
 
   async reset() {
+    if (!this.sdkInitialized) return;
     this.sdkInitialized = false;
     if (!this.sdk) return;
     this.sdk.event$.next(null); // unsubscribes
     subscribedToEvents = false;
-    await this.sdk.reset({
-      device: true,
-      session: true,
-    }).catch(null);
+    await this.sdk.reset({ device: true, session: true }).catch(null);
   }
 }
 

--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -403,7 +403,10 @@ class SmartWallet {
     if (!this.sdk) return;
     this.sdk.event$.next(null); // unsubscribes
     subscribedToEvents = false;
-    await this.sdk.reset({ device: true, session: true }).catch(null);
+    await this.sdk.reset({
+      device: true,
+      session: true,
+    }).catch(null);
   }
 }
 


### PR DESCRIPTION
Small fix that checks if smart wallet is initialized before calling SDK reset method.