### PR TITLE
Install bundler version 2.0.2 fixing ios builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ jobs:
             - ./ios/Pods
       - run:
           name: Install Bundler
-          command: sudo gem install bundler
+          command: sudo gem install bundler -v 2.0.2
       - restore_cache:
           key: ios-gems-{{ checksum "./ios/Gemfile" }}
       - run:


### PR DESCRIPTION
Install specific bundler version since prod_ios job was failing.