### PR TITLE
Ignore eslint rule that breaks tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,7 @@
     "no-plusplus": ["off"],
     "function-paren-newline": [0],
     "no-param-reassign": ["off"],
-    "react/default-props-match-prop-types": ["off"]
+    "react/default-props-match-prop-types": ["off"],
+    "react/no-did-mount-set-state": ["off"]
   }
 }


### PR DESCRIPTION
The eslint rule `react/no-did-mount-set-state` started breaking
the tests somehow. This PR ignores it, since it's a rule that we're
not following.