### PR TITLE
Fix ERC20 transactions showing as collectibles

### DIFF
--- a/src/actions/collectiblesActions.js
+++ b/src/actions/collectiblesActions.js
@@ -144,6 +144,17 @@ const collectibleTransaction = (event) => {
   };
 };
 
+const isCollectibleTransaction = (event: Object): boolean => {
+  const { asset } = event;
+  // NOTE: for some rare transactions we don't have information about the asset sent
+  if (!asset) return false;
+
+  const { asset_contract: assetContract } = asset;
+  if (!assetContract) return false;
+
+  return assetContract.schema_name === 'ERC721';
+};
+
 export const fetchCollectiblesHistoryAction = () => {
   return async (dispatch: Dispatch, getState: GetState, api: SDKWrapper) => {
     const {
@@ -156,9 +167,8 @@ export const fetchCollectiblesHistoryAction = () => {
 
     if (response.error || !response.asset_events) return;
 
-    // NOTE: for some rare transactions we don't have information about the asset sent
     const accountCollectiblesHistory = response.asset_events
-      .filter(event => !!event.asset)
+      .filter(isCollectibleTransaction)
       .map(collectibleTransaction);
 
     const updatedCollectiblesHistory = {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -390,7 +390,7 @@ SDKWrapper.prototype.fetchCollectibles = function (walletAddress: string) {
 };
 
 SDKWrapper.prototype.fetchCollectiblesTransactionHistory = function (walletAddress: string) {
-  const url = `${OPEN_SEA_API}/events/?account_address=${walletAddress}&exclude_currencies=true&event_type=transfer`;
+  const url = `${OPEN_SEA_API}/events/?account_address=${walletAddress}&event_type=transfer`;
   return Promise.resolve()
     .then(() => axios.get(url, {
       ...defaultAxiosRequestConfig,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -390,7 +390,7 @@ SDKWrapper.prototype.fetchCollectibles = function (walletAddress: string) {
 };
 
 SDKWrapper.prototype.fetchCollectiblesTransactionHistory = function (walletAddress: string) {
-  const url = `${OPEN_SEA_API}/events/?account_address=${walletAddress}&event_type=transfer`;
+  const url = `${OPEN_SEA_API}/events/?account_address=${walletAddress}&exclude_currencies=true&event_type=transfer`;
   return Promise.resolve()
     .then(() => axios.get(url, {
       ...defaultAxiosRequestConfig,


### PR DESCRIPTION
OpenSea returns events for some transactions of some ERC20 assets. This filters them out so they don't show up on the transaction history as collectibles.
ERC20 transactions still show up as asset transfers.