### PR TITLE
Fix double Choose Assets screen in smart wallet migration flow

### DIFF
--- a/src/navigation/appNavigation.js
+++ b/src/navigation/appNavigation.js
@@ -567,7 +567,6 @@ const manageWalletsFlow = createStackNavigator({
   [ACCOUNTS]: AccountsScreen,
   [FUND_CONFIRM]: FundConfirmScreen,
   [RECOVERY_AGENTS]: RecoveryAgentsScreen,
-  [CHOOSE_ASSETS_TO_TRANSFER]: ChooseAssetsScreen,
 }, StackNavigatorConfig);
 
 manageWalletsFlow.navigationOptions = hideTabNavigatorOnChildView;

--- a/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
+++ b/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
@@ -21,7 +21,6 @@ import * as React from 'react';
 import styled, { withTheme } from 'styled-components/native';
 import { StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
-import { NavigationActions } from 'react-navigation';
 import { connect } from 'react-redux';
 import { CachedImage } from 'react-native-cached-image';
 // import { utils } from 'ethers';
@@ -40,11 +39,7 @@ import { getThemeColors, themedColors } from 'utils/themes';
 // import { formatAmount, getCurrencySymbol, getGasPriceWei } from 'utils/common';
 // import { getRate } from 'utils/assets';
 
-import {
-  CHOOSE_ASSETS_TO_TRANSFER,
-  EXCHANGE, ASSETS,
-  UPGRADE_TO_SMART_WALLET_FLOW,
-} from 'constants/navigationConstants';
+import { CHOOSE_ASSETS_TO_TRANSFER, EXCHANGE, ASSETS } from 'constants/navigationConstants';
 import { defaultFiatCurrency } from 'constants/assetsConstants';
 
 import { deploySmartWalletAction } from 'actions/smartWalletActions';
@@ -210,10 +205,7 @@ class SmartWalletIntro extends React.PureComponent<Props, State> {
                       deploySmartWallet();
                       navigation.navigate(ASSETS);
                     } else {
-                      navigation.navigate({
-                        routeName: UPGRADE_TO_SMART_WALLET_FLOW,
-                        action: NavigationActions.navigate(CHOOSE_ASSETS_TO_TRANSFER),
-                      });
+                      navigation.navigate(CHOOSE_ASSETS_TO_TRANSFER);
                     }
                   });
                 }}

--- a/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
+++ b/src/screens/UpgradeToSmartWallet/SmartWalletIntro/SmartWalletIntro.js
@@ -21,6 +21,7 @@ import * as React from 'react';
 import styled, { withTheme } from 'styled-components/native';
 import { StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
+import { NavigationActions } from 'react-navigation';
 import { connect } from 'react-redux';
 import { CachedImage } from 'react-native-cached-image';
 // import { utils } from 'ethers';
@@ -39,7 +40,11 @@ import { getThemeColors, themedColors } from 'utils/themes';
 // import { formatAmount, getCurrencySymbol, getGasPriceWei } from 'utils/common';
 // import { getRate } from 'utils/assets';
 
-import { CHOOSE_ASSETS_TO_TRANSFER, EXCHANGE, ASSETS } from 'constants/navigationConstants';
+import {
+  CHOOSE_ASSETS_TO_TRANSFER,
+  EXCHANGE, ASSETS,
+  UPGRADE_TO_SMART_WALLET_FLOW,
+} from 'constants/navigationConstants';
 import { defaultFiatCurrency } from 'constants/assetsConstants';
 
 import { deploySmartWalletAction } from 'actions/smartWalletActions';
@@ -205,7 +210,10 @@ class SmartWalletIntro extends React.PureComponent<Props, State> {
                       deploySmartWallet();
                       navigation.navigate(ASSETS);
                     } else {
-                      navigation.navigate(CHOOSE_ASSETS_TO_TRANSFER);
+                      navigation.navigate({
+                        routeName: UPGRADE_TO_SMART_WALLET_FLOW,
+                        action: NavigationActions.navigate(CHOOSE_ASSETS_TO_TRANSFER),
+                      });
                     }
                   });
                 }}


### PR DESCRIPTION
To reproduce:
- enter the smart wallet migration flow
- select an asset
- click edit in the upper right corner
- go back to asset selection
- the previously selected asset is unselected
In fact when you go back once again, you are brought to the choose asset screen once again, with selected assets. That means that the choose asset screen is opened once again when we press Edit.
Why? When we go to the `appNavigation.js`we see two stack navigators:
```js
const smartWalletUpgradeFlow = createStackNavigator({
  [CHOOSE_ASSETS_TO_TRANSFER]: ChooseAssetsScreen,
...
  [EDIT_ASSET_AMOUNT_TO_TRANSFER]: EditAssetAmountScreen,
...
```
```js
const manageWalletsFlow = createStackNavigator({
  [ACCOUNTS]: AccountsScreen,
  ...
  [CHOOSE_ASSETS_TO_TRANSFER]: ChooseAssetsScreen,
}, StackNavigatorConfig);
```
So, in the smart wallet migration flow we firstly go to the `manageWalletsFlow` to the `AccountsScreen`, then we move on to the `ChooseAssetsScreen` in the same navigator, then it messes up as it goes to the `EditAssetAmountScreen` in another navigator that also contains `ChooseAssetsScreen`. 

So the solution might be moving explicitly to the `smartWalletUpgradeFlow` while moving to the `ChooseAssetsScreen` and it fixes this problem. We can also remove the `ChooseAssetsScreen` from one of the navigators but I guess it's there for a reason and we move to it from a couple of screens.
