### PR TITLE
Remove avatar and username from navbars

### DIFF
--- a/src/screens/Assets/Assets.js
+++ b/src/screens/Assets/Assets.js
@@ -315,7 +315,6 @@ class AssetsScreen extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          leftItems: [{ user: true }],
           rightItems: [{
             actionButton: {
               key: 'manageAccounts',
@@ -325,6 +324,7 @@ class AssetsScreen extends React.Component<Props, State> {
               ...customHeaderButtonProps,
             },
           }],
+          noBack: true,
         }}
         inset={{ bottom: 0 }}
       >

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -1116,8 +1116,9 @@ class ExchangeScreen extends React.Component<Props, State> {
     return (
       <ContainerWithHeader
         headerProps={{
-          leftItems: [{ user: true }],
           rightItems,
+          noBack: true,
+          centerItems: [{ title: 'Exchange' }],
         }}
         inset={{ bottom: 'never' }}
       >

--- a/src/screens/People/People.js
+++ b/src/screens/People/People.js
@@ -485,7 +485,7 @@ class PeopleScreen extends React.Component<Props, State> {
 
     return (
       <ContainerWithHeader
-        headerProps={{ leftItems: [{ user: true }] }}
+        headerProps={{ noBack: true, centerItems: [{ title: 'People' }] }}
         inset={{ bottom: 0 }}
       >
         <ScrollView


### PR DESCRIPTION
This PR removes avatar and username from all navbars except Home. In People and Exchange tab I've added a temporary title. It will be soon replaced with link, menus etc.