### PR TITLE
Validate QR scanner result's type

### DIFF
--- a/src/components/QRCodeScanner/QRCodeScanner.js
+++ b/src/components/QRCodeScanner/QRCodeScanner.js
@@ -22,6 +22,7 @@ import { Vibration, Dimensions, Platform } from 'react-native';
 import throttle from 'lodash.throttle';
 import Modal from 'react-native-modal';
 import Permissions from 'react-native-permissions';
+import { Sentry } from 'react-native-sentry';
 import { noop } from 'utils/common';
 import { CameraView } from 'components/QRCodeScanner/CameraView';
 import NoPermissions from 'components/QRCodeScanner/NoPermissions';
@@ -155,6 +156,11 @@ export default class QRCodeScanner extends React.Component<Props, State> {
     const isIos = Platform.OS === 'ios';
 
     if (isIos && !this.isInsideScanArea(bounds)) {
+      return;
+    }
+
+    if (typeof code !== 'string') {
+      Sentry.captureMessage('Wrong data from QR scanner received', { extra: { data: code } });
       return;
     }
 


### PR DESCRIPTION
Some users were getting not a string result after scanning the QR code.
This will check the result's type and report wrong data to Sentry.

[Sentry report](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1497983771/?environment=production&referrer=alert_email)