### PR TITLE
Validate identity keys related api responses

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -782,7 +782,13 @@ SDKWrapper.prototype.updateIdentityKeys = function (updatedIdentityKeys: Connect
 SDKWrapper.prototype.patchIdentityKeys = function (updatedIdentityKeys: ConnectionPatchIdentityKeys) {
   return Promise.resolve()
     .then(() => this.pillarWalletSdk.connection.patchIdentityKeys(updatedIdentityKeys))
-    .then(({ data }) => data)
+    .then(({ data }) => {
+      if (data && !Array.isArray(data)) {
+        Sentry.captureMessage('Wrong response from patchIdentityKeys', { extra: { data } });
+        return false;
+      }
+      return data;
+    })
     .catch(() => false);
 };
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -762,7 +762,13 @@ SDKWrapper.prototype.connectionsCount = function (walletId: string) {
 SDKWrapper.prototype.mapIdentityKeys = function (connectionKeyIdentityMap: ConnectionIdentityKeyMap) {
   return Promise.resolve()
     .then(() => this.pillarWalletSdk.connection.mapIdentityKeys(connectionKeyIdentityMap))
-    .then(({ data }) => data)
+    .then(({ data }) => {
+      if (!Array.isArray(data)) {
+        Sentry.captureMessage('Wrong Identity Keys received', { extra: { data } });
+        return [];
+      }
+      return data;
+    })
     .catch(() => []);
 };
 


### PR DESCRIPTION
1) Validate get identity keys api response type. [Sentry report](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1487473922/?environment=production&project=1289773&referrer=alert_email)

2) Validate patchIdentityKeys api response.  [Sentry report](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1483651652/?environment=production&project=1289773&referrer=alert_email)
