### PR TITLE
Handle missed icon in wallet connect ClientMeta

### DIFF
--- a/src/actions/walletConnectActions.js
+++ b/src/actions/walletConnectActions.js
@@ -140,7 +140,7 @@ const onWalletConnectCallRequest = (connector: Connector, payload: JsonRpcReques
     const request: CallRequest = {
       name,
       url,
-      icon: icons[0],
+      icon: get(icons, '[0]'),
       callId: payload.id,
       peerId: connector.peerId,
       method: payload.method,

--- a/src/models/WalletConnect.js
+++ b/src/models/WalletConnect.js
@@ -23,7 +23,7 @@
 export type ClientMeta = {|
   description: string,
   url: string,
-  icons: string[],
+  icons?: string[],
   name: string,
 |};
 

--- a/src/screens/ManageDetailsSessions/ManageDetailsSessions.js
+++ b/src/screens/ManageDetailsSessions/ManageDetailsSessions.js
@@ -20,6 +20,7 @@
 import * as React from 'react';
 import { FlatList } from 'react-native';
 import { connect } from 'react-redux';
+import get from 'lodash.get';
 import styled from 'styled-components/native';
 import { NavigationActions } from 'react-navigation';
 import Intercom from 'react-native-intercom';
@@ -120,11 +121,12 @@ class ManageDetailsSessions extends React.Component<Props, State> {
   renderSessionItem = ({ item }) => {
     const { peerMeta = {} } = item;
     const { name, icons, url } = peerMeta;
+    const icon = get(icons, '[0]');
 
     return (
       <ListItemWithImage
         label={name}
-        avatarUrl={icons[0]}
+        avatarUrl={icon}
         buttonAction={() => this.props.killWalletConnectSessionByUrl(url)}
         buttonActionLabel="Disconnect"
       />
@@ -143,7 +145,7 @@ class ManageDetailsSessions extends React.Component<Props, State> {
         onPress={() => this.onRequestItemPress(item)}
       />
     );
-  }
+  };
 
   renderRequestsList() {
     const { requests } = this.props;
@@ -212,7 +214,10 @@ class ManageDetailsSessions extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = ({ user: { data: user }, walletConnect: { connectors, requests } }) => ({
+const mapStateToProps = ({
+  user: { data: user },
+  walletConnect: { connectors, requests },
+}) => ({
   user,
   connectors,
   requests,
@@ -222,7 +227,4 @@ const mapDispatchToProps = dispatch => ({
   killWalletConnectSessionByUrl: url => dispatch(killWalletConnectSessionByUrl(url)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ManageDetailsSessions);
+export default connect(mapStateToProps, mapDispatchToProps)(ManageDetailsSessions);

--- a/src/screens/ManageDetailsSessions/ManageDetailsSessions.js
+++ b/src/screens/ManageDetailsSessions/ManageDetailsSessions.js
@@ -34,6 +34,7 @@ import { navigate } from 'services/navigation';
 
 import type { NavigationScreenProp } from 'react-navigation';
 import type { CallRequest } from 'models/WalletConnect';
+import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 
 export const SheetContentWrapper = styled.View`
   flex: 1;
@@ -217,13 +218,13 @@ class ManageDetailsSessions extends React.Component<Props, State> {
 const mapStateToProps = ({
   user: { data: user },
   walletConnect: { connectors, requests },
-}) => ({
+}: RootReducerState): $Shape<Props> => ({
   user,
   connectors,
   requests,
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   killWalletConnectSessionByUrl: url => dispatch(killWalletConnectSessionByUrl(url)),
 });
 


### PR DESCRIPTION
Closes this [report](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1439666379/?environment=production&project=1294444&referrer=alert_email). As it turns out the 'icons' property could be not set in the ClientMeta