### PR TITLE
Remove the v in the git bump tag action

### DIFF
--- a/.github/workflows/tag-prod.yml
+++ b/.github/workflows/tag-prod.yml
@@ -12,6 +12,6 @@ jobs:
       uses: anothrNick/github-tag-action@1.13.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+        WITH_V: false
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: minor

--- a/.github/workflows/tag-qa.yml
+++ b/.github/workflows/tag-qa.yml
@@ -12,6 +12,6 @@ jobs:
       uses: anothrNick/github-tag-action@1.13.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+        WITH_V: false
         RELEASE_BRANCHES: develop
         DEFAULT_BUMP: patch


### PR DESCRIPTION
iOS upload to Testflight failed due to the 'v' character in the version number. Will remove it and do the tags just with the simver.