### PR TITLE
Feature/devop 49 GitHub release tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,19 +308,9 @@ jobs:
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             export ENVFILE=$(echo ~/pillarwallet/.env)
             cd android && bundle exec fastlane deploy_android_appcenter
-      - run:
-          name: prepare to archive apk file
-          command: |
-            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
-            mkdir -p /tmp/workspace/android-release
-            cp ./android/app/build/outputs/apk/prod/staging/app-prod-staging.apk /tmp/workspace/android-release/pillarwallet-appcenter-android-$TAG_VERSION.apk
       - store_artifacts:
           path: android/app/build/outputs/apk
           destination: apks   
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - android-release
 
   get-latest-tag:
     executor: node10-executor
@@ -628,7 +618,8 @@ jobs:
             . ./setReleaseInfo.sh
             TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
             github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-appcenter-android-$TAG_VERSION" -f /tmp/workspace/android-release/*.apk
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$TAG_VERSION.apk" -f /tmp/workspace/android-release/*.apk
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$TAG_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
 
 workflows:
   version: 2.1
@@ -645,18 +636,17 @@ workflows:
       - appcenter_android:
           requires:
             - build-and-test
-            - get-latest-tag
           filters:
             branches:
               only:
-                  - feature/DEVOP-49-github-release-tool
+                  - develop
       - get-latest-tag:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - feature/DEVOP-49-github-release-tool
+                  - master
       - prod_ios:
           requires:
             - build-and-test
@@ -675,4 +665,5 @@ workflows:
                   - master
       - publish_releases_to_github:
           requires:
-            - appcenter_android
+            - prod_android
+            - prod_ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,26 +627,8 @@ jobs:
             chmod +x setReleaseInfo.sh
             . ./setReleaseInfo.sh
             TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
-            echo $TAG_VERSION
-            github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n $RELEASE_TITLE --description $RELEASE_DESCRIPTION
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-appcenter-android-$TAG-VERSION" -f /tmp/workspace/android-release/pillarwallet-appcenter-android-$TAG_VERSION.apk
-
-  # publish_releases_to_github:
-  #   docker:
-  #     - image: cibuilds/github:0.10
-  #   steps:
-  #     - checkout
-  #     - attach_workspace: &attach_workspace
-  #         at: /tmp/workspace
-  #     - run:
-  #         name: Set tag and publish releases to GitHub
-  #         command: |
-  #           chmod +x setReleaseInfo.sh
-  #           . ./setReleaseInfo.sh
-  #           TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
-  #           echo $TAG_VERSION
-  #           ghr -n $RELEASE_TITLE -b $RELEASE_DESCRIPTION $TAG_VERSION /tmp/workspace/android-release/
-  #           ghr $TAG_VERSION /tmp/workspace/ios-release/
+            github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-appcenter-android-$TAG_VERSION" -f /tmp/workspace/android-release/*.apk
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,9 +308,19 @@ jobs:
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             export ENVFILE=$(echo ~/pillarwallet/.env)
             cd android && bundle exec fastlane deploy_android_appcenter
+      - run:
+          name: prepare to archive apk file
+          command: |
+            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            mkdir -p /tmp/workspace/android-release
+            cp ./android/app/build/outputs/apk/prod/staging/app-prod-staging.apk /tmp/workspace/android-release/pillarwallet-appcenter-android-$TAG_VERSION.apk
       - store_artifacts:
           path: android/app/build/outputs/apk
-          destination: apks          
+          destination: apks   
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - android-release
 
   get-latest-tag:
     executor: node10-executor
@@ -602,18 +612,41 @@ jobs:
 
   publish_releases_to_github:
     docker:
-      - image: cibuilds/github:0.10
+      - image: circleci/golang:1.8
     steps:
       - checkout
       - attach_workspace: &attach_workspace
           at: /tmp/workspace
       - run:
+          name: Install github-release
+          command: |
+            go get github.com/aktau/github-release
+      - run:
           name: Set tag and publish releases to GitHub
           command: |
+            chmod +x setReleaseInfo.sh
+            . ./setReleaseInfo.sh
             TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
             echo $TAG_VERSION
-            ghr $TAG_VERSION /tmp/workspace/android-release/
-            ghr $TAG_VERSION /tmp/workspace/ios-release/ 
+            github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n $RELEASE_TITLE --description $RELEASE_DESCRIPTION
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-appcenter-android-$TAG-VERSION" -f /tmp/workspace/android-release/pillarwallet-appcenter-android-$TAG_VERSION.apk
+
+  # publish_releases_to_github:
+  #   docker:
+  #     - image: cibuilds/github:0.10
+  #   steps:
+  #     - checkout
+  #     - attach_workspace: &attach_workspace
+  #         at: /tmp/workspace
+  #     - run:
+  #         name: Set tag and publish releases to GitHub
+  #         command: |
+  #           chmod +x setReleaseInfo.sh
+  #           . ./setReleaseInfo.sh
+  #           TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+  #           echo $TAG_VERSION
+  #           ghr -n $RELEASE_TITLE -b $RELEASE_DESCRIPTION $TAG_VERSION /tmp/workspace/android-release/
+  #           ghr $TAG_VERSION /tmp/workspace/ios-release/
 
 workflows:
   version: 2.1
@@ -630,17 +663,18 @@ workflows:
       - appcenter_android:
           requires:
             - build-and-test
+            - get-latest-tag
           filters:
             branches:
               only:
-                  - develop
+                  - feature/DEVOP-49-github-release-tool
       - get-latest-tag:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                  - master
+                  - feature/DEVOP-49-github-release-tool
       - prod_ios:
           requires:
             - build-and-test
@@ -659,5 +693,4 @@ workflows:
                   - master
       - publish_releases_to_github:
           requires:
-            - prod_ios
-            - prod_android
+            - appcenter_android

--- a/setReleaseInfo.sh
+++ b/setReleaseInfo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+PR_NUMBER=$(git log -1 --pretty=%B | grep '#' | cut -d' ' -f4 | cut -d'#' -f2)
+export RELEASE_TITLE=$(curl https://api.github.com/repos/pillarwallet/pillarwallet/pulls/$PR_NUMBER | grep title | cut -d'"' -f4)
+export RELEASE_DESCRIPTION=$(curl https://api.github.com/repos/pillarwallet/pillarwallet/pulls/$PR_NUMBER | grep body | cut -d'"' -f4)


### PR DESCRIPTION
This:

1. Changes the tool we use for github releases and upload of artifacts to github-release
2. Will create the release with a title and description fetched from the PR that will be opened to master when a new Release candidate is needed.