### PR TITLE
Feature/erc20 support note on receive modal [PIL-268 and PIL-282]

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -228,7 +228,7 @@ const getButtonPadding = (props) => {
   } else if (props.square) {
     return '4px';
   }
-  return `${spacing.rhythm * 1.5}px`;
+  return '22px';
 };
 
 const getButtonFontSize = (props) => {

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -224,7 +224,7 @@ class HeaderBlock extends React.Component<Props> {
                 <BackIcon
                   icon="back"
                   color={transparent ? colors.control : colors.text}
-                  onPress={customOnBack ? () => customOnBack() : () => { navigation.goBack(null); }}
+                  onPress={customOnBack ? customOnBack : () => navigation.goBack(null)}
                   fontSize={fontSizes.large}
                   horizontalAlign="flex-start"
                 />

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -224,7 +224,7 @@ class HeaderBlock extends React.Component<Props> {
                 <BackIcon
                   icon="back"
                   color={transparent ? colors.control : colors.text}
-                  onPress={customOnBack ? customOnBack : () => navigation.goBack(null)}
+                  onPress={customOnBack || () => navigation.goBack(null)}
                   fontSize={fontSizes.large}
                   horizontalAlign="flex-start"
                 />

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -224,7 +224,7 @@ class HeaderBlock extends React.Component<Props> {
                 <BackIcon
                   icon="back"
                   color={transparent ? colors.control : colors.text}
-                  onPress={customOnBack || () => navigation.goBack(null)}
+                  onPress={customOnBack || (() => navigation.goBack(null))}
                   fontSize={fontSizes.large}
                   horizontalAlign="flex-start"
                 />

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -60,7 +60,7 @@ type Props = {
   wrapperStyle?: Object,
   noHorizonatalPadding?: boolean,
   forceInsetTop?: string,
-}
+};
 
 const Wrapper = styled.View`
   width: 100%;
@@ -126,7 +126,7 @@ const RightItems = styled.View`
 
 const BackIcon = styled(IconButton)`
   position: relative;
-  height: 24px;
+  height: 44px;
   width: 44px;
   padding-left: 10px;
   margin-left: -12px;
@@ -214,13 +214,22 @@ class HeaderBlock extends React.Component<Props> {
           {(leftItems.length || !!noBack)
             ? leftItems.map((item) => this.renderSideItems(item, LEFT))
             : (
-              <BackIcon
-                icon="back"
-                color={transparent ? colors.control : colors.text}
-                onPress={customOnBack ? () => customOnBack() : () => { navigation.goBack(null); }}
-                fontSize={fontSizes.large}
-                horizontalAlign="flex-start"
-              />)
+              <View
+                style={{
+                  marginTop: -20,
+                  marginBottom: -20,
+                }}
+                key="back"
+              >
+                <BackIcon
+                  icon="back"
+                  color={transparent ? colors.control : colors.text}
+                  onPress={customOnBack ? () => customOnBack() : () => { navigation.goBack(null); }}
+                  fontSize={fontSizes.large}
+                  horizontalAlign="flex-start"
+                />
+              </View>
+            )
           }
         </LeftItems>
         {!!centerItems.length &&

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -28,9 +28,6 @@ import { SafeAreaView } from 'react-navigation';
 import type { NavigationScreenProp } from 'react-navigation';
 import { BaseText } from 'components/Typography';
 import IconButton from 'components/IconButton';
-import { connect } from 'react-redux';
-import ProfileImage from 'components/ProfileImage';
-import { MANAGE_USERS_FLOW } from 'constants/navigationConstants';
 import { responsiveSize } from 'utils/ui';
 import { getThemeColors } from 'utils/themes';
 import type { Theme } from 'models/Theme';
@@ -48,7 +45,6 @@ type Props = {
   leftItems?: NavItem[],
   centerItems?: NavItem[],
   sideFlex?: number,
-  user: Object,
   navigation: NavigationScreenProp<*>,
   background?: string,
   floating?: boolean,
@@ -60,6 +56,9 @@ type Props = {
   noPaddingTop?: boolean,
   noBottomBorder?: boolean,
   onClose?: () => void,
+  leftSideFlex?: number,
+  wrapperStyle?: Object,
+  noHorizonatalPadding?: boolean,
 }
 
 const Wrapper = styled.View`
@@ -78,7 +77,8 @@ const Wrapper = styled.View`
 `;
 
 const HeaderContentWrapper = styled.View`
-  padding: 15px ${spacing.layoutSides}px;
+  padding-vertical: 15px;
+  ${({ noHorizonatalPadding }) => !noHorizonatalPadding && `padding-horizontal: ${spacing.layoutSides}px;`}
   width: 100%;
   min-height: 58px;
 `;
@@ -94,13 +94,6 @@ const HeaderRow = styled.View`
   width: 100%;
   align-items: center;
   justify-content: space-between;
-`;
-
-const HeaderProfileImage = styled(ProfileImage)``;
-
-const UserButton = styled.TouchableOpacity`
-  flex-direction: row;
-  align-items: center;
 `;
 
 const CenterItems = styled.View`
@@ -185,8 +178,6 @@ const IconImage = styled(CachedImage)`
   height: 24px;
 `;
 
-const profileImageWidth = 24;
-
 const LEFT = 'LEFT';
 const CENTER = 'CENTER';
 const RIGHT = 'RIGHT';
@@ -209,12 +200,16 @@ class HeaderBlock extends React.Component<Props> {
       customOnBack,
       theme,
       transparent,
+      leftSideFlex,
     } = this.props;
     const colors = getThemeColors(theme);
 
     return (
       <HeaderRow>
-        <LeftItems sideFlex={sideFlex} style={!centerItems.length && !rightItems.length ? { flexGrow: 2 } : {}}>
+        <LeftItems
+          sideFlex={sideFlex || leftSideFlex}
+          style={!centerItems.length && !rightItems.length && !leftSideFlex ? { flexGrow: 2 } : {}}
+        >
           {(leftItems.length || !!noBack)
             ? leftItems.map((item) => this.renderSideItems(item, LEFT))
             : (
@@ -247,9 +242,6 @@ class HeaderBlock extends React.Component<Props> {
     const { style: itemStyle = {} } = item;
     const commonStyle = {};
     if (type === RIGHT) commonStyle.marginLeft = spacing.small;
-    if (item.user || item.userIcon) {
-      return this.renderUser(!item.userIcon);
-    }
     if (item.title) {
       return (
         <View
@@ -350,33 +342,6 @@ class HeaderBlock extends React.Component<Props> {
     return null;
   };
 
-  renderUser = (showName: boolean) => {
-    const { user, navigation } = this.props;
-    const userImageUri = user.profileImage ? `${user.profileImage}?t=${user.lastUpdateTime || 0}` : null;
-    return (
-      <UserButton key="user" onPress={() => { navigation.navigate(MANAGE_USERS_FLOW); }}>
-        <HeaderProfileImage
-          uri={userImageUri}
-          userName={user.username}
-          diameter={profileImageWidth}
-          noShadow
-          borderWidth={0}
-        />
-        {showName &&
-        <View
-          style={{
-            flex: 1,
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginRight: spacing.medium,
-          }}
-        >
-          <HeaderTitleText style={{ marginLeft: 8 }}>{user.username}</HeaderTitleText>
-        </View>}
-      </UserButton>
-    );
-  };
-
   render() {
     const {
       floating,
@@ -384,6 +349,8 @@ class HeaderBlock extends React.Component<Props> {
       light,
       noPaddingTop,
       noBottomBorder,
+      wrapperStyle,
+      noHorizonatalPadding,
     } = this.props;
     const updatedColors = {};
     if (floating) {
@@ -401,13 +368,14 @@ class HeaderBlock extends React.Component<Props> {
         <Wrapper
           floating={floating}
           noBottomBorder={noBottomBorder}
+          style={wrapperStyle}
         >
           <SafeArea
             forceInset={{ bottom: 'never', top: 'always' }}
             noPaddingTop={noPaddingTop}
             androidStatusbarHeight={StatusBar.currentHeight}
           >
-            <HeaderContentWrapper>
+            <HeaderContentWrapper noHorizonatalPadding={noHorizonatalPadding}>
               {this.renderHeaderContent()}
             </HeaderContentWrapper>
           </SafeArea>
@@ -417,10 +385,4 @@ class HeaderBlock extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = ({
-  user: { data: user },
-}) => ({
-  user,
-});
-
-export default withTheme(connect(mapStateToProps)(HeaderBlock));
+export default withTheme(HeaderBlock);

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -59,6 +59,7 @@ type Props = {
   leftSideFlex?: number,
   wrapperStyle?: Object,
   noHorizonatalPadding?: boolean,
+  forceInsetTop?: string,
 }
 
 const Wrapper = styled.View`
@@ -351,6 +352,7 @@ class HeaderBlock extends React.Component<Props> {
       noBottomBorder,
       wrapperStyle,
       noHorizonatalPadding,
+      forceInsetTop = 'always',
     } = this.props;
     const updatedColors = {};
     if (floating) {
@@ -371,7 +373,7 @@ class HeaderBlock extends React.Component<Props> {
           style={wrapperStyle}
         >
           <SafeArea
-            forceInset={{ bottom: 'never', top: 'always' }}
+            forceInset={{ bottom: 'never', top: forceInsetTop }}
             noPaddingTop={noPaddingTop}
             androidStatusbarHeight={StatusBar.currentHeight}
           >

--- a/src/components/LabelBadge/LabelBadge.js
+++ b/src/components/LabelBadge/LabelBadge.js
@@ -21,16 +21,32 @@ import * as React from 'react';
 import styled from 'styled-components/native';
 import { MediumText } from 'components/Typography';
 import { themedColors } from 'utils/themes';
+import type { Theme } from 'models/Theme';
 
 type Props = {
   label: string,
   containerStyle?: Object,
   labelStyle?: Object,
   color?: string,
-}
+  primary?: boolean,
+};
+
+type BadgeProps = Props & {
+  theme: Theme,
+};
+
+const getBackgroundColor = (props: BadgeProps) => {
+  const { theme, color, primary } = props;
+  if (color) {
+    return color;
+  } else if (primary) {
+    return theme.colors.primary;
+  }
+  return theme.colors.positive;
+};
 
 const BadgeWrapper = styled.View`
-  background-color: ${({ color }) => color || themedColors.positive};
+  background-color: ${props => getBackgroundColor(props)};
   padding: 3px 8px;
   border-radius: 12px;
   align-self: flex-start;
@@ -49,7 +65,7 @@ export const LabelBadge = (props: Props) => {
     color,
   } = props;
   return (
-    <BadgeWrapper style={containerStyle} color={color}>
+    <BadgeWrapper style={containerStyle} color={color} {...props}>
       <Label style={labelStyle}>
         {label}
       </Label>

--- a/src/components/Modals/SlideModal/SlideModal.js
+++ b/src/components/Modals/SlideModal/SlideModal.js
@@ -66,6 +66,7 @@ type Props = {
   onSwipeComplete?: () => void,
   theme: Theme,
   noPadding?: boolean,
+  headerLeftItems?: Object[],
 };
 
 const themes = {
@@ -202,6 +203,7 @@ class SlideModal extends React.Component<Props, *> {
       scrollOffsetMax,
       theme,
       noPadding,
+      headerLeftItems,
     } = this.props;
 
     const customTheme = getTheme(this.props);
@@ -209,13 +211,16 @@ class SlideModal extends React.Component<Props, *> {
     const backgroundColor = bgColor || colors.surface;
 
     const showModalHeader = !fullScreen || showHeader;
-    const leftItems = [];
+    let leftItems = [];
     const centerItems = centerTitle ? [{ title }] : [];
     const rightItems = [{
       close: !noClose,
     }];
     if (!centerTitle) {
       leftItems.push({ title });
+    }
+    if (headerLeftItems) {
+      leftItems = [...leftItems, ...headerLeftItems];
     }
 
     const modalInner = (

--- a/src/components/Modals/SlideModal/SlideModal.js
+++ b/src/components/Modals/SlideModal/SlideModal.js
@@ -20,12 +20,11 @@
 import * as React from 'react';
 import Modal from 'react-native-modal';
 import styled, { withTheme } from 'styled-components/native';
-import Header from 'components/Header';
 import Root from 'components/Root';
 import Toast from 'components/Toast';
 import { Wrapper } from 'components/Layout';
+import HeaderBlock from 'components/HeaderBlock';
 import { spacing } from 'utils/variables';
-import { SubTitle } from 'components/Typography';
 import { Keyboard } from 'react-native';
 import { getThemeColors, themedColors } from 'utils/themes';
 import type { Theme } from 'models/Theme';
@@ -102,10 +101,6 @@ const getTheme = (props: Props) => {
   return themes.default;
 };
 
-const HeaderWrapper = styled.View`
-  width: 100%;
-`;
-
 const ContentWrapper = styled.View`
   width: 100%;
   height: 100%;
@@ -124,16 +119,12 @@ const Backdrop = styled.TouchableWithoutFeedback`
 const ModalBackground = styled.View`
   border-top-left-radius: ${props => props.customTheme.borderRadius};
   border-top-right-radius: ${props => props.customTheme.borderRadius};
+  overflow: hidden;
   padding: ${props => props.customTheme.padding};
   box-shadow: 0px 2px 7px rgba(0,0,0,.1);
   elevation: 1;
   margin-top: auto;
   background-color: ${({ customTheme, theme }) => customTheme.isTransparent ? 'transparent' : theme.colors.card};
-`;
-
-const ModalSubtitle = styled(SubTitle)`
-  padding: 10px 0;
-  color: ${themedColors.primary};
 `;
 
 const getModalContentPadding = (showHeader: boolean) => {
@@ -195,25 +186,18 @@ class SlideModal extends React.Component<Props, *> {
     const {
       children,
       title,
-      fullWidthTitle,
-      noBlueDotOnTitle,
-      dotColor,
       fullScreenComponent,
       onModalHidden,
       onModalShow,
       noClose,
       fullScreen,
-      subtitle,
       isVisible,
       showHeader,
       centerTitle,
-      noWrapTitle,
       backgroundColor: bgColor,
       avoidKeyboard,
       eventDetail,
       scrollOffset,
-      subtitleStyles,
-      titleStyles,
       noSwipeToDismiss,
       scrollOffsetMax,
       theme,
@@ -225,32 +209,30 @@ class SlideModal extends React.Component<Props, *> {
     const backgroundColor = bgColor || colors.surface;
 
     const showModalHeader = !fullScreen || showHeader;
+    const leftItems = [];
+    const centerItems = centerTitle ? [{ title }] : [];
+    const rightItems = [{
+      close: !noClose,
+    }];
+    if (!centerTitle) {
+      leftItems.push({ title });
+    }
 
     const modalInner = (
       <React.Fragment>
         {showModalHeader &&
-          <HeaderWrapper>
-            <Header
-              noMargin={!fullScreen}
-              centerTitle={centerTitle}
-              noWrapTitle={noWrapTitle}
-              noPadding={!fullScreen && !noPadding}
-              title={title}
-              titleStyles={titleStyles}
-              fullWidthTitle={fullWidthTitle}
-              noBlueDotOnTitle={noBlueDotOnTitle || !title}
-              dotColor={dotColor}
-              onClose={!noClose ? this.hideModal : () => {}}
-              noClose={noClose}
-            />
-          </HeaderWrapper>
-        }
-        {subtitle &&
-          <ModalSubtitle
-            style={subtitleStyles}
-          >
-            {subtitle}
-          </ModalSubtitle>
+          <HeaderBlock
+            leftItems={leftItems}
+            centerItems={centerItems}
+            rightItems={rightItems}
+            noBottomBorder
+            noPaddingTop={fullScreen}
+            onClose={this.hideModal}
+            wrapperStyle={{ backgroundColor: 'transparent' }}
+            noHorizonatalPadding={!fullScreen && !noPadding}
+            leftSideFlex={!title ? null : 4}
+            noBack
+          />
         }
         <ModalContent
           fullScreen={fullScreen}

--- a/src/components/Modals/SlideModal/SlideModal.js
+++ b/src/components/Modals/SlideModal/SlideModal.js
@@ -71,7 +71,7 @@ type Props = {
 
 const themes = {
   default: {
-    padding: `0 ${spacing.rhythm}px`,
+    padding: `0 ${spacing.layoutSides}px`,
     borderRadius: '30px',
   },
   fullScreen: {
@@ -231,12 +231,13 @@ class SlideModal extends React.Component<Props, *> {
             centerItems={centerItems}
             rightItems={rightItems}
             noBottomBorder
-            noPaddingTop={fullScreen}
+            noPaddingTop
             onClose={this.hideModal}
             wrapperStyle={{ backgroundColor: 'transparent' }}
             noHorizonatalPadding={!fullScreen && !noPadding}
-            leftSideFlex={!title ? null : 4}
+            leftSideFlex={centerTitle ? null : 4}
             noBack
+            forceInsetTop="never"
           />
         }
         <ModalContent

--- a/src/components/Modals/SlideModal/__tests__/SlideModal.test.js
+++ b/src/components/Modals/SlideModal/__tests__/SlideModal.test.js
@@ -54,7 +54,7 @@ describe('Slide Modal', () => {
         <SlideModal title="title" isVisible onModalHide={onModalHide} />
       </ThemeProvider>);
     const instance = component.root;
-    const button = instance.findByProps({ icon: 'close', fontSize: fontSizes.medium });
+    const button = instance.findByProps({ icon: 'close', fontSize: fontSizes.regular });
     button.props.onPress();
     await delay(400);
     expect(onModalHide).toHaveBeenCalled();

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -145,6 +145,7 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
                 "borderTopRightRadius": 30,
                 "elevation": 1,
                 "marginTop": "auto",
+                "overflow": "hidden",
                 "paddingBottom": 0,
                 "paddingLeft": 20,
                 "paddingRight": 20,
@@ -162,187 +163,182 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
           }
         >
           <View
+            noBottomBorder={true}
             style={
               Array [
                 Object {
+                  "backgroundColor": "#FFFFFF",
                   "width": "100%",
                 },
-                undefined,
+                Object {
+                  "backgroundColor": "transparent",
+                },
               ]
             }
           >
             <View
-              noPadding={true}
+              androidStatusbarHeight={42}
+              onLayout={[Function]}
+              pointerEvents="box-none"
               style={
-                Array [
-                  Object {
-                    "borderBottomWidth": 0,
-                    "paddingBottom": 0,
-                    "paddingLeft": 0,
-                    "paddingRight": 0,
-                    "paddingTop": 0,
-                    "zIndex": 10,
-                  },
-                  undefined,
-                ]
+                Object {
+                  "marginTop": 42,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 20,
+                }
               }
             >
               <View
+                noHorizonatalPadding={true}
                 style={
                   Array [
                     Object {
-                      "alignItems": "flex-end",
-                      "flexDirection": "row",
-                      "height": 50,
-                      "justifyContent": "flex-end",
-                      "marginBottom": 4,
-                      "marginTop": 20,
+                      "minHeight": 58,
+                      "paddingVertical": 15,
+                      "width": "100%",
                     },
                     undefined,
                   ]
                 }
               >
                 <View
-                  flex={[Function]}
-                  showTitleLeft={true}
                   style={
                     Array [
                       Object {
-                        "alignItems": "flex-start",
-                        "alignSelf": "center",
-                        "flex": 1,
-                      },
-                      Object {
-                        "alignItems": "flex-end",
-                        "flexBasis": 0,
-                        "flexGrow": 2,
-                        "flexShrink": 1,
-                        "justifyContent": "flex-start",
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "width": "100%",
                       },
                       undefined,
                     ]
                   }
                 >
                   <View
-                    noMargin={true}
+                    sideFlex={4}
                     style={
                       Array [
                         Object {
-                          "alignSelf": "flex-start",
-                          "marginBottom": 0,
-                          "marginLeft": 0,
-                          "marginRight": 0,
-                          "marginTop": 0,
-                          "position": "relative",
-                          "top": 0,
+                          "alignItems": "center",
+                          "flexBasis": 0,
+                          "flexDirection": "row",
+                          "flexGrow": 4,
+                          "flexShrink": 1,
+                          "flexWrap": "wrap",
+                          "justifyContent": "flex-start",
+                          "minHeight": 28,
                         },
-                        undefined,
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      ellipsizeMode="middle"
-                      numberOfLines={1}
+                    <View
                       style={
-                        Array [
-                          Object {
-                            "color": "#0A1427",
-                            "fontFamily": "EuclidCircularB-Regular",
-                            "textAlignVertical": "center",
-                          },
+                        Object {
+                          "flexDirection": "row",
+                          "flexWrap": "wrap",
+                        }
+                      }
+                    >
+                      <Text
+                        centerText={false}
+                        style={
                           Array [
                             Object {
                               "color": "#0A1427",
-                              "fontFamily": "EuclidCircularB-Medium",
+                              "fontFamily": "EuclidCircularB-Regular",
                               "textAlignVertical": "center",
                             },
                             Array [
                               Object {
-                                "fontSize": 18,
-                                "lineHeight": 28,
+                                "color": "#0A1427",
+                                "fontFamily": "EuclidCircularB-Medium",
+                                "textAlignVertical": "center",
                               },
-                              Object {},
+                              Array [
+                                Object {
+                                  "color": "#0A1427",
+                                  "fontSize": 16,
+                                  "lineHeight": 26,
+                                  "textAlign": "left",
+                                },
+                                Object {},
+                              ],
                             ],
-                          ],
-                        ]
-                      }
-                    >
-                      title
-                    </Text>
+                          ]
+                        }
+                      >
+                        title
+                      </Text>
+                    </View>
                   </View>
-                </View>
-                <View
-                  flex={[Function]}
-                  onClose={[Function]}
-                  style={
-                    Array [
-                      Object {
-                        "alignItems": "flex-end",
-                        "alignSelf": "center",
-                        "flex": 1,
-                      },
-                      Object {
-                        "alignItems": "flex-end",
-                        "flexBasis": 44,
-                        "flexDirection": "row",
-                        "flexGrow": 0,
-                        "flexShrink": 0,
-                        "justifyContent": "flex-end",
-                      },
-                      undefined,
-                    ]
-                  }
-                >
                   <View
                     style={
                       Array [
                         Object {
                           "alignItems": "center",
+                          "flexBasis": 0,
                           "flexDirection": "row",
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "flexWrap": "wrap",
                           "justifyContent": "flex-end",
+                          "minHeight": 28,
                         },
                         undefined,
                       ]
                     }
                   >
                     <View
-                      accessible={true}
-                      isTVSelectable={true}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
                         Object {
-                          "alignItems": "center",
-                          "height": 44,
-                          "justifyContent": "center",
+                          "marginBottom": -20,
+                          "marginLeft": -12,
                           "marginRight": -20,
-                          "opacity": 1,
-                          "paddingBottom": 0,
-                          "paddingLeft": 0,
-                          "paddingRight": 0,
-                          "paddingTop": 0,
-                          "width": 58,
+                          "marginTop": -20,
                         }
                       }
                     >
                       <View
-                        name="close"
+                        accessible={true}
+                        isTVSelectable={true}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
                         style={
                           Object {
-                            "color": "#0A1427",
-                            "fontSize": 16,
-                            "marginBottom": undefined,
-                            "marginLeft": undefined,
-                            "marginRight": undefined,
-                            "marginTop": undefined,
-                            "paddingTop": 0,
+                            "alignItems": "flex-end",
+                            "alignSelf": "center",
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "paddingBottom": 20,
+                            "paddingLeft": 20,
+                            "paddingRight": 20,
+                            "paddingTop": 20,
+                            "position": "relative",
                           }
                         }
-                      />
+                      >
+                        <View
+                          name="close"
+                          style={
+                            Object {
+                              "color": "#0A1427",
+                              "fontSize": 14,
+                              "marginBottom": undefined,
+                              "marginLeft": undefined,
+                              "marginRight": undefined,
+                              "marginTop": undefined,
+                              "paddingTop": 0,
+                            }
+                          }
+                        />
+                      </View>
                     </View>
                   </View>
                 </View>

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -134,7 +134,7 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
           customTheme={
             Object {
               "borderRadius": "30px",
-              "padding": "0 20px",
+              "padding": "0 16px",
             }
           }
           style={
@@ -147,8 +147,8 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
                 "marginTop": "auto",
                 "overflow": "hidden",
                 "paddingBottom": 0,
-                "paddingLeft": 20,
-                "paddingRight": 20,
+                "paddingLeft": 16,
+                "paddingRight": 16,
                 "paddingTop": 0,
                 "shadowColor": "rgba(0,0,0,.1)",
                 "shadowOffset": Object {
@@ -178,15 +178,15 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
           >
             <View
               androidStatusbarHeight={42}
+              noPaddingTop={true}
               onLayout={[Function]}
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginTop": 42,
                   "paddingBottom": 0,
                   "paddingLeft": 0,
                   "paddingRight": 0,
-                  "paddingTop": 20,
+                  "paddingTop": 0,
                 }
               }
             >

--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -436,9 +436,10 @@ class AssetScreen extends React.Component<Props, State> {
           token={assetData.token}
           tokenName={assetData.name}
           handleOpenShareDialog={this.handleOpenShareDialog}
-          showBuyTokensSection
+          showBuyTokensButton
           handleBuyTokens={this.handleBuyTokens}
           onModalHidden={this.handleModalHidden}
+          showErc20Note
         />
         <SlideModal
           title={assetData.name}

--- a/src/screens/Asset/ReceiveModal.js
+++ b/src/screens/Asset/ReceiveModal.js
@@ -157,12 +157,12 @@ export default class ReceiveModal extends React.Component<Props, *> {
             />
           </ButtonsRow>
           {showBuyTokensButton && (
-          <IconsContainer>
-            <Image source={visaIcon} />
-            <IconsSpacing />
-            <Image source={mastercardIcon} />
-          </IconsContainer>
-          }
+            <IconsContainer>
+              <Image source={visaIcon} />
+              <IconsSpacing />
+              <Image source={mastercardIcon} />
+            </IconsContainer>
+          )}
         </ContentWrapper>
       </SlideModal>
     );

--- a/src/screens/Asset/ReceiveModal.js
+++ b/src/screens/Asset/ReceiveModal.js
@@ -18,7 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import * as React from 'react';
-import { Clipboard, View, Image } from 'react-native';
+import { View, Image, Dimensions } from 'react-native';
 import { BaseText } from 'components/Typography';
 import { spacing, fontStyles, fontSizes } from 'utils/variables';
 import styled from 'styled-components/native';
@@ -26,7 +26,6 @@ import SlideModal from 'components/Modals/SlideModal';
 import Button from 'components/Button';
 import WarningBanner from 'components/WarningBanner';
 import QRCodeWithTheme from 'components/QRCode';
-import Toast from 'components/Toast';
 import { LabelBadge } from 'components/LabelBadge';
 import { themedColors } from 'utils/themes';
 
@@ -40,7 +39,7 @@ const BuyTokensWrapper = styled.View`
 `;
 
 const ContentWrapper = styled.View`
-  padding: 0 ${spacing.rhythm}px;
+  padding: 0 ${spacing.layoutSides}px ${spacing.large}px;
   align-items: center;
 `;
 
@@ -53,7 +52,8 @@ type Props = {
   isVisible: boolean,
   handleBuyTokens?: Function,
   onModalHidden?: Function,
-  showBuyTokensSection?: boolean,
+  showBuyTokensButton?: boolean,
+  showErc20Note?: boolean,
 }
 
 const QRCodeWrapper = styled.View`
@@ -68,25 +68,34 @@ const WalletAddress = styled(BaseText)`
 
 const IconsContainer = styled.View`
   flex-direction: row;
-  margin: ${spacing.rhythm}px;
+  margin: 0 ${spacing.layoutSides}px;
+  justify-content: center;
 `;
 
 const IconsSpacing = styled.View`
   width: ${spacing.small}px;
 `;
 
+const ButtonsRow = styled.View`
+  flex-direction: row;
+  margin-top: 40px;
+  margin-bottom: ${spacing.large}px;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const {
+  width: SCREEN_WIDTH,
+} = Dimensions.get('window');
+
+const getButtonWidth = () => {
+  return (SCREEN_WIDTH / 2) - (spacing.layoutSides * 1.5);
+};
+
 const visaIcon = require('assets/icons/visa.png');
 const mastercardIcon = require('assets/icons/mastercard.png');
 
 export default class ReceiveModal extends React.Component<Props, *> {
-  handleAddressClipboardSet = () => {
-    const {
-      address,
-    } = this.props;
-    Clipboard.setString(address);
-    Toast.show({ message: 'Address copied to clipboard', type: 'success', title: 'Success' });
-  };
-
   handleAddressShare = () => {
     const {
       handleOpenShareDialog,
@@ -103,8 +112,13 @@ export default class ReceiveModal extends React.Component<Props, *> {
       onModalHide,
       handleBuyTokens,
       onModalHidden,
-      showBuyTokensSection = false,
+      showBuyTokensButton = false,
+      showErc20Note,
     } = this.props;
+
+    const buttonWidth = showBuyTokensButton ? getButtonWidth() : 0;
+    const needsSmallButtons = showBuyTokensButton && buttonWidth <= 150;
+
     return (
       <SlideModal
         title="Receive"
@@ -112,7 +126,7 @@ export default class ReceiveModal extends React.Component<Props, *> {
         onModalHide={onModalHide}
         onModalHidden={onModalHidden}
         noPadding
-        headerLeftItems={[{
+        headerLeftItems={!!showErc20Note && [{
           custom: (
             <LabelBadge
               label="ERC-20 tokens only"
@@ -130,21 +144,39 @@ export default class ReceiveModal extends React.Component<Props, *> {
             <View
               style={{
                 overflow: 'hidden',
+                padding: 10,
               }}
             >
               <QRCodeWithTheme value={address} size={160} />
             </View>
           </QRCodeWrapper>
-          <Button
-            title="Share Address"
-            onPress={this.handleAddressShare}
-            style={{
-              marginBottom: 20,
-              marginTop: spacing.mediumLarge,
-            }}
-          />
+          <ButtonsRow>
+            {showBuyTokensButton && (
+              <Button
+                title="Buy tokens"
+                onPress={handleBuyTokens}
+                positive
+                width={buttonWidth}
+                small={needsSmallButtons}
+              />
+            )}
+            <Button
+              title="Share Address"
+              onPress={this.handleAddressShare}
+              width={buttonWidth}
+              small={needsSmallButtons}
+              block={!buttonWidth}
+            />
+          </ButtonsRow>
+          {showBuyTokensButton &&
+          <IconsContainer>
+            <Image source={visaIcon} />
+            <IconsSpacing />
+            <Image source={mastercardIcon} />
+          </IconsContainer>
+          }
         </ContentWrapper>
-        {showBuyTokensSection && (
+        {showBuyTokensButton && false && (
           <BuyTokensWrapper>
             <Button
               title="Buy tokens"

--- a/src/screens/Asset/ReceiveModal.js
+++ b/src/screens/Asset/ReceiveModal.js
@@ -156,7 +156,7 @@ export default class ReceiveModal extends React.Component<Props, *> {
               block={!buttonWidth}
             />
           </ButtonsRow>
-          {showBuyTokensButton &&
+          {showBuyTokensButton && (
           <IconsContainer>
             <Image source={visaIcon} />
             <IconsSpacing />

--- a/src/screens/Asset/ReceiveModal.js
+++ b/src/screens/Asset/ReceiveModal.js
@@ -20,13 +20,14 @@
 import * as React from 'react';
 import { Clipboard, View, Image } from 'react-native';
 import { BaseText } from 'components/Typography';
-import { spacing, fontStyles } from 'utils/variables';
+import { spacing, fontStyles, fontSizes } from 'utils/variables';
 import styled from 'styled-components/native';
 import SlideModal from 'components/Modals/SlideModal';
 import Button from 'components/Button';
 import WarningBanner from 'components/WarningBanner';
 import QRCodeWithTheme from 'components/QRCode';
 import Toast from 'components/Toast';
+import { LabelBadge } from 'components/LabelBadge';
 import { themedColors } from 'utils/themes';
 
 const BuyTokensWrapper = styled.View`
@@ -111,6 +112,16 @@ export default class ReceiveModal extends React.Component<Props, *> {
         onModalHide={onModalHide}
         onModalHidden={onModalHidden}
         noPadding
+        headerLeftItems={[{
+          custom: (
+            <LabelBadge
+              label="ERC-20 tokens only"
+              labelStyle={{ fontSize: fontSizes.tiny }}
+              primary
+              containerStyle={{ marginLeft: 8 }}
+            />
+          ),
+        }]}
       >
         <ContentWrapper>
           <WarningBanner rounded small />

--- a/src/screens/Asset/ReceiveModal.js
+++ b/src/screens/Asset/ReceiveModal.js
@@ -27,16 +27,6 @@ import Button from 'components/Button';
 import WarningBanner from 'components/WarningBanner';
 import QRCodeWithTheme from 'components/QRCode';
 import { LabelBadge } from 'components/LabelBadge';
-import { themedColors } from 'utils/themes';
-
-const BuyTokensWrapper = styled.View`
-  background-color: ${themedColors.surface};
-  width: 100%;
-  padding: 20px;
-  border-top-color: ${themedColors.tertiary};
-  border-top-width: 1px;
-  align-items: center;
-`;
 
 const ContentWrapper = styled.View`
   padding: 0 ${spacing.layoutSides}px ${spacing.large}px;
@@ -54,7 +44,7 @@ type Props = {
   onModalHidden?: Function,
   showBuyTokensButton?: boolean,
   showErc20Note?: boolean,
-}
+};
 
 const QRCodeWrapper = styled.View`
   align-items: center;
@@ -84,9 +74,7 @@ const ButtonsRow = styled.View`
   width: 100%;
 `;
 
-const {
-  width: SCREEN_WIDTH,
-} = Dimensions.get('window');
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 const getButtonWidth = () => {
   return (SCREEN_WIDTH / 2) - (spacing.layoutSides * 1.5);
@@ -176,20 +164,6 @@ export default class ReceiveModal extends React.Component<Props, *> {
           </IconsContainer>
           }
         </ContentWrapper>
-        {showBuyTokensButton && false && (
-          <BuyTokensWrapper>
-            <Button
-              title="Buy tokens"
-              onPress={handleBuyTokens}
-              positive
-            />
-            <IconsContainer>
-              <Image source={visaIcon} />
-              <IconsSpacing />
-              <Image source={mastercardIcon} />
-            </IconsContainer>
-          </BuyTokensWrapper>
-        )}
       </SlideModal>
     );
   }

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -1424,6 +1424,70 @@ exports[`Asset renders the Asset correctly 1`] = `
                             Receive
                           </Text>
                         </View>
+                        <View
+                          style={Object {}}
+                        >
+                          <View
+                            containerStyle={
+                              Object {
+                                "marginLeft": 8,
+                              }
+                            }
+                            label="ERC-20 tokens only"
+                            labelStyle={
+                              Object {
+                                "fontSize": 10,
+                              }
+                            }
+                            primary={true}
+                            style={
+                              Array [
+                                Object {
+                                  "alignSelf": "flex-start",
+                                  "backgroundColor": "#007AFF",
+                                  "borderRadius": 12,
+                                  "paddingBottom": 3,
+                                  "paddingLeft": 8,
+                                  "paddingRight": 8,
+                                  "paddingTop": 3,
+                                },
+                                Object {
+                                  "marginLeft": 8,
+                                },
+                              ]
+                            }
+                          >
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#0A1427",
+                                    "fontFamily": "EuclidCircularB-Regular",
+                                    "textAlignVertical": "center",
+                                  },
+                                  Array [
+                                    Object {
+                                      "color": "#0A1427",
+                                      "fontFamily": "EuclidCircularB-Medium",
+                                      "textAlignVertical": "center",
+                                    },
+                                    Array [
+                                      Object {
+                                        "color": "#FCFDFF",
+                                        "fontSize": 8,
+                                      },
+                                      Object {
+                                        "fontSize": 10,
+                                      },
+                                    ],
+                                  ],
+                                ]
+                              }
+                            >
+                              ERC-20 tokens only
+                            </Text>
+                          </View>
+                        </View>
                       </View>
                       <View
                         style={

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -1328,15 +1328,15 @@ exports[`Asset renders the Asset correctly 1`] = `
               >
                 <View
                   androidStatusbarHeight={42}
+                  noPaddingTop={true}
                   onLayout={[Function]}
                   pointerEvents="box-none"
                   style={
                     Object {
-                      "marginTop": 42,
                       "paddingBottom": 0,
                       "paddingLeft": 0,
                       "paddingRight": 0,
-                      "paddingTop": 20,
+                      "paddingTop": 0,
                     }
                   }
                 >
@@ -1575,9 +1575,9 @@ exports[`Asset renders the Asset correctly 1`] = `
                     Array [
                       Object {
                         "alignItems": "center",
-                        "paddingBottom": 0,
-                        "paddingLeft": 20,
-                        "paddingRight": 20,
+                        "paddingBottom": 20,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
                         "paddingTop": 0,
                       },
                       undefined,
@@ -1621,6 +1621,7 @@ exports[`Asset renders the Asset correctly 1`] = `
                       style={
                         Object {
                           "overflow": "hidden",
+                          "padding": 10,
                         }
                       }
                     >
@@ -1888,250 +1889,249 @@ exports[`Asset renders the Asset correctly 1`] = `
                     </View>
                   </View>
                   <View
-                    accessible={true}
-                    isTVSelectable={true}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
                     style={
-                      Object {
-                        "alignItems": "center",
-                        "alignSelf": "auto",
-                        "backgroundColor": "#007AFF",
-                        "borderColor": "#007AFF",
-                        "borderRadius": 6,
-                        "borderStyle": "solid",
-                        "borderWidth": 0,
-                        "elevation": 1,
-                        "flexDirection": "row",
-                        "height": 56,
-                        "justifyContent": "center",
-                        "marginBottom": 20,
-                        "marginLeft": 0,
-                        "marginRight": 0,
-                        "marginTop": 16,
-                        "opacity": 1,
-                        "paddingBottom": 0,
-                        "paddingLeft": 30,
-                        "paddingRight": 30,
-                        "paddingTop": 0,
-                        "shadowColor": "rgba(0,0,0,.12)",
-                        "shadowOffset": Object {
-                          "height": 2,
-                          "width": 0,
+                      Array [
+                        Object {
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                          "marginBottom": 20,
+                          "marginTop": 40,
+                          "width": "100%",
                         },
-                        "shadowOpacity": 1,
-                        "shadowRadius": 7,
-                        "width": "auto",
-                      }
+                        undefined,
+                      ]
                     }
                   >
-                    <Text
-                      customTheme={
+                    <View
+                      accessible={true}
+                      isTVSelectable={true}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
                         Object {
+                          "alignItems": "center",
+                          "alignSelf": "auto",
+                          "backgroundColor": "#2AA057",
+                          "borderColor": "#EDEDED",
+                          "borderRadius": 6,
+                          "borderStyle": "solid",
                           "borderWidth": 0,
-                          "shadow": true,
+                          "flexDirection": "row",
+                          "height": 56,
+                          "justifyContent": "center",
+                          "marginBottom": 0,
+                          "marginLeft": 0,
+                          "marginRight": 0,
+                          "marginTop": 0,
+                          "opacity": 1,
+                          "paddingBottom": 0,
+                          "paddingLeft": 22,
+                          "paddingRight": 22,
+                          "paddingTop": 0,
+                          "width": 351,
                         }
                       }
-                      style={
-                        Array [
+                    >
+                      <Text
+                        customTheme={
                           Object {
-                            "color": "#0A1427",
-                            "fontFamily": "EuclidCircularB-Regular",
-                            "fontSize": 12,
-                            "lineHeight": 18,
-                            "textAlignVertical": "center",
-                          },
+                            "borderWidth": 0,
+                          }
+                        }
+                        small={false}
+                        style={
                           Array [
                             Object {
                               "color": "#0A1427",
-                              "fontFamily": "EuclidCircularB-Medium",
+                              "fontFamily": "EuclidCircularB-Regular",
                               "fontSize": 12,
                               "lineHeight": 18,
                               "textAlignVertical": "center",
                             },
                             Array [
                               Object {
-                                "color": "#FCFDFF",
-                                "fontSize": 18,
-                                "marginBottom": 0,
+                                "color": "#0A1427",
+                                "fontFamily": "EuclidCircularB-Medium",
+                                "fontSize": 12,
+                                "lineHeight": 18,
+                                "textAlignVertical": "center",
                               },
-                              undefined,
+                              Array [
+                                Object {
+                                  "color": "#FCFDFF",
+                                  "fontSize": 18,
+                                  "marginBottom": 0,
+                                },
+                                undefined,
+                              ],
                             ],
-                          ],
-                        ]
-                      }
-                      theme={
+                          ]
+                        }
+                        theme={
+                          Object {
+                            "colors": Object {
+                              "PPNSurface": "#0a0c78",
+                              "PPNText": "#f33726",
+                              "accent": "#818EB3",
+                              "bitcoinWallet": "#F79319",
+                              "border": "#EDEDED",
+                              "card": "#FFFFFF",
+                              "control": "#FCFDFF",
+                              "danger": "#ff0005",
+                              "indicator": "#F8E71C",
+                              "legacyWallet": "#FA574F",
+                              "navbarItems": "#D4D9DB",
+                              "negative": "#BD573A",
+                              "orange": "#f57c00",
+                              "positive": "#2AA057",
+                              "primary": "#007AFF",
+                              "secondaryAccent": "#EBF0F5",
+                              "secondaryText": "#8B939E",
+                              "smartWallet": "#3C71FE",
+                              "smartWalletSurface": "#f3f7ff",
+                              "smartWalletText": "#1D24D8",
+                              "surface": "#2AA057",
+                              "tertiary": "#EBF0F6",
+                              "text": "#FCFDFF",
+                              "userAvatar": "#d1d9e4",
+                              "warning": "#ECA93A",
+                            },
+                            "current": "lightTheme",
+                          }
+                        }
+                      >
+                        Buy tokens
+                      </Text>
+                    </View>
+                    <View
+                      accessible={true}
+                      isTVSelectable={true}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
                         Object {
-                          "colors": Object {
-                            "PPNSurface": "#0a0c78",
-                            "PPNText": "#f33726",
-                            "accent": "#818EB3",
-                            "bitcoinWallet": "#F79319",
-                            "border": "#007AFF",
-                            "card": "#FFFFFF",
-                            "control": "#FCFDFF",
-                            "danger": "#ff0005",
-                            "indicator": "#F8E71C",
-                            "legacyWallet": "#FA574F",
-                            "navbarItems": "#D4D9DB",
-                            "negative": "#BD573A",
-                            "orange": "#f57c00",
-                            "positive": "#2AA057",
-                            "primary": "#007AFF",
-                            "secondaryAccent": "#EBF0F5",
-                            "secondaryText": "#8B939E",
-                            "smartWallet": "#3C71FE",
-                            "smartWalletSurface": "#f3f7ff",
-                            "smartWalletText": "#1D24D8",
-                            "surface": "#007AFF",
-                            "tertiary": "#EBF0F6",
-                            "text": "#FCFDFF",
-                            "userAvatar": "#d1d9e4",
-                            "warning": "#ECA93A",
+                          "alignItems": "center",
+                          "alignSelf": "auto",
+                          "backgroundColor": "#007AFF",
+                          "borderColor": "#007AFF",
+                          "borderRadius": 6,
+                          "borderStyle": "solid",
+                          "borderWidth": 0,
+                          "elevation": 1,
+                          "flexDirection": "row",
+                          "height": 56,
+                          "justifyContent": "center",
+                          "marginBottom": 0,
+                          "marginLeft": 0,
+                          "marginRight": 0,
+                          "marginTop": 0,
+                          "opacity": 1,
+                          "paddingBottom": 0,
+                          "paddingLeft": 22,
+                          "paddingRight": 22,
+                          "paddingTop": 0,
+                          "shadowColor": "rgba(0,0,0,.12)",
+                          "shadowOffset": Object {
+                            "height": 2,
+                            "width": 0,
                           },
-                          "current": "lightTheme",
+                          "shadowOpacity": 1,
+                          "shadowRadius": 7,
+                          "width": 351,
                         }
                       }
                     >
-                      Share Address
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  style={
-                    Array [
-                      Object {
-                        "alignItems": "center",
-                        "backgroundColor": "#FAFAFA",
-                        "borderTopColor": "#EBF0F6",
-                        "borderTopWidth": 1,
-                        "paddingBottom": 20,
-                        "paddingLeft": 20,
-                        "paddingRight": 20,
-                        "paddingTop": 20,
-                        "width": "100%",
-                      },
-                      undefined,
-                    ]
-                  }
-                >
-                  <View
-                    accessible={true}
-                    isTVSelectable={true}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "alignSelf": "auto",
-                        "backgroundColor": "#2AA057",
-                        "borderColor": "#EDEDED",
-                        "borderRadius": 6,
-                        "borderStyle": "solid",
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "height": 56,
-                        "justifyContent": "center",
-                        "marginBottom": 0,
-                        "marginLeft": 0,
-                        "marginRight": 0,
-                        "marginTop": 0,
-                        "opacity": 1,
-                        "paddingBottom": 0,
-                        "paddingLeft": 30,
-                        "paddingRight": 30,
-                        "paddingTop": 0,
-                        "width": "auto",
-                      }
-                    }
-                  >
-                    <Text
-                      customTheme={
-                        Object {
-                          "borderWidth": 0,
-                        }
-                      }
-                      style={
-                        Array [
+                      <Text
+                        customTheme={
                           Object {
-                            "color": "#0A1427",
-                            "fontFamily": "EuclidCircularB-Regular",
-                            "fontSize": 12,
-                            "lineHeight": 18,
-                            "textAlignVertical": "center",
-                          },
+                            "borderWidth": 0,
+                            "shadow": true,
+                          }
+                        }
+                        small={false}
+                        style={
                           Array [
                             Object {
                               "color": "#0A1427",
-                              "fontFamily": "EuclidCircularB-Medium",
+                              "fontFamily": "EuclidCircularB-Regular",
                               "fontSize": 12,
                               "lineHeight": 18,
                               "textAlignVertical": "center",
                             },
                             Array [
                               Object {
-                                "color": "#FCFDFF",
-                                "fontSize": 18,
-                                "marginBottom": 0,
+                                "color": "#0A1427",
+                                "fontFamily": "EuclidCircularB-Medium",
+                                "fontSize": 12,
+                                "lineHeight": 18,
+                                "textAlignVertical": "center",
                               },
-                              undefined,
+                              Array [
+                                Object {
+                                  "color": "#FCFDFF",
+                                  "fontSize": 18,
+                                  "marginBottom": 0,
+                                },
+                                undefined,
+                              ],
                             ],
-                          ],
-                        ]
-                      }
-                      theme={
-                        Object {
-                          "colors": Object {
-                            "PPNSurface": "#0a0c78",
-                            "PPNText": "#f33726",
-                            "accent": "#818EB3",
-                            "bitcoinWallet": "#F79319",
-                            "border": "#EDEDED",
-                            "card": "#FFFFFF",
-                            "control": "#FCFDFF",
-                            "danger": "#ff0005",
-                            "indicator": "#F8E71C",
-                            "legacyWallet": "#FA574F",
-                            "navbarItems": "#D4D9DB",
-                            "negative": "#BD573A",
-                            "orange": "#f57c00",
-                            "positive": "#2AA057",
-                            "primary": "#007AFF",
-                            "secondaryAccent": "#EBF0F5",
-                            "secondaryText": "#8B939E",
-                            "smartWallet": "#3C71FE",
-                            "smartWalletSurface": "#f3f7ff",
-                            "smartWalletText": "#1D24D8",
-                            "surface": "#2AA057",
-                            "tertiary": "#EBF0F6",
-                            "text": "#FCFDFF",
-                            "userAvatar": "#d1d9e4",
-                            "warning": "#ECA93A",
-                          },
-                          "current": "lightTheme",
+                          ]
                         }
-                      }
-                    >
-                      Buy tokens
-                    </Text>
+                        theme={
+                          Object {
+                            "colors": Object {
+                              "PPNSurface": "#0a0c78",
+                              "PPNText": "#f33726",
+                              "accent": "#818EB3",
+                              "bitcoinWallet": "#F79319",
+                              "border": "#007AFF",
+                              "card": "#FFFFFF",
+                              "control": "#FCFDFF",
+                              "danger": "#ff0005",
+                              "indicator": "#F8E71C",
+                              "legacyWallet": "#FA574F",
+                              "navbarItems": "#D4D9DB",
+                              "negative": "#BD573A",
+                              "orange": "#f57c00",
+                              "positive": "#2AA057",
+                              "primary": "#007AFF",
+                              "secondaryAccent": "#EBF0F5",
+                              "secondaryText": "#8B939E",
+                              "smartWallet": "#3C71FE",
+                              "smartWalletSurface": "#f3f7ff",
+                              "smartWalletText": "#1D24D8",
+                              "surface": "#007AFF",
+                              "tertiary": "#EBF0F6",
+                              "text": "#FCFDFF",
+                              "userAvatar": "#d1d9e4",
+                              "warning": "#ECA93A",
+                            },
+                            "current": "lightTheme",
+                          }
+                        }
+                      >
+                        Share Address
+                      </Text>
+                    </View>
                   </View>
                   <View
                     style={
                       Array [
                         Object {
                           "flexDirection": "row",
-                          "marginBottom": 20,
-                          "marginLeft": 20,
-                          "marginRight": 20,
-                          "marginTop": 20,
+                          "justifyContent": "center",
+                          "marginBottom": 0,
+                          "marginLeft": 16,
+                          "marginRight": 16,
+                          "marginTop": 0,
                         },
                         undefined,
                       ]
@@ -2569,7 +2569,7 @@ exports[`Asset renders the Asset correctly 1`] = `
               customTheme={
                 Object {
                   "borderRadius": "30px",
-                  "padding": "0 20px",
+                  "padding": "0 16px",
                 }
               }
               style={
@@ -2582,8 +2582,8 @@ exports[`Asset renders the Asset correctly 1`] = `
                     "marginTop": "auto",
                     "overflow": "hidden",
                     "paddingBottom": 0,
-                    "paddingLeft": 20,
-                    "paddingRight": 20,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
                     "paddingTop": 0,
                     "shadowColor": "rgba(0,0,0,.1)",
                     "shadowOffset": Object {
@@ -2613,15 +2613,15 @@ exports[`Asset renders the Asset correctly 1`] = `
               >
                 <View
                   androidStatusbarHeight={42}
+                  noPaddingTop={true}
                   onLayout={[Function]}
                   pointerEvents="box-none"
                   style={
                     Object {
-                      "marginTop": 42,
                       "paddingBottom": 0,
                       "paddingLeft": 0,
                       "paddingRight": 0,
-                      "paddingTop": 20,
+                      "paddingTop": 0,
                     }
                   }
                 >
@@ -2652,14 +2652,14 @@ exports[`Asset renders the Asset correctly 1`] = `
                       }
                     >
                       <View
-                        sideFlex={null}
+                        sideFlex={4}
                         style={
                           Array [
                             Object {
                               "alignItems": "center",
                               "flexBasis": 0,
                               "flexDirection": "row",
-                              "flexGrow": 1,
+                              "flexGrow": 4,
                               "flexShrink": 1,
                               "flexWrap": "wrap",
                               "justifyContent": "flex-start",

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -79,44 +79,53 @@ exports[`Asset renders the Asset correctly 1`] = `
             }
           >
             <View
-              accessible={true}
-              isTVSelectable={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "alignItems": "flex-start",
-                  "height": 24,
-                  "justifyContent": "center",
-                  "marginLeft": -12,
-                  "opacity": 1,
-                  "paddingBottom": 0,
-                  "paddingLeft": 10,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                  "position": "relative",
-                  "width": 44,
+                  "marginBottom": -20,
+                  "marginTop": -20,
                 }
               }
             >
               <View
-                name="back"
+                accessible={true}
+                isTVSelectable={true}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "color": "#0A1427",
-                    "fontSize": 24,
-                    "marginBottom": undefined,
-                    "marginLeft": undefined,
-                    "marginRight": undefined,
-                    "marginTop": undefined,
+                    "alignItems": "flex-start",
+                    "height": 44,
+                    "justifyContent": "center",
+                    "marginLeft": -12,
+                    "opacity": 1,
+                    "paddingBottom": 0,
+                    "paddingLeft": 10,
+                    "paddingRight": 0,
                     "paddingTop": 0,
+                    "position": "relative",
+                    "width": 44,
                   }
                 }
-              />
+              >
+                <View
+                  name="back"
+                  style={
+                    Object {
+                      "color": "#0A1427",
+                      "fontSize": 24,
+                      "marginBottom": undefined,
+                      "marginLeft": undefined,
+                      "marginRight": undefined,
+                      "marginTop": undefined,
+                      "paddingTop": 0,
+                    }
+                  }
+                />
+              </View>
             </View>
           </View>
           <View

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -40,10 +40,8 @@ exports[`Asset renders the Asset correctly 1`] = `
           Array [
             Object {
               "minHeight": 58,
-              "paddingBottom": 15,
-              "paddingLeft": 16,
-              "paddingRight": 16,
-              "paddingTop": 15,
+              "paddingHorizontal": 16,
+              "paddingVertical": 15,
               "width": "100%",
             },
             undefined,
@@ -1297,6 +1295,7 @@ exports[`Asset renders the Asset correctly 1`] = `
                     "borderTopRightRadius": 30,
                     "elevation": 1,
                     "marginTop": "auto",
+                    "overflow": "hidden",
                     "paddingBottom": 0,
                     "paddingLeft": 0,
                     "paddingRight": 0,
@@ -1314,187 +1313,183 @@ exports[`Asset renders the Asset correctly 1`] = `
               }
             >
               <View
+                noBottomBorder={true}
                 style={
                   Array [
                     Object {
+                      "backgroundColor": "#FFFFFF",
                       "width": "100%",
                     },
-                    undefined,
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
                   ]
                 }
               >
                 <View
-                  noPadding={false}
+                  androidStatusbarHeight={42}
+                  onLayout={[Function]}
+                  pointerEvents="box-none"
                   style={
-                    Array [
-                      Object {
-                        "borderBottomWidth": 0,
-                        "paddingBottom": 0,
-                        "paddingLeft": 16,
-                        "paddingRight": 16,
-                        "paddingTop": 0,
-                        "zIndex": 10,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "marginTop": 42,
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 20,
+                    }
                   }
                 >
                   <View
+                    noHorizonatalPadding={false}
                     style={
                       Array [
                         Object {
-                          "alignItems": "flex-end",
-                          "flexDirection": "row",
-                          "height": 50,
-                          "justifyContent": "flex-end",
-                          "marginBottom": 4,
-                          "marginTop": 20,
+                          "minHeight": 58,
+                          "paddingHorizontal": 16,
+                          "paddingVertical": 15,
+                          "width": "100%",
                         },
                         undefined,
                       ]
                     }
                   >
                     <View
-                      flex={[Function]}
-                      showTitleLeft={true}
                       style={
                         Array [
                           Object {
-                            "alignItems": "flex-start",
-                            "alignSelf": "center",
-                            "flex": 1,
-                          },
-                          Object {
-                            "alignItems": "flex-end",
-                            "flexBasis": 0,
-                            "flexGrow": 2,
-                            "flexShrink": 1,
-                            "justifyContent": "flex-start",
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
                           },
                           undefined,
                         ]
                       }
                     >
                       <View
-                        noMargin={true}
+                        sideFlex={4}
                         style={
                           Array [
                             Object {
-                              "alignSelf": "flex-start",
-                              "marginBottom": 0,
-                              "marginLeft": 0,
-                              "marginRight": 0,
-                              "marginTop": 0,
-                              "position": "relative",
-                              "top": 0,
+                              "alignItems": "center",
+                              "flexBasis": 0,
+                              "flexDirection": "row",
+                              "flexGrow": 4,
+                              "flexShrink": 1,
+                              "flexWrap": "wrap",
+                              "justifyContent": "flex-start",
+                              "minHeight": 28,
                             },
-                            undefined,
+                            Object {},
                           ]
                         }
                       >
-                        <Text
-                          ellipsizeMode="middle"
-                          numberOfLines={1}
+                        <View
                           style={
-                            Array [
-                              Object {
-                                "color": "#0A1427",
-                                "fontFamily": "EuclidCircularB-Regular",
-                                "textAlignVertical": "center",
-                              },
+                            Object {
+                              "flexDirection": "row",
+                              "flexWrap": "wrap",
+                            }
+                          }
+                        >
+                          <Text
+                            centerText={false}
+                            style={
                               Array [
                                 Object {
                                   "color": "#0A1427",
-                                  "fontFamily": "EuclidCircularB-Medium",
+                                  "fontFamily": "EuclidCircularB-Regular",
                                   "textAlignVertical": "center",
                                 },
                                 Array [
                                   Object {
-                                    "fontSize": 18,
-                                    "lineHeight": 28,
+                                    "color": "#0A1427",
+                                    "fontFamily": "EuclidCircularB-Medium",
+                                    "textAlignVertical": "center",
                                   },
-                                  Object {},
+                                  Array [
+                                    Object {
+                                      "color": "#0A1427",
+                                      "fontSize": 16,
+                                      "lineHeight": 26,
+                                      "textAlign": "left",
+                                    },
+                                    Object {},
+                                  ],
                                 ],
-                              ],
-                            ]
-                          }
-                        >
-                          Receive
-                        </Text>
+                              ]
+                            }
+                          >
+                            Receive
+                          </Text>
+                        </View>
                       </View>
-                    </View>
-                    <View
-                      flex={[Function]}
-                      onClose={[Function]}
-                      style={
-                        Array [
-                          Object {
-                            "alignItems": "flex-end",
-                            "alignSelf": "center",
-                            "flex": 1,
-                          },
-                          Object {
-                            "alignItems": "flex-end",
-                            "flexBasis": 44,
-                            "flexDirection": "row",
-                            "flexGrow": 0,
-                            "flexShrink": 0,
-                            "justifyContent": "flex-end",
-                          },
-                          undefined,
-                        ]
-                      }
-                    >
                       <View
                         style={
                           Array [
                             Object {
                               "alignItems": "center",
+                              "flexBasis": 0,
                               "flexDirection": "row",
+                              "flexGrow": 1,
+                              "flexShrink": 1,
+                              "flexWrap": "wrap",
                               "justifyContent": "flex-end",
+                              "minHeight": 28,
                             },
                             undefined,
                           ]
                         }
                       >
                         <View
-                          accessible={true}
-                          isTVSelectable={true}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
                           style={
                             Object {
-                              "alignItems": "center",
-                              "height": 44,
-                              "justifyContent": "center",
+                              "marginBottom": -20,
+                              "marginLeft": -12,
                               "marginRight": -20,
-                              "opacity": 1,
-                              "paddingBottom": 0,
-                              "paddingLeft": 0,
-                              "paddingRight": 0,
-                              "paddingTop": 0,
-                              "width": 58,
+                              "marginTop": -20,
                             }
                           }
                         >
                           <View
-                            name="close"
+                            accessible={true}
+                            isTVSelectable={true}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
                             style={
                               Object {
-                                "color": "#0A1427",
-                                "fontSize": 16,
-                                "marginBottom": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginTop": undefined,
-                                "paddingTop": 0,
+                                "alignItems": "flex-end",
+                                "alignSelf": "center",
+                                "justifyContent": "center",
+                                "opacity": 1,
+                                "paddingBottom": 20,
+                                "paddingLeft": 20,
+                                "paddingRight": 20,
+                                "paddingTop": 20,
+                                "position": "relative",
                               }
                             }
-                          />
+                          >
+                            <View
+                              name="close"
+                              style={
+                                Object {
+                                  "color": "#0A1427",
+                                  "fontSize": 14,
+                                  "marginBottom": undefined,
+                                  "marginLeft": undefined,
+                                  "marginRight": undefined,
+                                  "marginTop": undefined,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            />
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -2521,6 +2516,7 @@ exports[`Asset renders the Asset correctly 1`] = `
                     "borderTopRightRadius": 30,
                     "elevation": 1,
                     "marginTop": "auto",
+                    "overflow": "hidden",
                     "paddingBottom": 0,
                     "paddingLeft": 20,
                     "paddingRight": 20,
@@ -2538,185 +2534,142 @@ exports[`Asset renders the Asset correctly 1`] = `
               }
             >
               <View
+                noBottomBorder={true}
                 style={
                   Array [
                     Object {
+                      "backgroundColor": "#FFFFFF",
                       "width": "100%",
                     },
-                    undefined,
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
                   ]
                 }
               >
                 <View
-                  noPadding={true}
+                  androidStatusbarHeight={42}
+                  onLayout={[Function]}
+                  pointerEvents="box-none"
                   style={
-                    Array [
-                      Object {
-                        "borderBottomWidth": 0,
-                        "paddingBottom": 0,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 0,
-                        "zIndex": 10,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "marginTop": 42,
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 20,
+                    }
                   }
                 >
                   <View
+                    noHorizonatalPadding={true}
                     style={
                       Array [
                         Object {
-                          "alignItems": "flex-end",
-                          "flexDirection": "row",
-                          "height": 50,
-                          "justifyContent": "flex-end",
-                          "marginBottom": 4,
-                          "marginTop": 20,
+                          "minHeight": 58,
+                          "paddingVertical": 15,
+                          "width": "100%",
                         },
                         undefined,
                       ]
                     }
                   >
                     <View
-                      flex={[Function]}
-                      showTitleLeft={true}
                       style={
                         Array [
                           Object {
-                            "alignItems": "flex-start",
-                            "alignSelf": "center",
-                            "flex": 1,
-                          },
-                          Object {
-                            "alignItems": "flex-end",
-                            "flexBasis": 0,
-                            "flexGrow": 2,
-                            "flexShrink": 1,
-                            "justifyContent": "flex-start",
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
                           },
                           undefined,
                         ]
                       }
                     >
                       <View
-                        noMargin={true}
+                        sideFlex={null}
                         style={
                           Array [
                             Object {
-                              "alignSelf": "flex-start",
-                              "marginBottom": 0,
-                              "marginLeft": 0,
-                              "marginRight": 0,
-                              "marginTop": 0,
-                              "position": "relative",
-                              "top": 0,
+                              "alignItems": "center",
+                              "flexBasis": 0,
+                              "flexDirection": "row",
+                              "flexGrow": 1,
+                              "flexShrink": 1,
+                              "flexWrap": "wrap",
+                              "justifyContent": "flex-start",
+                              "minHeight": 28,
                             },
-                            undefined,
+                            Object {},
                           ]
                         }
-                      >
-                        <Text
-                          ellipsizeMode="middle"
-                          numberOfLines={1}
-                          style={
-                            Array [
-                              Object {
-                                "color": "#0A1427",
-                                "fontFamily": "EuclidCircularB-Regular",
-                                "textAlignVertical": "center",
-                              },
-                              Array [
-                                Object {
-                                  "color": "#0A1427",
-                                  "fontFamily": "EuclidCircularB-Medium",
-                                  "textAlignVertical": "center",
-                                },
-                                Array [
-                                  Object {
-                                    "fontSize": 18,
-                                    "lineHeight": 28,
-                                  },
-                                  Object {},
-                                ],
-                              ],
-                            ]
-                          }
-                        />
-                      </View>
-                    </View>
-                    <View
-                      flex={[Function]}
-                      onClose={[Function]}
-                      style={
-                        Array [
-                          Object {
-                            "alignItems": "flex-end",
-                            "alignSelf": "center",
-                            "flex": 1,
-                          },
-                          Object {
-                            "alignItems": "flex-end",
-                            "flexBasis": 44,
-                            "flexDirection": "row",
-                            "flexGrow": 0,
-                            "flexShrink": 0,
-                            "justifyContent": "flex-end",
-                          },
-                          undefined,
-                        ]
-                      }
-                    >
+                      />
                       <View
                         style={
                           Array [
                             Object {
                               "alignItems": "center",
+                              "flexBasis": 0,
                               "flexDirection": "row",
+                              "flexGrow": 1,
+                              "flexShrink": 1,
+                              "flexWrap": "wrap",
                               "justifyContent": "flex-end",
+                              "minHeight": 28,
                             },
                             undefined,
                           ]
                         }
                       >
                         <View
-                          accessible={true}
-                          isTVSelectable={true}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
                           style={
                             Object {
-                              "alignItems": "center",
-                              "height": 44,
-                              "justifyContent": "center",
+                              "marginBottom": -20,
+                              "marginLeft": -12,
                               "marginRight": -20,
-                              "opacity": 1,
-                              "paddingBottom": 0,
-                              "paddingLeft": 0,
-                              "paddingRight": 0,
-                              "paddingTop": 0,
-                              "width": 58,
+                              "marginTop": -20,
                             }
                           }
                         >
                           <View
-                            name="close"
+                            accessible={true}
+                            isTVSelectable={true}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
                             style={
                               Object {
-                                "color": "#0A1427",
-                                "fontSize": 16,
-                                "marginBottom": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginTop": undefined,
-                                "paddingTop": 0,
+                                "alignItems": "flex-end",
+                                "alignSelf": "center",
+                                "justifyContent": "center",
+                                "opacity": 1,
+                                "paddingBottom": 20,
+                                "paddingLeft": 20,
+                                "paddingRight": 20,
+                                "paddingTop": 20,
+                                "position": "relative",
                               }
                             }
-                          />
+                          >
+                            <View
+                              name="close"
+                              style={
+                                Object {
+                                  "color": "#0A1427",
+                                  "fontSize": 14,
+                                  "marginBottom": undefined,
+                                  "marginLeft": undefined,
+                                  "marginRight": undefined,
+                                  "marginTop": undefined,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            />
+                          </View>
                         </View>
                       </View>
                     </View>

--- a/src/screens/Contact/ConnectionConfirmationModal.js
+++ b/src/screens/Contact/ConnectionConfirmationModal.js
@@ -19,7 +19,7 @@
 */
 
 import * as React from 'react';
-import { withTheme } from 'styled-components';
+import capitalize from 'lodash.capitalize';
 
 // constants
 import {
@@ -33,18 +33,13 @@ import {
 // components
 import SlideModal from 'components/Modals/SlideModal';
 import Button from 'components/Button';
-
-// utils
-import { fontSizes, lineHeights } from 'utils/variables';
-import { getThemeColors } from 'utils/themes';
-
-import type { Theme } from 'models/Theme';
+import { Paragraph } from 'components/Typography';
 
 /* eslint max-len:0 */
 const subtitleDescription = {
-  block: `You will no longer be able to find this user, chat, and make any transactions.
-  Your chat history will be erased on your device. No notifications on this user's actions will be received.
-  This user will not  be able to see any of your activity. You can unblock the user from your blocked list.`,
+  block: 'You will no longer be able to find this user, chat, and make any transactions.\n' +
+"Your chat history will be erased on your device. No notifications on this user's actions will be received.\n" +
+'This user will not be able to see any of your activity. \nYou can unblock the user from your blocked list.',
   disconnect: 'After disconnecting you will no longer be able to chat and send assets. You can re-establish connection later.',
   mute: 'If you mute the user, you will not longer be able to receive notifications for chat or transactions. You can unmute later.',
   unmute: 'If you unmute the user, you will be able to receive notifications for chat and transactions.',
@@ -54,7 +49,7 @@ const subtitleDescription = {
 const titleConfirmation = (manageContactType: string, username: string) => {
   const contactType = manageContactType;
   const usernameToConfirm = username;
-  return `${contactType} ${contactType === DISCONNECT ? 'from' : ''} ${usernameToConfirm}`;
+  return `${capitalize(contactType)} ${contactType === DISCONNECT ? 'from' : ''} ${usernameToConfirm}`;
 };
 
 type Props = {
@@ -63,7 +58,6 @@ type Props = {
   showConfirmationModal: boolean,
   manageContactType: string,
   contact: Object,
-  theme: Theme,
 };
 
 const ConnectionConfirmationModal = (props: Props) => {
@@ -73,9 +67,7 @@ const ConnectionConfirmationModal = (props: Props) => {
     showConfirmationModal,
     manageContactType,
     contact,
-    theme,
   } = props;
-  const colors = getThemeColors(theme);
 
   const { username, status } = contact;
   let contactType = manageContactType;
@@ -92,19 +84,11 @@ const ConnectionConfirmationModal = (props: Props) => {
       isVisible={showConfirmationModal}
       onModalHide={onModalHide}
       title={titleConfirmation(contactType, username)}
-      fullWidthTitle
-      noWrapTitle
       noClose
-      subtitle={subtitle}
-      subtitleStyles={{
-        color: colors.secondaryText,
-        fontSize: fontSizes.medium,
-        lineHeight: lineHeights.medium,
-        letterSpacing: 0.1,
-        marginTop: 7,
-        marginBottom: 22,
-      }}
     >
+      <Paragraph small light style={{ marginTop: 7, marginBottom: 22 }}>
+        {subtitle}
+      </Paragraph>
       <Button
         dangerInverted
         title={`Confirm ${contactType}`}
@@ -125,4 +109,4 @@ const ConnectionConfirmationModal = (props: Props) => {
   );
 };
 
-export default withTheme(ConnectionConfirmationModal);
+export default ConnectionConfirmationModal;

--- a/src/screens/Contact/Contact.js
+++ b/src/screens/Contact/Contact.js
@@ -449,6 +449,7 @@ class Contact extends React.Component<Props, State> {
                     fontIcon="chat"
                     onPress={() => navigation.navigate(CHAT, { username: contactUsername, backTo: CONTACT })}
                     showIndicator={!!unreadChats.length}
+                    fontIconStyle={{ fontSize: 20 }}
                   />
                 </CircleButtonsWrapper>
                 {disableSend &&

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -38,6 +38,8 @@ import BadgeTouchableItem from 'components/BadgeTouchableItem';
 import PortfolioBalance from 'components/PortfolioBalance';
 import EmptyStateParagraph from 'components/EmptyState/EmptyStateParagraph';
 import Toast from 'components/Toast';
+import HeaderTitleText from 'components/HeaderBlock/HeaderTitleText';
+import ProfileImage from 'components/ProfileImage';
 
 // constants
 import { defaultFiatCurrency } from 'constants/assetsConstants';
@@ -45,6 +47,7 @@ import {
   MANAGE_DETAILS_SESSIONS,
   BADGE,
   SETTINGS,
+  MANAGE_USERS_FLOW,
 } from 'constants/navigationConstants';
 import { ALL, TRANSACTIONS, SOCIAL } from 'constants/activityConstants';
 import { TRANSACTION_EVENT } from 'constants/historyConstants';
@@ -91,6 +94,7 @@ import type { Connector } from 'models/WalletConnect';
 import type { UserEvent } from 'models/userEvent';
 import type { Theme } from 'models/Theme';
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
+
 
 type Props = {
   navigation: NavigationScreenProp<*>,
@@ -160,6 +164,23 @@ const BadgesWrapper = styled.View`
 const EmptyStateWrapper = styled.View`
   margin: 20px 0 30px;
 `;
+
+const User = ({ user, navigation }) => {
+  const userImageUri = user.profileImage ? `${user.profileImage}?t=${user.lastUpdateTime || 0}` : null;
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <ProfileImage
+        uri={userImageUri}
+        userName={user.username}
+        diameter={24}
+        noShadow
+        borderWidth={0}
+        onPress={() => { navigation.navigate(MANAGE_USERS_FLOW); }}
+      />
+      <HeaderTitleText style={{ marginLeft: 8 }}>{user.username}</HeaderTitleText>
+    </View>
+  );
+};
 
 class HomeScreen extends React.Component<Props, State> {
   _willFocus: NavigationEventSubscription;
@@ -312,6 +333,7 @@ class HomeScreen extends React.Component<Props, State> {
       theme,
       baseFiatCurrency,
       activeBlockchainNetwork,
+      user,
     } = this.props;
     const colors = getThemeColors(theme);
 
@@ -394,7 +416,7 @@ class HomeScreen extends React.Component<Props, State> {
       <ContainerWithHeader
         backgroundColor={colors.card}
         headerProps={{
-          leftItems: [{ user: true }],
+          leftItems: [{ custom: <User user={user} navigation={navigation} /> }],
           rightItems: [
             {
               link: 'Settings',


### PR DESCRIPTION
This PR:
1. Adds ERC20 support note on receive modal (PIL-268)
I've reused HeaderBlock on SlideModals in order to allow passing in custom components to SlideHeader. 
While at it, I've removed user component form HeaderBlock, since it is no longer used on almost each screen as it was initially planned. I've passed it as a custom prop on Home screen.
Also, I've slightly altered ConnectionConfirmationModal since it was the only modal that used subtitle. I've changed it into paragraph.

2. Increases back button's clickable area (PIL-282).


