### PR TITLE
Fix/bump tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            export buildNumber="$(cat /tmp/workspace/build-num/app_version.txt.txt)"
+            export buildNumber="$(cat /tmp/workspace/build-num/app_version.txt)"
             rm .env
             cp environments/.env.production ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,9 +322,12 @@ jobs:
           name: Fetch and set the latest GitHub tag
           command: |
             TAG_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+            APP_VERSION=${TAG_VERSION#?}
             cd /tmp/workspace/build-num
             echo $TAG_VERSION
+            echo $APP_VERSION
             echo $TAG_VERSION > gh_tag_version.txt
+            echo $APP_VERSION > app_version.txt
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -348,7 +351,7 @@ jobs:
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            export buildNumber="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            export buildNumber="$(cat /tmp/workspace/build-num/app_version.txt.txt)"
             rm .env
             cp environments/.env.production ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
@@ -425,26 +428,26 @@ jobs:
            name: Announce Prod Builds
            command: |
              chmod +x .circleci/announceProdBuilds.sh
-             .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+             .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
            name: Announce Deployment
            command: |
              chmod +x .circleci/announceDeployment.sh
-             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: Announce production iOS URL
           command: |
             cd ~/pillarwallet
             chmod +x .circleci/announceURLs.sh
-            .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive ipa file
           command: |
-            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
             mkdir -p ./toArchive
             mkdir -p /tmp/workspace/ios-release
             cp ./ios/output/gym/pillarwallet.ipa ./toArchive
-            cp ./ios/output/gym/pillarwallet.ipa /tmp/workspace/ios-release/pillarwallet-prod-ios-$TAG_VERSION.ipa
+            cp ./ios/output/gym/pillarwallet.ipa /tmp/workspace/ios-release/pillarwallet-prod-ios-$APP_VERSION.ipa
       - store_artifacts:
           path: ./toArchive
           destination: app_build
@@ -479,7 +482,7 @@ jobs:
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            export buildNumber="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            export buildNumber="$(cat /tmp/workspace/build-num/app_version.txt)"
             rm .env
             cp environments/.env.production ./.env
             sed -i.bak "s/_build_number_/$buildNumber/g" .env
@@ -572,26 +575,26 @@ jobs:
           command: |
             cd ~/pillarwallet
             chmod +x .circleci/announceProdBuilds.sh
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
            name: Announce Deployment
            command: |
              chmod +x .circleci/announceDeployment.sh
-             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: Announce Prod Android URL
           command: |
             cd ~/pillarwallet
             chmod +x .circleci/announceURLs.sh
-            .circleci/announceURLs.sh "pillarwallet" "production" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/prod/release/android-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            .circleci/announceURLs.sh "pillarwallet" "production" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/prod/release/android-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive apk file
           command: |
-            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
             mkdir -p ./toArchive
             mkdir -p /tmp/workspace/android-release
             cp ./android/app/build/outputs/apk/prod/release/app-prod-release.apk ./toArchive
-            cp ./android/app/build/outputs/apk/prod/release/app-prod-release.apk /tmp/workspace/android-release/pillarwallet-prod-android-$TAG_VERSION.apk
+            cp ./android/app/build/outputs/apk/prod/release/app-prod-release.apk /tmp/workspace/android-release/pillarwallet-prod-android-$APP_VERSION.apk
       - store_artifacts:
           path: ./toArchive
           destination: apks
@@ -617,9 +620,10 @@ jobs:
             chmod +x setReleaseInfo.sh
             . ./setReleaseInfo.sh
             TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
             github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$TAG_VERSION.apk" -f /tmp/workspace/android-release/*.apk
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$TAG_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
 
 workflows:
   version: 2.1

--- a/.github/workflows/bump-tag-prod.yml
+++ b/.github/workflows/bump-tag-prod.yml
@@ -2,7 +2,7 @@ name: Bump version Prod
 on:
   push:
     branches:
-      - fix/bump-tag
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,4 +15,3 @@ jobs:
         WITH_V: true
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: minor
-        DRY_RUN: true

--- a/.github/workflows/bump-tag-prod.yml
+++ b/.github/workflows/bump-tag-prod.yml
@@ -2,7 +2,7 @@ name: Bump version Prod
 on:
   push:
     branches:
-      - master
+      - fix/bump-tag
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +12,7 @@ jobs:
       uses: anothrNick/github-tag-action@1.13.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: false
+        WITH_V: true
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: minor
+        DRY_RUN: true


### PR DESCRIPTION
This commit will:

1. Use the github bump action to create tags with the `v`, e.g. `v1.3.0`
1.1 We need this since a bug in the tool caused it to neglect the tags w/o `v` and treat them as older even though those were created as the latest tag.
2. Configure the pipeline to use the TAG w/o `v` in the versioning of the applications since App Store does not accept releases named like v1.3.0