### PR TITLE
Fix/user info on import [PIL-285]

### DIFF
--- a/src/actions/__tests__/onboardingActions.test.js
+++ b/src/actions/__tests__/onboardingActions.test.js
@@ -33,7 +33,7 @@ import { UPDATE_CONTACTS } from 'constants/contactsConstants';
 import { RESET_APP_SETTINGS } from 'constants/appSettingsConstants';
 import { UPDATE_INVITATIONS } from 'constants/invitationsConstants';
 import { UPDATE_RATES } from 'constants/ratesConstants';
-import { UPDATE_USER, REGISTERED } from 'constants/userConstants';
+import { SET_USER, REGISTERED } from 'constants/userConstants';
 import { UPDATE_ACCESS_TOKENS } from 'constants/accessTokensConstants';
 import { UPDATE_OAUTH_TOKENS } from 'constants/oAuthConstants';
 import { SET_HISTORY } from 'constants/historyConstants';
@@ -189,7 +189,7 @@ describe('Wallet actions', () => {
       { type: UPDATE_WALLET_STATE, payload: REGISTERING },
       { type: UPDATE_OAUTH_TOKENS, payload: { accessToken: 'uniqueAccessToken', refreshToken: 'uniqueRefreshToken' } },
       { type: UPDATE_SESSION, payload: { fcmToken: '12x2342x212' } },
-      { type: UPDATE_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
+      { type: SET_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
       { type: UPDATE_SESSION, payload: { isSignalInitiated: true } },
       { type: ADD_ACCOUNT, payload: mockKeyBasedAccount },
       { type: UPDATE_RATES, payload: mockExchangeRates },
@@ -257,7 +257,7 @@ describe('Wallet actions', () => {
       { type: UPDATE_WALLET_STATE, payload: REGISTERING },
       { type: UPDATE_OAUTH_TOKENS, payload: { accessToken: 'uniqueAccessToken', refreshToken: 'uniqueRefreshToken' } },
       { type: UPDATE_SESSION, payload: { fcmToken: '12x2342x212' } },
-      { type: UPDATE_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
+      { type: SET_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
       { type: UPDATE_SESSION, payload: { isSignalInitiated: true } },
       { type: ADD_ACCOUNT, payload: mockKeyBasedAccount },
       { type: UPDATE_RATES, payload: mockExchangeRates },
@@ -337,7 +337,7 @@ describe('Wallet actions', () => {
       { type: UPDATE_WALLET_STATE, payload: REGISTERING },
       { type: UPDATE_OAUTH_TOKENS, payload: { accessToken: 'uniqueAccessToken', refreshToken: 'uniqueRefreshToken' } },
       { type: UPDATE_SESSION, payload: { fcmToken: '12x2342x212' } },
-      { type: UPDATE_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
+      { type: SET_USER, payload: { state: REGISTERED, user: { username: 'snow', walletId: 2 } } },
       { type: UPDATE_SESSION, payload: { isSignalInitiated: true } },
       { type: ADD_ACCOUNT, payload: mockKeyBasedAccount },
       { type: UPDATE_RATES, payload: mockExchangeRates },

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -47,7 +47,7 @@ import { TYPE_ACCEPTED, TYPE_RECEIVED, UPDATE_INVITATIONS } from 'constants/invi
 import { RESET_APP_SETTINGS, USER_JOINED_BETA_SETTING } from 'constants/appSettingsConstants';
 import { UPDATE_CONNECTION_IDENTITY_KEYS } from 'constants/connectionIdentityKeysConstants';
 import { UPDATE_CONNECTION_KEY_PAIRS } from 'constants/connectionKeyPairsConstants';
-import { PENDING, REGISTERED, UPDATE_USER } from 'constants/userConstants';
+import { PENDING, REGISTERED, SET_USER } from 'constants/userConstants';
 import { UPDATE_ACCESS_TOKENS } from 'constants/accessTokensConstants';
 import { SET_HISTORY } from 'constants/historyConstants';
 import { UPDATE_ACCOUNTS } from 'constants/accountsConstants';
@@ -129,7 +129,7 @@ const getTokenWalletAndRegister = async (
 
   dispatch({ type: UPDATE_SESSION, payload: { fcmToken } });
   dispatch({
-    type: UPDATE_USER,
+    type: SET_USER,
     payload: {
       user: userInfo,
       state: userState,
@@ -260,6 +260,7 @@ export const registerWalletAction = (enableBiometrics?: boolean, themeToStore?: 
 
     // STEP 0: Clear local storage and reset app state
     await storage.removeAll();
+
     dispatch({ type: UPDATE_ACCOUNTS, payload: [] });
     dispatch({ type: UPDATE_CONTACTS, payload: [] });
     dispatch({ type: UPDATE_INVITATIONS, payload: [] });

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -91,6 +91,7 @@ import { addWalletCreationEventAction, getWalletsCreationEventsAction } from 'ac
 import { loadFeatureFlagsAction } from 'actions/featureFlagsActions';
 import { labelUserAsLegacyAction } from 'actions/userActions';
 import { setRatesAction } from 'actions/ratesActions';
+import { resetAppState } from 'actions/authActions';
 
 // types
 import type { Dispatch, GetState } from 'reducers/rootReducer';
@@ -259,7 +260,11 @@ export const registerWalletAction = (enableBiometrics?: boolean, themeToStore?: 
     const { isBackedUp, isImported } = currentState.wallet.backupStatus;
 
     // STEP 0: Clear local storage and reset app state
-    await storage.removeAll();
+    if (isImported) {
+      await resetAppState(dispatch, getState);
+    } else {
+      await storage.removeAll();
+    }
 
     dispatch({ type: UPDATE_ACCOUNTS, payload: [] });
     dispatch({ type: UPDATE_CONTACTS, payload: [] });

--- a/src/constants/userConstants.js
+++ b/src/constants/userConstants.js
@@ -19,6 +19,7 @@
 */
 
 export const SET_USERNAME = 'SET_USERNAME';
+export const SET_USER = 'SET_USER';
 export const UPDATE_USER = 'UPDATE_USER';
 export const USER_PHONE_VERIFIED = 'USER_PHONE_VERIFIED';
 export const REGISTERED = 'REGISTERED';

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -17,7 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import { SET_USERNAME, UPDATE_USER, USER_PHONE_VERIFIED } from 'constants/userConstants';
+import { SET_USERNAME, UPDATE_USER, USER_PHONE_VERIFIED, SET_USER } from 'constants/userConstants';
 import merge from 'lodash.merge';
 
 export type UserReducerState = {
@@ -43,6 +43,12 @@ const userReducer = (
   action: UserReducerAction,
 ): UserReducerState => {
   switch (action.type) {
+    case SET_USER:
+      return {
+        ...state,
+        data: { ...initialState.data, ...action.payload.user },
+        userState: action.payload.state,
+      };
     case UPDATE_USER:
       const { state: userState, user } = action.payload;
       return {


### PR DESCRIPTION
This PR adds SET_USER action type to set new user object rather than merging it with existing one during wallet import so previous info would not be kept.