### PR TITLE
Fix/avoid threads debugging crash android

### DIFF
--- a/src/utils/keyPairGenerator.js
+++ b/src/utils/keyPairGenerator.js
@@ -133,7 +133,7 @@ export async function generateKeyPairThreadPool(
   if (connectionsKeyPairCount <= PRE_KEY_THRESHOLD) {
     const isDebuggingEnabled = typeof location !== 'undefined' // eslint-disable-line no-restricted-globals
       && location.href.toLowerCase().includes('debug'); // eslint-disable-line no-restricted-globals,no-undef
-    if (isDebuggingEnabled && __DEV__) {
+    if (isDebuggingEnabled) {
       promiseJobs = generateKeyPairPool(mnemonic, privateKey, lastConnectionKeyIndex, connectionsCount, 25);
     } else {
       const threads = await threadPoolCreation(5);

--- a/src/utils/keyPairGenerator.js
+++ b/src/utils/keyPairGenerator.js
@@ -17,7 +17,6 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import { Platform } from 'react-native';
 import { utils } from 'ethers';
 import { Thread } from 'react-native-threads';
 import { PRE_KEY_THRESHOLD } from 'configs/connectionKeysConfig';

--- a/src/utils/keyPairGenerator.js
+++ b/src/utils/keyPairGenerator.js
@@ -132,10 +132,9 @@ export async function generateKeyPairThreadPool(
   const derivePathBase = 'm/44/60\'/0\'/0/0';
   let promiseJobs = [];
   if (connectionsKeyPairCount <= PRE_KEY_THRESHOLD) {
-    const isIOSDebuggingEnabled = Platform.OS === 'ios'
-      && typeof location !== 'undefined' // eslint-disable-line no-restricted-globals
+    const isDebuggingEnabled = typeof location !== 'undefined' // eslint-disable-line no-restricted-globals
       && location.href.toLowerCase().includes('debug'); // eslint-disable-line no-restricted-globals,no-undef
-    if (isIOSDebuggingEnabled) {
+    if (isDebuggingEnabled && __DEV__) {
       promiseJobs = generateKeyPairPool(mnemonic, privateKey, lastConnectionKeyIndex, connectionsCount, 25);
     } else {
       const threads = await threadPoolCreation(5);

--- a/src/utils/keyPairGenerator.js
+++ b/src/utils/keyPairGenerator.js
@@ -17,6 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+import { Platform } from 'react-native';
 import { utils } from 'ethers';
 import { Thread } from 'react-native-threads';
 import { PRE_KEY_THRESHOLD } from 'configs/connectionKeysConfig';
@@ -133,7 +134,8 @@ export async function generateKeyPairThreadPool(
   if (connectionsKeyPairCount <= PRE_KEY_THRESHOLD) {
     const isDebuggingEnabled = typeof location !== 'undefined' // eslint-disable-line no-restricted-globals
       && location.href.toLowerCase().includes('debug'); // eslint-disable-line no-restricted-globals,no-undef
-    if (isDebuggingEnabled) {
+    const isAndroidDev = __DEV__ && Platform.OS === 'android';
+    if (isDebuggingEnabled || isAndroidDev) {
       promiseJobs = generateKeyPairPool(mnemonic, privateKey, lastConnectionKeyIndex, connectionsCount, 25);
     } else {
       const threads = await threadPoolCreation(5);


### PR DESCRIPTION
Avoid running threads if on emulator debug since non refactored code in the threads module crashes the application when the threads are invoked