### PR TITLE
[PIL-309] Fix/ hidden assets remove from storage

### DIFF
--- a/src/actions/userSettingsActions.js
+++ b/src/actions/userSettingsActions.js
@@ -50,7 +50,7 @@ export const hideAssetAction = (asset: Asset) => {
       autoClose: true,
     });
 
-    dispatch(saveDbAction('userSettings', { userSettings: { hiddenAssets: updatedHiddenAssets } }));
+    dispatch(saveDbAction('userSettings', { userSettings: { hiddenAssets: updatedHiddenAssets } }, true));
     dispatch({ type: SET_HIDDEN_ASSETS, payload: updatedHiddenAssets });
   };
 };
@@ -72,7 +72,7 @@ export const showAssetAction = (asset: Asset) => {
       [accountId]: updatedHiddenAccountAssets,
     };
 
-    dispatch(saveDbAction('userSettings', { userSettings: { hiddenAssets: updatedHiddenAssets } }));
+    dispatch(saveDbAction('userSettings', { userSettings: { hiddenAssets: updatedHiddenAssets } }, true));
     dispatch({ type: SET_HIDDEN_ASSETS, payload: updatedHiddenAssets });
   };
 };


### PR DESCRIPTION
Add forceRewrite when hiding/showing asset in local storage.
This fixes the issue between toggle show/hide not being reflected when the app is killed and restarted.