### PR TITLE
Update profile phone input type

### DIFF
--- a/src/screens/Users/AddOrEditUser.js
+++ b/src/screens/Users/AddOrEditUser.js
@@ -253,7 +253,7 @@ class AddOrEditUser extends React.PureComponent<Props, State> {
               hasVerification: true,
               isVerified: isPhoneVerified,
               onPressVerify: this.verifyPhone,
-              keyboardType: 'number-pad',
+              keyboardType: 'phone-pad',
             }]}
             onUpdate={this.handleUserFieldUpdate}
             value={{ phone }}


### PR DESCRIPTION
The type number-pad doesn't have the '+' sign on iOS, making it
impossible to enter phone numbers. The phone-pad has everything
needed for phone inputs.