### PR TITLE
[PIL-371] Fix/add ens domain placeholder

### DIFF
--- a/src/components/ProfileForm/ProfileForm.js
+++ b/src/components/ProfileForm/ProfileForm.js
@@ -28,6 +28,9 @@ export const InputTemplate = (locals: Object) => {
     additionalProps.loading = config.isLoading;
   }
 
+  if (config.rightPlaceholder) {
+    additionalProps.rightPlaceholder = config.rightPlaceholder;
+  }
 
   if (config.statusIcon || config.statusIconColor) {
     additionalProps.iconProps = {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -114,6 +114,7 @@ type Props = {
   selectorOptions?: SelectorOptions,
   errorMessageOnTop?: boolean,
   inputWrapperStyle?: Object,
+  rightPlaceholder?: string,
 };
 
 type State = {
@@ -264,6 +265,11 @@ const ValueWrapper = styled.View`
 
 const Placeholder = styled(MediumText)`
   ${fontStyles.big};
+`;
+
+const PlaceholderRight = styled(BaseText)`
+  ${fontStyles.medium};
+  margin-right: 8px;
 `;
 
 const SelectorValue = styled(MediumText)`
@@ -508,6 +514,7 @@ class TextInput extends React.Component<Props, State> {
       leftSideText,
       numeric,
       iconProps,
+      rightPlaceholder,
       selectorOptions = {},
       errorMessageOnTop,
       inputWrapperStyle = {},
@@ -540,7 +547,7 @@ class TextInput extends React.Component<Props, State> {
     } = selectorOptions;
 
     const showLeftAddon = (innerImageURI || fallbackSource) || !!leftSideText;
-    const showRightAddon = !!iconProps || loading;
+    const showRightAddon = !!iconProps || loading || rightPlaceholder;
 
     const selectorOptionsCount = options.length + horizontalOptions.length;
     const {
@@ -648,6 +655,7 @@ class TextInput extends React.Component<Props, State> {
               />}
               {showRightAddon &&
               <RightSideWrapper>
+                {!!rightPlaceholder && <PlaceholderRight color={colors.accent}>{rightPlaceholder}</PlaceholderRight>}
                 {!!iconProps && <IconButton color={colors.primary} {...iconProps} />}
                 {!!loading && <Spinner width={30} height={30} />}
               </RightSideWrapper>}

--- a/src/screens/NewProfile/NewProfile.js
+++ b/src/screens/NewProfile/NewProfile.js
@@ -119,6 +119,7 @@ const getDefaultFormOptions = (inputDisabled: boolean, isLoading?: boolean) => (
         statusIcon: null,
         statusIconColor: null,
         inputType: 'bigText',
+        rightPlaceholder: '.pillar.eth',
       },
     },
   },

--- a/src/screens/NewProfile/NewProfile.js
+++ b/src/screens/NewProfile/NewProfile.js
@@ -102,7 +102,7 @@ const formStructure = t.struct({
 
 const PROFILE_IMAGE_WIDTH = 144;
 
-const getDefaultFormOptions = (inputDisabled: boolean, isLoading?: boolean) => ({
+const getDefaultFormOptions = (inputDisabled: boolean, showRightPlaceholder?: boolean) => ({
   fields: {
     username: {
       auto: 'placeholders',
@@ -110,7 +110,7 @@ const getDefaultFormOptions = (inputDisabled: boolean, isLoading?: boolean) => (
       template: InputTemplate,
       maxLength: MAX_USERNAME_LENGTH,
       config: {
-        isLoading,
+        isLoading: false,
         inputProps: {
           autoCapitalize: 'none',
           disabled: inputDisabled,
@@ -119,7 +119,7 @@ const getDefaultFormOptions = (inputDisabled: boolean, isLoading?: boolean) => (
         statusIcon: null,
         statusIconColor: null,
         inputType: 'bigText',
-        rightPlaceholder: '.pillar.eth',
+        rightPlaceholder: showRightPlaceholder ? '.pillar.eth' : null,
       },
     },
   },
@@ -157,12 +157,13 @@ class NewProfile extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    const { apiUser } = props;
+    const { apiUser, importedWallet } = props;
     const value = apiUser && apiUser.username ? { username: apiUser.username } : null;
     const inputDisabled = !!(apiUser && apiUser.id);
+    const showRightPlaceholder = !importedWallet;
     this.state = {
       value,
-      formOptions: getDefaultFormOptions(inputDisabled),
+      formOptions: getDefaultFormOptions(inputDisabled, showRightPlaceholder),
       hasAgreedToTerms: false,
       hasAgreedToPolicy: false,
       isPendingCheck: false,


### PR DESCRIPTION
Add rightPlaceholder feature for textInput like '.pillar.eth'
Show ens for new pillarwallet, do not show for externally imported one

<img src="https://user-images.githubusercontent.com/37015091/76647556-5293c000-655d-11ea-913a-77e066729f0d.png" width="25%"><img src="https://user-images.githubusercontent.com/37015091/76647637-76ef9c80-655d-11ea-88ea-06214b8035ba.png" width="25%"><img src="https://user-images.githubusercontent.com/37015091/76647592-64756300-655d-11ea-9b8d-f77b108ead32.png" width="25%">
