### PR TITLE
Fix/modal scroll (proposition)

### DIFF
--- a/src/components/Input/InputWithSwitch.js
+++ b/src/components/Input/InputWithSwitch.js
@@ -82,7 +82,7 @@ const StyledItemView = styled.View`
   padding: 0 ${spacing.layoutSides}px 0;
   border-bottom-color: ${({ hasErrors }) => hasErrors ? themedColors.negative : themedColors.tertiary};
   border-bottom-width: 1px;
-  height: 60px;
+  height: 65px;
 `;
 
 const Wrapper = styled.View`
@@ -106,12 +106,12 @@ const ItemValue = styled(Input)`
   font-family: ${appFont.medium};
 `;
 
-const SelectedOption = styled(BaseText)`
-  ${fontStyles.medium};
+const SelectedOption = styled(MediumText)`
+  ${fontStyles.big};
   flex-wrap: wrap;
   flex: 1;
   padding: 0 0 9px;
-  width:100%;
+  width: 100%;
 `;
 
 const ItemAddon = styled.View`

--- a/src/components/Input/InputWithSwitch.js
+++ b/src/components/Input/InputWithSwitch.js
@@ -82,7 +82,6 @@ const StyledItemView = styled.View`
   padding: 0 ${spacing.layoutSides}px 0;
   border-bottom-color: ${({ hasErrors }) => hasErrors ? themedColors.negative : themedColors.tertiary};
   border-bottom-width: 1px;
-  height: 65px;
 `;
 
 const Wrapper = styled.View`
@@ -196,12 +195,12 @@ export default class InputWithSwitch extends React.Component<Props, State> {
     this.scrollViewRef.scrollToOffset({ animated: false, offset: p.y });
   };
 
-  handleListOnScroll = (event: Object) => {
+  onListScroll = (event: Event) => {
     const contentOffsetY = get(event, 'nativeEvent.contentOffset.y');
     this.setState({ contentOffsetY });
   };
 
-  onListLayout = (event: Object) => {
+  onListLayout = (event: Event) => {
     const { containerHeight } = this.state;
     const { height } = event.nativeEvent.layout;
     if (!containerHeight || containerHeight !== height) {
@@ -301,7 +300,7 @@ export default class InputWithSwitch extends React.Component<Props, State> {
               flatListProps={{
                 ref: (ref) => { this.scrollViewRef = ref; },
                 scrollEventThrottle: 16,
-                onScroll: this.handleListOnScroll,
+                onScroll: this.onListScroll,
                 onLayout: this.onListLayout,
                 onContentSizeChange: this.onContentSizeChange,
               }}

--- a/src/components/Input/SelectList.js
+++ b/src/components/Input/SelectList.js
@@ -32,7 +32,9 @@ const SearchBarWrapper = styled.View`
 
 type Props = {
   onSelect: Function,
-  options: Object[]
+  options: Object[],
+  customClickable?: boolean,
+  flatListProps?: Object,
 }
 
 type State = {
@@ -55,18 +57,19 @@ export default class SelectList extends React.Component<Props, State> {
   };
 
   renderListItem = ({ item: { name } }: Object) => {
-    const { onSelect } = this.props;
+    const { onSelect, customClickable } = this.props;
     return (
       <ProfileSettingsItem
         key={name}
         label={name}
         onPress={() => onSelect(name)}
+        customClickable={customClickable}
       />
     );
   };
 
   render() {
-    const { options } = this.props;
+    const { options, flatListProps } = this.props;
     const { query } = this.state;
     const filteredOptions = (query && query.length >= MIN_QUERY_LENGTH && options.length)
       ? options.filter(({ name }) => name.toUpperCase().includes(query.toUpperCase()))
@@ -90,6 +93,17 @@ export default class SelectList extends React.Component<Props, State> {
           renderItem={this.renderListItem}
           keyExtractor={({ name }) => name}
           keyboardShouldPersistTaps="handled"
+          initialNumToRender={10}
+          viewabilityConfig={{
+            minimumViewTime: 300,
+            viewAreaCoveragePercentThreshold: 100,
+            waitForInteraction: true,
+          }}
+          getItemLayout={(data, index) => ({
+            length: 70,
+            offset: 70 * index,
+            index,
+          })}
           ListEmptyComponent={
             <Wrapper
               fullScreen
@@ -102,6 +116,7 @@ export default class SelectList extends React.Component<Props, State> {
               <EmptyStateParagraph title="Nothing found" />
             </Wrapper>
           }
+          {...flatListProps}
         />
       </React.Fragment>
     );

--- a/src/components/ListItem/SettingsItem.js
+++ b/src/components/ListItem/SettingsItem.js
@@ -18,7 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, PanResponder } from 'react-native';
 import styled from 'styled-components/native';
 import { fontSizes, fontStyles, spacing } from 'utils/variables';
 import { Badge as NBBadge } from 'native-base';
@@ -28,6 +28,7 @@ import NativeTouchable from 'components/NativeTouchable';
 import Switcher from 'components/Switcher';
 import { LabelBadge } from 'components/LabelBadge';
 import { themedColors } from 'utils/themes';
+
 
 type Props = {
   label: string,
@@ -46,18 +47,25 @@ type Props = {
   labelBadge?: {
     label: string,
     color?: string,
-  }
-}
+  },
+  customClickable?: boolean,
+};
+
+type State = {
+  opacity: number,
+};
+
 
 const MainWrapper = styled.View`
   flex: 1;
   padding: 22px ${spacing.large}px 24px;
+  height: 70px;
   ${({ bordered, theme }) => bordered
     ? `
-   border-bottom-width: ${StyleSheet.hairlineWidth}px;
-   border-top-width: ${StyleSheet.hairlineWidth}px;
-   border-color: ${theme.colors.border};
-   `
+     border-bottom-width: ${StyleSheet.hairlineWidth}px;
+     border-top-width: ${StyleSheet.hairlineWidth}px;
+     border-color: ${theme.colors.border};
+     `
     : ''}
 `;
 
@@ -136,7 +144,32 @@ const Description = styled(BaseText)`
   padding-right: 10%;
 `;
 
-class SettingsListItem extends React.Component<Props> {
+const CustomTouchable = styled.View`
+  width: 100%;
+  color: ${themedColors.surface};
+`;
+
+class SettingsListItem extends React.Component<Props, State> {
+  _panResponder: PanResponder;
+
+  constructor(props: Props) {
+    super(props);
+    this._panResponder = PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponderCapture: () => true,
+      onMoveShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponderCapture: () => false,
+      onPanResponderGrant: () => { this.setState({ opacity: 0.7 }); },
+      onPanResponderRelease: () => {
+        if (props.onPress) props.onPress();
+        this.setState({ opacity: 1 });
+      },
+    });
+    this.state = {
+      opacity: 1,
+    };
+  }
+
   renderContent(processedValue: ?string | ?boolean) {
     const {
       label,
@@ -202,7 +235,10 @@ class SettingsListItem extends React.Component<Props> {
       onPress,
       toggle,
       value,
+      customClickable,
     } = this.props;
+
+    const { opacity } = this.state;
 
     let processedValue;
 
@@ -216,6 +252,17 @@ class SettingsListItem extends React.Component<Props> {
       }
     } else {
       processedValue = value;
+    }
+
+    if (customClickable) {
+      return (
+        <CustomTouchable
+          {...this._panResponder.panHandlers}
+          style={{ opacity }}
+        >
+          {this.renderContent(processedValue)}
+        </CustomTouchable>
+      );
     }
 
     return (

--- a/src/components/Modals/SlideModal/SlideModal.js
+++ b/src/components/Modals/SlideModal/SlideModal.js
@@ -67,6 +67,7 @@ type Props = {
   theme: Theme,
   noPadding?: boolean,
   headerLeftItems?: Object[],
+  propagateSwipe?: boolean,
 };
 
 const themes = {
@@ -177,6 +178,7 @@ class SlideModal extends React.Component<Props, *> {
 
   handleScroll = (p: ScrollToProps) => {
     const { handleScrollTo } = this.props;
+
     if (Toast.isVisible()) {
       Toast.close();
     }
@@ -204,6 +206,7 @@ class SlideModal extends React.Component<Props, *> {
       theme,
       noPadding,
       headerLeftItems,
+      propagateSwipe,
     } = this.props;
 
     const customTheme = getTheme(this.props);
@@ -276,6 +279,7 @@ class SlideModal extends React.Component<Props, *> {
     };
 
     const animationTiming = 400;
+
     return (
       <Modal
         isVisible={isVisible}
@@ -295,6 +299,7 @@ class SlideModal extends React.Component<Props, *> {
         swipeDirection={!noSwipeToDismiss ? 'down' : null}
         avoidKeyboard={avoidKeyboard}
         scrollOffsetMax={scrollOffsetMax}
+        propagateSwipe={propagateSwipe}
         style={{
           margin: 0,
           position: 'relative',


### PR DESCRIPTION
This PR is an attempt to fix scroll issue on country select modal.
As of my understanding, scroll freezes due to multiple pan responders:
- SlideModal (modal in it) has a pan responder that captures scrolling to bottom (in order to dismiss modal)
- SelectList (FlatList in it) has a pan responder to scroll list
- SettingsItem (SelectList item) (TouchableOpacity / TouchableNativeFeedback in it) has a pan responder to capture touches (to execute onPress)

I've added couple of methods to manage modal's dismiss action when user interacts with SelectList (while scrolling it). Yet having touchable items in it, messes with Modal's pan responders. To disable capturing onMove, I've added custom touchable (view with custom pan responder).

This solution still has a latency when trying to close modal when scrolling down. 
So I've added another PR (#1752) that disables this scroll to dismiss feature in order to have smooth scrolling experience on modal's content.

Let me know what you think. Any optimisation ideas are more than welcome :)