### PR TITLE
Restructure notifications subscribe actions

### DIFF
--- a/src/actions/notificationsActions.js
+++ b/src/actions/notificationsActions.js
@@ -70,7 +70,7 @@ import {
   CONNECTION_DISCONNECTED_EVENT,
   CONNECTION_REJECTED_EVENT,
   CONNECTION_REQUESTED_EVENT,
-  CONNECTION_COLLECTIBLE_EVENT,
+  COLLECTIBLE_EVENT,
 } from 'constants/socketConstants';
 import { STATUS_MUTED } from 'constants/connectionsConstants';
 
@@ -164,73 +164,78 @@ export const fetchAllNotificationsAction = () => {
   };
 };
 
-export const startListeningNotificationsAction = () => {
+export const subscribeToSocketEventsAction = () => {
+  return async (dispatch: Dispatch, getState: GetState) => {
+    const { invitations: { data: invitations } } = getState();
+    if (get(SOCKET, 'socket.readyState') !== 1) return;
+
+    SOCKET.onMessage((response) => {
+      let data;
+      try {
+        data = JSON.parse(response.data.msg);
+      } catch (error) {
+        // this shouldn't happen, but was reported to Sentry as issue, let's report with more details
+        Sentry.captureMessage('Platform WebSocket notification parse failed', { extra: { response, error } });
+        return; // unable to parse data, do not proceed
+      }
+
+      const senderUserId = get(data, 'senderUserData.id');
+
+      if (data.type === CONNECTION_REQUESTED_EVENT) {
+        dispatch(fetchInviteNotificationsAction());
+      }
+      if (
+        data.type === CONNECTION_CANCELLED_EVENT ||
+        data.type === CONNECTION_REJECTED_EVENT
+      ) {
+        const updatedInvitations = invitations.filter(({ id }) => id !== senderUserId);
+        dispatch({
+          type: UPDATE_INVITATIONS,
+          payload: updatedInvitations,
+        });
+      }
+      if (
+        data.type === CONNECTION_ACCEPTED_EVENT ||
+        data.type === CONNECTION_DISCONNECTED_EVENT
+      ) {
+        dispatch(updateConnectionsAction());
+      }
+      if (data.type === COLLECTIBLE_EVENT) {
+        dispatch(fetchAllCollectiblesDataAction());
+      }
+      if (data.type === BCX) {
+        dispatch(fetchTransactionsHistoryNotificationsAction());
+        dispatch(fetchSmartWalletTransactionsAction());
+        dispatch(fetchAssetTransactionsAction(data.asset));
+        dispatch(fetchAssetsBalancesAction());
+      }
+      if (data.type === BADGE) {
+        dispatch(fetchBadgesAction(false));
+      }
+      if (
+        data.type === CONNECTION_REQUESTED_EVENT ||
+        data.type === COLLECTIBLE_EVENT ||
+        data.type === BCX ||
+        data.type === BADGE
+      ) {
+        const payload = {
+          title: response.notification.title,
+          message: response.notification.body,
+        };
+        dispatch({ type: ADD_NOTIFICATION, payload });
+        dispatch({ type: SET_UNREAD_NOTIFICATIONS_STATUS, payload: true });
+      }
+    });
+  };
+};
+
+export const subscribeToPushNotificationsAction = () => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const {
       wallet: { data: wallet },
-      invitations: { data: invitations },
       contacts: { data: contacts },
     } = getState();
-    if (SOCKET && SOCKET.socket && SOCKET.socket.readyState === 1) {
-      SOCKET.onMessage((response) => {
-        let data;
-        try {
-          data = JSON.parse(response.data.msg);
-        } catch (error) {
-          // this shouldn't happen, but was reported to Sentry as issue, let's report with more details
-          Sentry.captureMessage('Platform WebSocket notification parse failed', { extra: { response, error } });
-          return; // unable to parse data, do not proceed
-        }
 
-        const senderUserId = get(data, 'senderUserData.id');
-
-        if (data.type === CONNECTION_REQUESTED_EVENT) {
-          dispatch(fetchInviteNotificationsAction());
-        }
-        if (
-          data.type === CONNECTION_CANCELLED_EVENT ||
-          data.type === CONNECTION_REJECTED_EVENT
-        ) {
-          const updatedInvitations = invitations.filter(({ id }) => id !== senderUserId);
-          dispatch({
-            type: UPDATE_INVITATIONS,
-            payload: updatedInvitations,
-          });
-        }
-        if (
-          data.type === CONNECTION_ACCEPTED_EVENT ||
-          data.type === CONNECTION_DISCONNECTED_EVENT
-        ) {
-          dispatch(updateConnectionsAction());
-        }
-        if (data.type === CONNECTION_COLLECTIBLE_EVENT) {
-          dispatch(fetchAllCollectiblesDataAction());
-        }
-        if (data.type === BCX) {
-          dispatch(fetchTransactionsHistoryNotificationsAction());
-          dispatch(fetchSmartWalletTransactionsAction());
-          dispatch(fetchAssetTransactionsAction(data.asset));
-          dispatch(fetchAssetsBalancesAction());
-        }
-        if (data.type === BADGE) {
-          dispatch(fetchBadgesAction(false));
-        }
-        if (
-          data.type === CONNECTION_REQUESTED_EVENT ||
-          data.type === CONNECTION_COLLECTIBLE_EVENT ||
-          data.type === BCX ||
-          data.type === BADGE
-        ) {
-          const payload = {
-            title: response.notification.title,
-            message: response.notification.body,
-          };
-          dispatch({ type: ADD_NOTIFICATION, payload });
-          dispatch({ type: SET_UNREAD_NOTIFICATIONS_STATUS, payload: true });
-        }
-      });
-      return;
-    }
     const firebaseNotificationsEnabled = await firebase.messaging().hasPermission();
     if (!firebaseNotificationsEnabled) {
       try {
@@ -248,7 +253,7 @@ export const startListeningNotificationsAction = () => {
 
     if (notificationsListener) return;
     notificationsListener = firebase.notifications().onNotification(debounce(message => {
-      if (!message._data || !Object.keys(message._data).length) return;
+      if (isEmpty(message._data)) return;
       if (checkForSupportAlert(message._data)) return;
       const notification = processNotification(message._data, wallet.address.toUpperCase());
       if (!notification) return;
@@ -299,6 +304,13 @@ export const startListeningNotificationsAction = () => {
         dispatch({ type: SET_UNREAD_NOTIFICATIONS_STATUS, payload: true });
       }
     }, 500));
+  };
+};
+
+export const startListeningNotificationsAction = () => {
+  return async (dispatch: Dispatch) => {
+    dispatch(subscribeToSocketEventsAction());
+    dispatch(subscribeToPushNotificationsAction());
   };
 };
 

--- a/src/constants/socketConstants.js
+++ b/src/constants/socketConstants.js
@@ -4,4 +4,4 @@ export const CONNECTION_CANCELLED_EVENT = 'connectionCancelledEvent';
 export const CONNECTION_ACCEPTED_EVENT = 'connectionAcceptedEvent';
 export const CONNECTION_REJECTED_EVENT = 'connectionRejectedEvent';
 export const CONNECTION_DISCONNECTED_EVENT = 'connectionDisconnectedEvent';
-export const CONNECTION_COLLECTIBLE_EVENT = 'collectible';
+export const COLLECTIBLE_EVENT = 'collectible';


### PR DESCRIPTION
The `startListeningNotificationsAction()` method got hard to read, so I've split it into 2 new actions