### PR TITLE
Fix/android staging build crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ jobs:
             cd android && bundle exec fastlane deploy_android_appcenter
       - store_artifacts:
           path: android/app/build/outputs/apk
-          destination: apks   
+          destination: apks
       - slack/status:
           fail_only: true
           failure_message: "Triggered by: *${CIRCLE_USERNAME}* \n\n Are you guys surprised that *$CIRCLE_JOB* failed? :circleci-fail:"
@@ -663,6 +663,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix/android-staging-build-crash
       - get-latest-tag:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,7 +663,6 @@ workflows:
             branches:
               only:
                 - develop
-                - fix/android-staging-build-crash
       - get-latest-tag:
           requires:
             - build-and-test

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: true,  // clean and rebuild if changing
+    enableHermes: false,  // clean and rebuild if changing
     // custom build params:
     bundleInDebug: false,
     bundleInRelease: true,
@@ -254,7 +254,6 @@ dependencies {
         def hermesPath = "../../node_modules/hermes-engine/android/";
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
-        stagingImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -254,6 +254,7 @@ dependencies {
         def hermesPath = "../../node_modules/hermes-engine/android/";
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
+        stagingImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
     }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -14,9 +14,8 @@
 
 # hermes
 -keep class com.facebook.hermes.unicode.** { *; }
+-keep class com.facebook.jni.** { *; }
 
 # ranch.io
 -dontwarn io.branch.**
-
-# ranch.io
 -keep class com.google.android.gms.ads.identifier.** { *; }


### PR DESCRIPTION
Excludes `hermes` as on staging build it seems to cause crash. Disabling it allows further investigation and unblocks release.