### PR TITLE
android prod build and proguard updates, gesture handler lib update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ aliases:
   - &gradle_dependencies
     run:
       name: Download Dependencies
-      command: cd android && ./gradlew androidDependencies --no-daemon --stacktrace --max-workers=2
+      command: cd android && ./gradlew app:androidDependencies --no-daemon --stacktrace --max-workers=2
   - &gradle_save_cache
     save_cache:
       key: android-jars-v1-{{ checksum "./android/build.gradle" }}-{{ checksum  "./android/app/build.gradle" }}
@@ -306,7 +306,7 @@ jobs:
           command: |
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            cd android && ./gradlew clean assembleStaging --no-daemon --stacktrace --max-workers=2 -PBUILD_NUMBER=$APP_BUILD_NUMBER
+            cd android && ./gradlew clean app:assembleStaging --no-daemon --stacktrace --max-workers=2 -PBUILD_NUMBER=$APP_BUILD_NUMBER
 
       - *gradle_save_cache
 
@@ -552,7 +552,7 @@ jobs:
             yes | sdkmanager --update || exit 0
       - run:
           name: Download Dependencies
-          command: cd android && ./gradlew androidDependencies --no-daemon --stacktrace --max-workers=2
+          command: cd android && ./gradlew app:androidDependencies --no-daemon --stacktrace --max-workers=2
       - save_cache:
           key: android-jars-{{ checksum "./android/build.gradle" }}-{{ checksum "./android/app/build.gradle" }}
           paths:
@@ -564,7 +564,7 @@ jobs:
             cd android
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
-            ./gradlew clean assembleRelease --no-daemon --stacktrace --max-workers=2 -PBUILD_NUMBER=$APP_BUILD_NUMBER
+            ./gradlew clean app:assembleRelease --no-daemon --stacktrace --max-workers=2 -PBUILD_NUMBER=$APP_BUILD_NUMBER
       - run:
           name: Fastlane deploy to Google Play
           command: |

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,10 +12,13 @@
 # react-native-keychain:
 -keep class com.facebook.crypto.** { *; }
 
-# hermes
+# hermes:
 -keep class com.facebook.hermes.unicode.** { *; }
 -keep class com.facebook.jni.** { *; }
 
-# ranch.io
+# ranch.io:
 -dontwarn io.branch.**
 -keep class com.google.android.gms.ads.identifier.** { *; }
+
+# signal:
+-keep class * { public private *; }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -16,7 +16,7 @@
 -keep class com.facebook.hermes.unicode.** { *; }
 -keep class com.facebook.jni.** { *; }
 
-# ranch.io:
+# branch.io:
 -dontwarn io.branch.**
 -keep class com.google.android.gms.ads.identifier.** { *; }
 

--- a/android/app/src/main/java/com/pillarproject/wallet/MainActivity.java
+++ b/android/app/src/main/java/com/pillarproject/wallet/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends ReactActivity {
         return "pillarwallet";
     }
 
+    // react-native-gesture-handler
     @Override
     protected ReactActivityDelegate createReactActivityDelegate() {
         return new ReactActivityDelegate(this, getMainComponentName()) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@matt-block/react-native-in-app-browser": "^3.2.0",
     "@netgum/utils": "^0.1.3",
-    "@pillarwallet/pillarwallet-nodejs-sdk": "1.45.1793",
+    "@pillarwallet/pillarwallet-nodejs-sdk": "1.45.1811",
     "@react-native-community/async-storage": "^1.7.1",
     "@react-native-community/netinfo": "^5.6.1",
     "@react-native-firebase/analytics": "^6.3.3",
@@ -204,7 +204,7 @@
     "mock-socket": "^9.0.3",
     "npm-run-all": "^4.1.5",
     "react-dom": "16.8.3",
-    "react-native-gesture-handler": "1.4.1",
+    "react-native-gesture-handler": "1.6.1",
     "react-native-safe-area-context": "^0.4.1",
     "react-native-storybook-loader": "^1.8.1",
     "react-test-renderer": "16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,6 +997,13 @@
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@ctrl/tinycolor/-/tinycolor-2.6.1.tgz#0e78cc836a1fd997a9a22fa1c26c555411882160"
   integrity sha1-DnjMg2of2Zepoi+hwmxVVBGIIWA=
 
+"@egjs/hammerjs@^2.0.17":
+  version "2.0.17"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha1-XcAq91pqBuTC2wICyuOMkmOJUSQ=
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@emotion/cache@^10.0.27":
   version "10.0.27"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
@@ -1515,10 +1522,10 @@
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=
 
-"@pillarwallet/pillarwallet-nodejs-sdk@1.45.1793":
-  version "1.45.1793"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@pillarwallet/pillarwallet-nodejs-sdk/-/@pillarwallet/pillarwallet-nodejs-sdk-1.45.1793.tgz#198fec6131d1f8ce535e99879a089b4591c95a22"
-  integrity sha1-GY/sYTHR+M5TXpmHmgibRZHJWiI=
+"@pillarwallet/pillarwallet-nodejs-sdk@1.45.1811":
+  version "1.45.1811"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@pillarwallet/pillarwallet-nodejs-sdk/-/@pillarwallet/pillarwallet-nodejs-sdk-1.45.1811.tgz#cb09096b1064911e8f03b5225fc345c344e2cc47"
+  integrity sha1-ywkJaxBkkR6PA7UiX8NFw0TizEc=
   dependencies:
     "@pillarwallet/plr-auth-sdk" "1.1.2-84"
     "@types/ethereumjs-util" "5.1.1"
@@ -2398,6 +2405,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hammerjs@^2.0.36":
+  version "2.0.36"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
+  integrity sha1-F84KI16f+83N9QlWRrN0wr9hWkw=
 
 "@types/history@*":
   version "4.7.5"
@@ -8727,11 +8739,6 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-hammerjs@^2.0.8:
-  version "2.0.8"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
-  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
-
 handlebars@^4.0.3:
   version "4.7.3"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
@@ -14957,12 +14964,12 @@ react-native-extra-dimensions-android@^1.2.5:
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-extra-dimensions-android/-/react-native-extra-dimensions-android-1.2.5.tgz#8ade91029aaac7519bf305116d39019e618a60f0"
   integrity sha1-it6RApqqx1Gb8wURbTkBnmGKYPA=
 
-react-native-gesture-handler@1.4.1:
-  version "1.4.1"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz#c38d9e57637b95e221722a79f2bafac62e3aeb21"
-  integrity sha1-w42eV2N7leIhcip58rr6xi466yE=
+react-native-gesture-handler@1.6.1:
+  version "1.6.1"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-gesture-handler/-/react-native-gesture-handler-1.6.1.tgz#678e2dce250ed66e93af409759be22cd6375dd17"
+  integrity sha1-Z44tziUO1m6Tr0CXWb4izWN13Rc=
   dependencies:
-    hammerjs "^2.0.8"
+    "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.4"
     prop-types "^15.7.2"


### PR DESCRIPTION
Includes:
- Fix for Android pipeline build commands.
- Fix for Android proguard rules to ignore Signal dependencies (had to be there, but was previously removed while solving merge conflicts).
- Fix for optional FCM token in Pillar SDK (bumped new version per @msazdova suggestion, didn't test yet).
- React Native gesture handler lib update for navigation crashes.