### PR TITLE
[PIL-502] Fix/hide-pk-when-mnemonic

### DIFF
--- a/src/screens/Menu/RecoverySettings.js
+++ b/src/screens/Menu/RecoverySettings.js
@@ -82,7 +82,7 @@ class RecoverySettings extends React.Component<Props, State> {
         key: 'viewPrivateKey',
         title: 'View private key',
         onPress: () => navigation.navigate(REVEAL_BACKUP_PHRASE, { showPrivateKey: true, wallet }),
-        hidden: !isBackedUp,
+        hidden: !isBackedUp || !!wallet.mnemonic,
       },
       {
         key: 'backupNotFinished',
@@ -95,7 +95,7 @@ class RecoverySettings extends React.Component<Props, State> {
         hidden: isBackedUp,
       },
     ];
-  }
+  };
 
   onPinValid = (pin: string, wallet: EthereumWallet) => {
     this.setState({ pinIsValid: true, wallet });


### PR DESCRIPTION
Hide PrivateKey backup when mnemonic is available since it will affect the restoration of BTC addresses and will make the mnemonic get lost if restored with pk on the app