### PR TITLE
Fix/chat re-render

### DIFF
--- a/src/screens/Chat/Chat.js
+++ b/src/screens/Chat/Chat.js
@@ -43,7 +43,6 @@ import {
   TimeProps,
   DayProps,
 } from 'react-native-gifted-chat';
-import isEqual from 'lodash.isequal';
 
 // models
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
@@ -283,8 +282,13 @@ class Chat extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    const { isFetching, draft, isOnline, themeType } = this.props;
+  componentDidUpdate(prevProps: Props) {
+    const {
+      isFetching,
+      draft,
+      isOnline,
+      themeType,
+    } = this.props;
     const { forceRerender } = this.state;
     const { draft: prevDraft } = prevProps;
 


### PR DESCRIPTION
This PR solves theming issue on Chat component.
Chat bubbles keep previous theme styling due to GiftedChat render optimisations - chat components are not re-rendering when we would need them to.
It is because most of GiftedChat components are PureComponents and have shouldComponentUpdate methods that does not respect any of props that could be passed into GiftedChat component.
(Except for Message component in the newest version of  GiftedChat. Yet it is not enough for us - we also need to update MessageText and Time components to change their text colour.)

So this PR forces GiftedChat to re-render by unmounting and mounting it again when Theme is changed so all PureComponents would be rendered with correct styles based on current theme.