### PR TITLE
fcm token optional per last sdk changes

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -36,6 +36,7 @@ import {
   MOONPAY_KEY,
 } from 'react-native-dotenv';
 import axios, { AxiosResponse } from 'axios';
+import isEmpty from 'lodash.isempty';
 
 // constants
 import { USERNAME_EXISTS, REGISTRATION_FAILED } from 'constants/walletConstants';
@@ -142,9 +143,11 @@ class SDKWrapper {
       .catch(() => []);
   }
 
-  registerOnBackend(fcm: string, username: string) {
+  registerOnBackend(fcmToken: ?string, username: string) {
+    let requestPayload = { username };
+    if (!isEmpty(fcmToken)) requestPayload = { ...requestPayload, fcmToken };
     return Promise.resolve()
-      .then(() => this.pillarWalletSdk.wallet.register({ fcmToken: fcm, username }))
+      .then(() => this.pillarWalletSdk.wallet.register(requestPayload))
       .then(({ data }) => data)
       .catch((e = {}) => {
         const status = get(e, 'response.status');
@@ -173,13 +176,11 @@ class SDKWrapper {
 
   registerOnAuthServer(walletPrivateKey: string, fcmToken: ?string, username: string) {
     const privateKey = walletPrivateKey.indexOf('0x') === 0 ? walletPrivateKey.slice(2) : walletPrivateKey;
+    let requestPayload = { privateKey, username };
+    if (!isEmpty(fcmToken)) requestPayload = { ...requestPayload, fcmToken };
     return Promise.resolve()
       .then(() => {
-        return this.pillarWalletSdk.wallet.registerAuthServer({
-          privateKey,
-          fcmToken,
-          username,
-        });
+        return this.pillarWalletSdk.wallet.registerAuthServer(requestPayload);
       })
       .then(({ data }) => data)
       .catch((error) => {


### PR DESCRIPTION
There was SDK change per back-end ticket https://linear.app/issue/BAC-121/platform-core-fcm-optional, but it was made optional in a way either to pass it with value or don't pass it at all so added a fix in SDK request calls for this.