### PR TITLE
Use next gen go image and change github-release get command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ jobs:
   publish_releases_to_github:
     working_directory: ~/pillarwallet
     docker:
-      - image: circleci/golang:1.8
+      - image: cimg/go:1.13
     steps:
       - checkout
       - attach_workspace: &attach_workspace
@@ -657,7 +657,7 @@ jobs:
       - run:
           name: Install github-release
           command: |
-            go get github.com/aktau/github-release
+            go get github.com/github-release/github-release
       - run:
           name: Set tag and publish releases to GitHub
           command: |


### PR DESCRIPTION
Fix for the failed publish job yesterday, github release guys did changes that caused our job to fail.