### PR TITLE
Fix sw activation screen from ppn screen

### DIFF
--- a/src/screens/Assets/Assets.js
+++ b/src/screens/Assets/Assets.js
@@ -274,7 +274,7 @@ class AssetsScreen extends React.Component<Props, State> {
       );
     }
 
-    if (isDeploying && viewType === VIEWS.SMART_WALLET_VIEW) {
+    if (isDeploying && (viewType === VIEWS.SMART_WALLET_VIEW || VIEWS.PPN_VIEW)) {
       const deploymentHash = getDeploymentHash(smartWalletState);
       return (
         <WalletActivation deploymentHash={deploymentHash} />


### PR DESCRIPTION
A small fix. To reproduce the bug:
- create a new account
- go to the ppn view
- activate sw
- nothing happens, we stay in ppn view
- when we try to activate sw again (because we think the app is stuck or something), it'll lead to red screen crashes