### PR TITLE
Stop scaring user that has 0 PLR to top up

### DIFF
--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -102,6 +102,7 @@ import { calculateGasEstimate, waitForTransaction } from 'services/assets';
 import { accountAssetsSelector } from 'selectors/assets';
 import { activeAccountAddressSelector } from 'selectors';
 import { accountHistorySelector } from 'selectors/history';
+import { accountBalancesSelector } from 'selectors/balances';
 
 // actions
 import { addAccountAction, setActiveAccountAction, switchAccountAction } from 'actions/accountsActions';
@@ -141,6 +142,7 @@ import {
   getAssetData,
   getAssetDataByAddress,
   getAssetsAsList,
+  getBalance,
   getPPNTokenAddress,
 } from 'utils/assets';
 import {
@@ -1002,9 +1004,14 @@ export const estimateTopUpVirtualAccountAction = (amount?: string = '1') => {
     dispatch({ type: RESET_ESTIMATED_TOPUP_FEE });
 
     const accountAssets = accountAssetsSelector(getState());
+    const balances = accountBalancesSelector(getState());
     const { decimals = 18 } = accountAssets[PPN_TOKEN] || {};
     const value = utils.parseUnits(amount, decimals);
     const tokenAddress = getPPNTokenAddress(PPN_TOKEN, accountAssets);
+    if (!tokenAddress) return;
+
+    const balance = getBalance(balances, tokenAddress);
+    if (balance < +amount) return;
 
     const response = await smartWalletService
       .estimateTopUpAccountVirtualBalance(value, tokenAddress)

--- a/src/screens/Tank/FundTank/FundTank.js
+++ b/src/screens/Tank/FundTank/FundTank.js
@@ -245,7 +245,7 @@ class FundTank extends React.Component<Props, State> {
         headerProps={{ centerItems: [{ title: isInitFlow ? 'Stake initial PLR' : 'Fund PLR tank' }] }}
         footer={(
           <FooterInner>
-            {!topUpFee.isFetched && <Spinner width={20} height={20} />}
+            {!topUpFee.isFetched && balance > 0 && <Spinner width={20} height={20} />}
             {topUpFee.isFetched && <Label>Estimated fee: {feeDisplayValue}</Label>}
             {!!value && !!parseFloat(value.amount) && !inputHasError &&
             <Button


### PR DESCRIPTION
This fixes the case when the user clicks on Top Up button having 0 PLR in his account.
Now it won't run the estimation and thus won't fail with the unnecessary error toast