### PR TITLE
PIL-562: Android prod app startup time potential improvements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,9 +84,8 @@ project.ext.react = [
     bundleInRelease: true,
     bundleInStaging: true,
     devDisabledInStaging: true,
-    // bundle in 1 file, ref – https://reactnative.dev/docs/ram-bundles-inline-requires#enable-the-ram-format
+    // bundle in multiple files, ref – https://reactnative.dev/docs/ram-bundles-inline-requires#enable-the-ram-format
     bundleCommand: "ram-bundle",
-    extraPackagerArgs: ["--indexed-ram-bundle"]
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,10 @@ project.ext.react = [
     bundleInDebug: false,
     bundleInRelease: true,
     bundleInStaging: true,
-    devDisabledInStaging: true
+    devDisabledInStaging: true,
+    // bundle in 1 file, ref – https://reactnative.dev/docs/ram-bundles-inline-requires#enable-the-ram-format
+    bundleCommand: "ram-bundle",
+    extraPackagerArgs: ["--indexed-ram-bundle"]
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,5 +12,8 @@ module.exports = {
     development: {
       plugins: ['babel-plugin-styled-components'],
     },
+    production: {
+      plugins: ['transform-remove-console'],
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lottie-ios": "3.1.3",
     "lottie-react-native": "^3.3.2",
     "memoize-one": "^5.1.1",
-    "native-base": "2.11.0",
+    "native-base": "2.13.12",
     "patch-package": "^6.2.0",
     "path-browserify": "0.0.0",
     "polished": "^1.9.2",
@@ -211,7 +211,8 @@
     "react-native-storybook-loader": "^1.8.1",
     "react-test-renderer": "16.9.0",
     "redux-mock-store": "^1.5.1",
-    "util-deprecate": "^1.0.2"
+    "util-deprecate": "^1.0.2",
+    "babel-plugin-transform-remove-console": "^6.9.4"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
+++ b/src/components/Modals/SlideModal/__tests__/__snapshots__/SlideModal.test.js.snap
@@ -597,7 +597,6 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
               Object {
                 "backgroundColor": "#fff",
                 "elevation": 4,
-                "height": NaN,
                 "maxHeight": 667,
                 "minHeight": 56,
                 "opacity": 1,
@@ -627,10 +626,14 @@ exports[`Slide Modal should render SlideModal correctly 1`] = `
               scrollEventThrottle={50}
               stickyHeaderIndices={Array []}
               style={
-                Object {
-                  "marginHorizontal": -15,
-                  "marginTop": 0,
-                }
+                Array [
+                  Object {
+                    "marginHorizontal": -15,
+                  },
+                  Object {
+                    "marginTop": 0,
+                  },
+                ]
               }
               updateCellsBatchingPeriod={50}
               viewabilityConfigCallbackPairs={Array []}

--- a/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
+++ b/src/screens/Asset/__tests__/__snapshots__/Asset.test.js.snap
@@ -2219,7 +2219,6 @@ exports[`Asset renders the Asset Screen correctly 1`] = `
                   Object {
                     "backgroundColor": "#fff",
                     "elevation": 4,
-                    "height": NaN,
                     "maxHeight": 667,
                     "minHeight": 56,
                     "opacity": 1,
@@ -2249,10 +2248,14 @@ exports[`Asset renders the Asset Screen correctly 1`] = `
                   scrollEventThrottle={50}
                   stickyHeaderIndices={Array []}
                   style={
-                    Object {
-                      "marginHorizontal": -15,
-                      "marginTop": 0,
-                    }
+                    Array [
+                      Object {
+                        "marginHorizontal": -15,
+                      },
+                      Object {
+                        "marginTop": 0,
+                      },
+                    ]
                   }
                   updateCellsBatchingPeriod={50}
                   viewabilityConfigCallbackPairs={Array []}
@@ -2854,7 +2857,6 @@ exports[`Asset renders the Asset Screen correctly 1`] = `
                   Object {
                     "backgroundColor": "#fff",
                     "elevation": 4,
-                    "height": NaN,
                     "maxHeight": 667,
                     "minHeight": 56,
                     "opacity": 1,
@@ -2884,10 +2886,14 @@ exports[`Asset renders the Asset Screen correctly 1`] = `
                   scrollEventThrottle={50}
                   stickyHeaderIndices={Array []}
                   style={
-                    Object {
-                      "marginHorizontal": -15,
-                      "marginTop": 0,
-                    }
+                    Array [
+                      Object {
+                        "marginHorizontal": -15,
+                      },
+                      Object {
+                        "marginTop": 0,
+                      },
+                    ]
                   }
                   updateCellsBatchingPeriod={50}
                   viewabilityConfigCallbackPairs={Array []}

--- a/storybook/__snapshots__/storyshots.test.js.snap
+++ b/storybook/__snapshots__/storyshots.test.js.snap
@@ -635,7 +635,6 @@ exports[`Storyshots ActionModal default 1`] = `
               Object {
                 "backgroundColor": "#fff",
                 "elevation": 4,
-                "height": NaN,
                 "maxHeight": 667,
                 "minHeight": 56,
                 "opacity": 1,
@@ -665,10 +664,14 @@ exports[`Storyshots ActionModal default 1`] = `
               scrollEventThrottle={50}
               stickyHeaderIndices={Array []}
               style={
-                Object {
-                  "marginHorizontal": -15,
-                  "marginTop": 0,
-                }
+                Array [
+                  Object {
+                    "marginHorizontal": -15,
+                  },
+                  Object {
+                    "marginTop": 0,
+                  },
+                ]
               }
               updateCellsBatchingPeriod={50}
               viewabilityConfigCallbackPairs={Array []}
@@ -10463,7 +10466,6 @@ Array [
                 Object {
                   "backgroundColor": "#fff",
                   "elevation": 4,
-                  "height": NaN,
                   "maxHeight": 667,
                   "minHeight": 56,
                   "opacity": 1,
@@ -10493,10 +10495,14 @@ Array [
                 scrollEventThrottle={50}
                 stickyHeaderIndices={Array []}
                 style={
-                  Object {
-                    "marginHorizontal": -15,
-                    "marginTop": 0,
-                  }
+                  Array [
+                    Object {
+                      "marginHorizontal": -15,
+                    },
+                    Object {
+                      "marginTop": 0,
+                    },
+                  ]
                 }
                 updateCellsBatchingPeriod={50}
                 viewabilityConfigCallbackPairs={Array []}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,7 +5426,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.8.2, color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=
@@ -5450,7 +5450,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=
 
-color-string@^1.4.0, color-string@^1.5.2:
+color-string@^1.5.2:
   version "1.5.3"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
   integrity sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=
@@ -5463,21 +5463,13 @@ color-support@^1.1.3:
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=
 
-color@^3.1.2:
+color@^3.1.2, color@~3.1.2:
   version "3.1.2"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
   integrity sha1-aBSOf4XUGtdknF+oyBBvCY0inhA=
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
-
-color@~1.0.3:
-  version "1.0.3"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/color/-/color-1.0.3.tgz#e48e832d85f14ef694fb468811c2d5cfe729b55d"
-  integrity sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=
-  dependencies:
-    color-convert "^1.8.2"
-    color-string "^1.4.0"
 
 colorette@^1.0.7:
   version "1.1.0"
@@ -7011,6 +7003,13 @@ eslint-config-airbnb@^16.1.0:
   integrity sha1-JUa/sCzJ/pIoS/FyPM8uh7xFykY=
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
+
+eslint-config-prettier@^6.0.0:
+  version "6.11.0"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
+  integrity sha1-9tIjjBKQ0ByFmotcH301KgsNqLE=
+  dependencies:
+    get-stdin "^6.0.0"
 
 eslint-import-resolver-babel-module@5.0.0-beta.0:
   version "5.0.0-beta.0"
@@ -8559,6 +8558,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha1-ngm/cSs2CrkiXoEgSPcf3pyJZXs=
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -11821,17 +11825,12 @@ lodash.uniq@^4.5.0:
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=
-
 lodash@4.17.4:
   version "4.17.4"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
-lodash@^4.0.0, lodash@^4.10.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=
@@ -12761,33 +12760,36 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-base-shoutem-theme@0.2.2:
-  version "0.2.2"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/native-base-shoutem-theme/-/native-base-shoutem-theme-0.2.2.tgz#5823310455fe391adf72236469c039fd44f56a20"
-  integrity sha1-WCMxBFX+ORrfciNkacA5/UT1aiA=
+native-base-shoutem-theme@0.3.1:
+  version "0.3.1"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/native-base-shoutem-theme/-/native-base-shoutem-theme-0.3.1.tgz#f15cbd4ca74ca1c8b6a636d297b9164a5f2b3662"
+  integrity sha1-8Vy9TKdMoci2pjbSl7kWSl8rNmI=
   dependencies:
     hoist-non-react-statics "^1.0.5"
-    lodash "^4.10.1"
+    lodash "^4.17.14"
     prop-types "^15.5.10"
 
-native-base@2.11.0:
-  version "2.11.0"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/native-base/-/native-base-2.11.0.tgz#853ec5efed54a294e649662ec310c19785fdb2f2"
-  integrity sha1-hT7F7+1UopTmSWYuwxDBl4X9svI=
+native-base@2.13.12:
+  version "2.13.12"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/native-base/-/native-base-2.13.12.tgz#06020b46019964ddaef3a646ec07e72008018efc"
+  integrity sha1-BgILRgGZZN2u86ZG7AfnIAgBjvw=
   dependencies:
     blueimp-md5 "^2.5.0"
     clamp "^1.0.1"
-    color "~1.0.3"
+    color "~3.1.2"
+    create-react-class "^15.6.3"
+    eslint-config-prettier "^6.0.0"
     fs-extra "^2.0.0"
     jest-react-native "^18.0.0"
-    lodash "4.17.10"
-    native-base-shoutem-theme "0.2.2"
+    lodash "^4.17.14"
+    native-base-shoutem-theme "0.3.1"
+    opencollective-postinstall "^2.0.2"
     print-message "^2.1.0"
     prop-types "^15.5.10"
     react-native-drawer "2.5.1"
-    react-native-easy-grid "0.2.0"
-    react-native-keyboard-aware-scroll-view "0.8.0"
-    react-native-vector-icons "6.1.0"
+    react-native-easy-grid "0.2.2"
+    react-native-keyboard-aware-scroll-view "0.9.1"
+    react-native-vector-icons "^6.6.0"
     react-timer-mixin "^0.13.4"
     react-tween-state "^0.1.5"
     tween-functions "^1.0.1"
@@ -13257,7 +13259,7 @@ open@^7.0.0:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-opencollective-postinstall@^2.0.1:
+opencollective-postinstall@^2.0.1, opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha1-Vlfxvt5ptuM6RZObBh61PTxsOok=
@@ -14989,12 +14991,12 @@ react-native-drawer@2.5.1:
     prop-types "^15.5.8"
     tween-functions "^1.0.1"
 
-react-native-easy-grid@0.2.0:
-  version "0.2.0"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-easy-grid/-/react-native-easy-grid-0.2.0.tgz#4718031aa1baaa2613b829fc807da288eb0d2797"
-  integrity sha1-RxgDGqG6qiYTuCn8gH2iiOsNJ5c=
+react-native-easy-grid@0.2.2:
+  version "0.2.2"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-easy-grid/-/react-native-easy-grid-0.2.2.tgz#f0be33620be1ebe2d2295918eb58b0a27e8272ab"
+  integrity sha1-8L4zYgvh6+LSKVkY61iwon6Ccqs=
   dependencies:
-    lodash "^4.11.1"
+    lodash "^4.17.15"
 
 react-native-emoji@^1.6.0:
   version "1.8.0"
@@ -15063,15 +15065,7 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha1-ZF4v+7tJ6AhEu0y740oSb9oeZ3I=
 
-react-native-keyboard-aware-scroll-view@0.8.0:
-  version "0.8.0"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.8.0.tgz#00bcaa38c91323913bb7a733059ad2bc4875f88c"
-  integrity sha1-ALyqOMkTI5E7t6czBZrSvEh1+Iw=
-  dependencies:
-    prop-types "^15.6.2"
-    react-native-iphone-x-helper "^1.0.3"
-
-react-native-keyboard-aware-scroll-view@^0.9.1:
+react-native-keyboard-aware-scroll-view@0.9.1, react-native-keyboard-aware-scroll-view@^0.9.1:
   version "0.9.1"
   resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.1.tgz#9e54b565a5f19b30bed12221d48921781f7630af"
   integrity sha1-nlS1ZaXxmzC+0SIh1IkheB92MK8=
@@ -15287,15 +15281,6 @@ react-native-udp@^2.6.0:
     inherits "^2.0.1"
     ip-regex "^1.0.3"
     util "^0.10.3"
-
-react-native-vector-icons@6.1.0:
-  version "6.1.0"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/react-native-vector-icons/-/react-native-vector-icons-6.1.0.tgz#770a3f8ced692d75deb3afbb9829195ceed1eedd"
-  integrity sha1-dwo/jO1pLXXes6+7mCkZXO7R7t0=
-  dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.6.2"
-    yargs "^8.0.2"
 
 react-native-vector-icons@^6.6.0:
   version "6.6.0"


### PR DESCRIPTION
https://linear.app/issue/PIL-562/fix-long-start-up-times-in-android

This PR is only a try to solve the issue according to known/found things as I'm unable to replicate in any devices I have around physically.

Includes:
1. According to https://mattermost.com/blog/how-we-improved-our-react-native-cold-start-for-android/ having bundled source code file split using React Native's "ram-bundle" format (ref – https://reactnative.dev/docs/ram-bundles-inline-requires#enable-the-ram-format) might increase startup time.
2. Added babel plugin to remove console prints in production builds (ref – https://reactnative.dev/docs/performance#using-consolelog-statements).
3. Updated `native-base` to latest version. Reason for this is that I was wondering if it might be producing some of current deprecation logs that we have, but it ended up as false, however, I noticed that this lib was not updated for a while and just thought it's a good call to just TRY to update it as it's huge lib, SO – did quick runs for both iOS and Android and both seemed fine which led me to decision to leave it updated in this PR. The only breaking change was ListView which we were not using.