### PR TITLE
PIL-554 Fix SW deployment tx link

### DIFF
--- a/src/screens/Assets/Assets.js
+++ b/src/screens/Assets/Assets.js
@@ -276,9 +276,12 @@ class AssetsScreen extends React.Component<Props, State> {
 
     if (isDeploying && viewType === VIEWS.SMART_WALLET_VIEW) {
       const deploymentHash = getDeploymentHash(smartWalletState);
-      return (
-        <WalletActivation deploymentHash={deploymentHash} />
-      );
+
+      if (deploymentHash) {
+        return (
+          <WalletActivation deploymentHash={deploymentHash} />
+        );
+      }
     }
 
     switch (viewType) {

--- a/src/screens/Assets/WalletActivation.js
+++ b/src/screens/Assets/WalletActivation.js
@@ -44,7 +44,7 @@ const ButtonsWrapper = styled.View`
 `;
 
 type Props = {
-  deploymentHash: ?string,
+  deploymentHash: string,
 }
 
 class WalletActivation extends React.PureComponent<Props> {


### PR DESCRIPTION
For the short while the `deploymentHash` is `null`, so that clicking the tx link immediately after showing this screen won't work. This PR shows the wallet activation screen only after the hash is available (we have a nice spinner in the meanwhile anyway).