### PR TITLE
fix/show eth gastoken keybased

### DIFF
--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -277,7 +277,6 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
     if (activeAccount && checkIfSmartWalletAccount(activeAccount)) {
       return this.getSmartWalletTxFeeInWei();
     }
-
     txSpeed = txSpeed || SPEED_TYPES.NORMAL;
     // calculate either with gasLimit in state or provided as param
     if (!gasLimit) {

--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -274,9 +274,16 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
 
   getTxFeeInWei = (txSpeed?: string, gasLimit?: number): BigNumber => {
     const { gasInfo, activeAccount } = this.props;
+    const { feeByGasToken } = this.state;
     if (activeAccount && checkIfSmartWalletAccount(activeAccount)) {
       return this.getSmartWalletTxFeeInWei();
     }
+    if (feeByGasToken) {
+      this.setState({
+        feeByGasToken: false,
+      });
+    }
+
     txSpeed = txSpeed || SPEED_TYPES.NORMAL;
     // calculate either with gasLimit in state or provided as param
     if (!gasLimit) {

--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -168,7 +168,7 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
     txFeeInWei: new BigNumber(0),
     gasLimit: 0,
     gettingFee: true,
-    feeByGasToken: true,
+    feeByGasToken: false,
   };
 
   constructor(props: Props) {
@@ -274,14 +274,8 @@ class ExchangeConfirmScreen extends React.Component<Props, State> {
 
   getTxFeeInWei = (txSpeed?: string, gasLimit?: number): BigNumber => {
     const { gasInfo, activeAccount } = this.props;
-    const { feeByGasToken } = this.state;
     if (activeAccount && checkIfSmartWalletAccount(activeAccount)) {
       return this.getSmartWalletTxFeeInWei();
-    }
-    if (feeByGasToken) {
-      this.setState({
-        feeByGasToken: false,
-      });
     }
 
     txSpeed = txSpeed || SPEED_TYPES.NORMAL;


### PR DESCRIPTION
Set feeByGasToken false when it's not smartwallet
This will set ETH for KeyBased wallets and fix the bug which may be the cause of TransactionFailed in Exchanges