### PR TITLE
[PIL-539] Fix/SW and KW addresses in Receive

### DIFF
--- a/src/components/ListItem/ListItemWithImage.js
+++ b/src/components/ListItem/ListItemWithImage.js
@@ -93,6 +93,7 @@ type Props = {
   badge?: string,
   iconBackgroundColor?: string,
   iconBorder?: boolean,
+  address?: string,
 }
 
 type AddonProps = {

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -254,6 +254,7 @@ class AssetsList extends React.Component<Props, State> {
               },
             );
           }}
+          address={props.address}
           label={name}
           avatarUrl={fullIconUrl}
           balance={{


### PR DESCRIPTION
Add address as prop so that the list item is re-rendered when accounts are switched