### PR TITLE
moved supported gas token state check to selector

### DIFF
--- a/src/actions/historyActions.js
+++ b/src/actions/historyActions.js
@@ -56,7 +56,10 @@ import { extractBitcoinTransactions } from 'utils/bitcoin';
 
 // services
 import smartWalletService from 'services/smartWallet';
+
+// selectors
 import { accountAssetsSelector } from 'selectors/assets';
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 
 // models, types
 import type { ApiNotification } from 'models/Notification';
@@ -158,7 +161,7 @@ export const fetchSmartWalletTransactionsAction = () => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const {
       accounts: { data: accounts },
-      smartWallet: { lastSyncedTransactionId, connectedAccount },
+      smartWallet: { lastSyncedTransactionId },
     } = getState();
 
     const activeAccount = getActiveAccount(accounts);
@@ -172,12 +175,13 @@ export const fetchSmartWalletTransactionsAction = () => {
     const accountId = getActiveAccountId(accounts);
     const smartWalletTransactions = await smartWalletService.getAccountTransactions(lastSyncedTransactionId);
     const accountAssets = accountAssetsSelector(getState());
+    const isSmartWalletAccountGasTokenSupported = isSmartWalletAccountGasTokenSupportedSelector(getState());
     const assetsList = getAssetsAsList(accountAssets);
     const history = parseSmartWalletTransactions(
       smartWalletTransactions,
       supportedAssets,
       assetsList,
-      connectedAccount,
+      isSmartWalletAccountGasTokenSupported,
     );
 
     if (!history.length) return;

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -212,7 +212,6 @@ export const setSmartWalletUpgradeStatusAction = (upgradeStatus: string) => {
 
       const accountAssets = accountAssetsSelector(getState());
       if (isEmpty(accountAssets)) dispatch(fetchInitialAssetsAction(false));
-      dispatch(fetchConnectedAccountAction());
     }
     dispatch({
       type: SET_SMART_WALLET_UPGRADE_STATUS,

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -45,7 +45,6 @@ import {
   PAYMENT_COMPLETED,
   PAYMENT_PROCESSED,
   SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER,
-  SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED,
 } from 'constants/smartWalletConstants';
 import { ACCOUNT_TYPES, UPDATE_ACCOUNTS } from 'constants/accountsConstants';
 import { ETH, SET_INITIAL_ASSETS, UPDATE_BALANCES } from 'constants/assetsConstants';
@@ -98,10 +97,7 @@ import { accountBalancesSelector } from 'selectors/balances';
 // actions
 import { addAccountAction, setActiveAccountAction, switchAccountAction } from 'actions/accountsActions';
 import { saveDbAction } from 'actions/dbActions';
-import {
-  fetchAssetsBalancesAction,
-  fetchInitialAssetsAction,
-} from 'actions/assetsActions';
+import { fetchAssetsBalancesAction, fetchInitialAssetsAction } from 'actions/assetsActions';
 import { fetchCollectiblesAction } from 'actions/collectiblesActions';
 import { fetchSmartWalletTransactionsAction, insertTransactionAction } from 'actions/historyActions';
 
@@ -117,9 +113,7 @@ import type { SendNavigateOptions } from 'models/Navigation';
 import { buildHistoryTransaction, updateAccountHistory, updateHistoryRecord } from 'utils/history';
 import { getActiveAccountAddress, getActiveAccountId, normalizeForEns } from 'utils/accounts';
 import {
-  accountHasGasTokenSupport,
   buildSmartWalletTransactionEstimate,
-  deviceHasGasTokenSupport,
   isConnectedToSmartAccount,
   isHiddenUnsettledTransaction,
 } from 'utils/smartWallet';
@@ -198,6 +192,18 @@ export const loadSmartWalletAccountsAction = (privateKey?: string) => {
   };
 };
 
+export const fetchConnectedAccountAction = () => {
+  return async (dispatch: Dispatch) => {
+    const account = await smartWalletService.fetchConnectedAccount();
+    if (account) {
+      dispatch({
+        type: SET_SMART_WALLET_CONNECTED_ACCOUNT,
+        payload: account,
+      });
+    }
+  };
+};
+
 export const setSmartWalletUpgradeStatusAction = (upgradeStatus: string) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     dispatch(saveDbAction('smartWallet', { upgradeStatus }));
@@ -206,11 +212,7 @@ export const setSmartWalletUpgradeStatusAction = (upgradeStatus: string) => {
 
       const accountAssets = accountAssetsSelector(getState());
       if (isEmpty(accountAssets)) dispatch(fetchInitialAssetsAction(false));
-
-      const { smartWallet: { connectedAccount } } = getState();
-      if (accountHasGasTokenSupport(connectedAccount)) {
-        dispatch({ type: SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED });
-      }
+      dispatch(fetchConnectedAccountAction());
     }
     dispatch({
       type: SET_SMART_WALLET_UPGRADE_STATUS,
@@ -252,13 +254,12 @@ export const connectSmartWalletAccountAction = (accountId: string) => {
         });
         return;
       }
-      if (accountHasGasTokenSupport(connectedAccount)) {
-        connectedAccount = { ...connectedAccount, gasTokenSupported: true };
-      }
       dispatch({
         type: SET_SMART_WALLET_CONNECTED_ACCOUNT,
         payload: connectedAccount,
       });
+    } else {
+      dispatch(fetchConnectedAccountAction());
     }
 
     dispatch(setActiveAccountAction(accountId));
@@ -288,9 +289,7 @@ export const deploySmartWalletAction = () => {
     await dispatch(setActiveAccountAction(accountAddress));
 
     if (accountState === sdkConstants.AccountStates.Deployed) {
-      dispatch(setSmartWalletUpgradeStatusAction(
-        SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE,
-      ));
+      dispatch(setSmartWalletUpgradeStatusAction(SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE));
       printLog('deploySmartWalletAction account is already deployed!');
       return;
     }
@@ -317,20 +316,12 @@ export const deploySmartWalletAction = () => {
 
     // depends from where it's called status might already be `deploying`
     if (upgradeStatus !== SMART_WALLET_UPGRADE_STATUSES.DEPLOYING) {
-      await dispatch(setSmartWalletUpgradeStatusAction(
-        SMART_WALLET_UPGRADE_STATUSES.DEPLOYING,
-      ));
+      await dispatch(setSmartWalletUpgradeStatusAction(SMART_WALLET_UPGRADE_STATUSES.DEPLOYING));
     }
 
     // update account info
     await dispatch(loadSmartWalletAccountsAction());
-    const account = await smartWalletService.fetchConnectedAccount();
-    if (account) {
-      dispatch({
-        type: SET_SMART_WALLET_CONNECTED_ACCOUNT,
-        payload: account,
-      });
-    }
+    dispatch(fetchConnectedAccountAction());
   };
 };
 
@@ -552,13 +543,6 @@ export const onSmartWalletSdkEventAction = (event: Object) => {
           dispatch(setSmartWalletUpgradeStatusAction(SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE));
           navigate(WALLET_ACTIVATED);
         }
-
-        // smart wallet account relayer device deployment check
-        const gasTokenSupportedPrev = get(getState(), 'smartWallet.connectedAccount.gasTokenSupported');
-        const gasTokenSupportedNew = deviceHasGasTokenSupport(event.payload);
-        if (!gasTokenSupportedPrev && gasTokenSupportedNew) {
-          dispatch({ type: SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED });
-        }
       }
     }
 
@@ -705,13 +689,7 @@ export const onSmartWalletSdkEventAction = (event: Object) => {
     if (event.name === ACCOUNT_UPDATED && !event.payload.nextState) {
       // update account info
       await dispatch(loadSmartWalletAccountsAction());
-      const account = await smartWalletService.fetchConnectedAccount();
-      if (account) {
-        dispatch({
-          type: SET_SMART_WALLET_CONNECTED_ACCOUNT,
-          payload: account,
-        });
-      }
+      dispatch(fetchConnectedAccountAction());
     }
 
     printLog(event);
@@ -1361,13 +1339,6 @@ export const switchToGasTokenRelayerAction = () => {
       tag: SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER,
     });
     dispatch(insertTransactionAction(historyTx, accountId));
-    // get updated devices
-    const connectedAccount = await smartWalletService.fetchConnectedAccount();
-    if (connectedAccount) {
-      dispatch({
-        type: SET_SMART_WALLET_CONNECTED_ACCOUNT,
-        payload: connectedAccount,
-      });
-    }
+    dispatch(fetchConnectedAccountAction());
   };
 };

--- a/src/constants/smartWalletConstants.js
+++ b/src/constants/smartWalletConstants.js
@@ -43,4 +43,3 @@ export const SMART_WALLET_DEPLOYMENT_ERRORS = {
 export const PAYMENT_COMPLETED = get(sdkConstants, 'AccountPaymentStates.Completed', '');
 export const PAYMENT_PROCESSED = get(sdkConstants, 'AccountPaymentStates.Processed', '');
 export const SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER = 'SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER';
-export const SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED = 'SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED';

--- a/src/reducers/smartWalletReducer.js
+++ b/src/reducers/smartWalletReducer.js
@@ -28,7 +28,6 @@ import {
   SET_SMART_WALLET_LAST_SYNCED_TRANSACTION_ID,
   START_SMART_WALLET_DEPLOYMENT,
   RESET_SMART_WALLET_DEPLOYMENT,
-  SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED,
 } from 'constants/smartWalletConstants';
 import type { SmartWalletAccount, SmartWalletDeploymentError } from 'models/SmartWalletAccount';
 
@@ -133,14 +132,6 @@ export default function smartWalletReducer(
         upgrade: {
           ...state.upgrade,
           deploymentStarted: false,
-        },
-      };
-    case SET_SMART_WALLET_ACCOUNT_GAS_TOKEN_SUPPORTED:
-      return {
-        ...state,
-        connectedAccount: {
-          ...state.connectedAccount,
-          gasTokenSupported: true,
         },
       };
     default:

--- a/src/screens/Exchange/ExchangeOffers.js
+++ b/src/screens/Exchange/ExchangeOffers.js
@@ -68,7 +68,7 @@ import type { SessionData } from 'models/Session';
 
 //  selectors
 import { accountBalancesSelector } from 'selectors/balances';
-import { activeAccountSelector } from 'selectors';
+import { activeAccountSelector, isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 import { accountAssetsSelector } from 'selectors/assets';
 
 // utils
@@ -130,7 +130,7 @@ type Props = {
   activeAccount: ?Account,
   accountAssets: Assets,
   supportedAssets: Asset[],
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -291,7 +291,7 @@ class ExchangeOffers extends React.Component<Props, State> {
       activeAccount,
       accountAssets,
       supportedAssets,
-      smartWalletAccountSupportsGasToken,
+      isSmartWalletAccountGasTokenSupported,
     } = this.props;
 
     const {
@@ -341,7 +341,7 @@ class ExchangeOffers extends React.Component<Props, State> {
           },
         };
 
-        if (activeAccount && checkIfSmartWalletAccount(activeAccount) && smartWalletAccountSupportsGasToken) {
+        if (activeAccount && checkIfSmartWalletAccount(activeAccount) && isSmartWalletAccountGasTokenSupported) {
           const gasTokenData = getAssetDataByAddress(
             getAssetsAsList(accountAssets),
             supportedAssets,
@@ -722,7 +722,6 @@ const mapStateToProps = ({
   rates: { data: rates },
   session: { data: session },
   assets: { supportedAssets },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }: RootReducerState): $Shape<Props> => ({
   accounts,
   baseFiatCurrency,
@@ -736,13 +735,13 @@ const mapStateToProps = ({
   rates,
   session,
   supportedAssets,
-  smartWalletAccountSupportsGasToken,
 });
 
 const structuredSelector = createStructuredSelector({
   balances: accountBalancesSelector,
   activeAccount: activeAccountSelector,
   accountAssets: accountAssetsSelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -39,7 +39,11 @@ import smartWalletService from 'services/smartWallet';
 import { buildERC721TransactionData, calculateGasEstimate, fetchRinkebyETHBalance } from 'services/assets';
 
 // selectors
-import { activeAccountAddressSelector, activeAccountSelector } from 'selectors';
+import {
+  activeAccountAddressSelector,
+  activeAccountSelector,
+  isSmartWalletAccountGasTokenSupportedSelector,
+} from 'selectors';
 import { accountBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 
@@ -64,7 +68,7 @@ type Props = {
   activeAccount: ?Account,
   accountAssets: Assets,
   supportedAssets: Asset[],
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
   balances: Balances,
   contactsSmartAddresses: ContactSmartAddressData[],
 };
@@ -115,12 +119,12 @@ class SendCollectibleConfirm extends React.Component<Props, State> {
       activeAccount,
       accountAssets,
       supportedAssets,
-      smartWalletAccountSupportsGasToken,
+      isSmartWalletAccountGasTokenSupported,
     } = props;
     const gasTokenData = getAssetDataByAddress(getAssetsAsList(accountAssets), supportedAssets, GAS_TOKEN_ADDRESS);
     const isSmartAccount = activeAccount && checkIfSmartWalletAccount(activeAccount);
     if (isSmartAccount
-      && smartWalletAccountSupportsGasToken
+      && isSmartWalletAccountGasTokenSupported
       && !isEmpty(gasTokenData)) {
       const { decimals, address, symbol } = gasTokenData;
       this.gasToken = { decimals, address, symbol };
@@ -440,7 +444,6 @@ const mapStateToProps = ({
   wallet: { data: wallet },
   accounts: { data: accounts },
   assets: { supportedAssets },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }: RootReducerState): $Shape<Props> => ({
   contacts,
   session,
@@ -448,7 +451,6 @@ const mapStateToProps = ({
   wallet,
   accounts,
   supportedAssets,
-  smartWalletAccountSupportsGasToken,
   contactsSmartAddresses,
 });
 
@@ -457,6 +459,7 @@ const structuredSelector = createStructuredSelector({
   activeAccountAddress: activeAccountAddressSelector,
   activeAccount: activeAccountSelector,
   accountAssets: accountAssetsSelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/SendToken/SendTokenAmount.js
+++ b/src/screens/SendToken/SendTokenAmount.js
@@ -49,7 +49,11 @@ import type { Transaction } from 'models/Transaction';
 
 // selectors
 import { accountBalancesSelector } from 'selectors/balances';
-import { activeAccountAddressSelector, activeAccountSelector } from 'selectors';
+import {
+  activeAccountAddressSelector,
+  activeAccountSelector,
+  isSmartWalletAccountGasTokenSupportedSelector,
+} from 'selectors';
 import { accountAssetsSelector } from 'selectors/assets';
 import { accountHistorySelector } from 'selectors/history';
 
@@ -70,7 +74,7 @@ type Props = {
   updateAppSettings: (path: string, value: any) => void,
   accountAssets: Assets,
   supportedAssets: Asset[],
-  smartWalletAccountSupportsGasToken: ?boolean,
+  isSmartWalletAccountGasTokenSupported: ?boolean,
   accountHistory: Transaction[],
 };
 
@@ -114,7 +118,7 @@ class SendTokenAmount extends React.Component<Props> {
       navigation,
       accountAssets,
       supportedAssets,
-      smartWalletAccountSupportsGasToken,
+      isSmartWalletAccountGasTokenSupported,
       accountHistory,
     } = this.props;
     const { token } = this.assetData;
@@ -126,7 +130,7 @@ class SendTokenAmount extends React.Component<Props> {
     const gasTokenData = getAssetDataByAddress(getAssetsAsList(accountAssets), supportedAssets, GAS_TOKEN_ADDRESS);
     const isSmartAccount = activeAccount && checkIfSmartWalletAccount(activeAccount);
     if (isSmartAccount
-      && smartWalletAccountSupportsGasToken
+      && isSmartWalletAccountGasTokenSupported
       && !isEmpty(gasTokenData)) {
       const { decimals, address, symbol } = gasTokenData;
       gasToken = { decimals, address, symbol };
@@ -160,14 +164,12 @@ const mapStateToProps = ({
   rates: { data: rates },
   appSettings: { data: { baseFiatCurrency, transactionSpeed } },
   assets: { supportedAssets },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }: RootReducerState): $Shape<Props> => ({
   rates,
   session,
   baseFiatCurrency,
   transactionSpeed,
   supportedAssets,
-  smartWalletAccountSupportsGasToken,
 });
 
 const structuredSelector = createStructuredSelector({
@@ -176,6 +178,7 @@ const structuredSelector = createStructuredSelector({
   activeAccountAddress: activeAccountAddressSelector,
   accountAssets: accountAssetsSelector,
   accountHistory: accountHistorySelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Tank/FundConfirm/FundConfirm.js
+++ b/src/screens/Tank/FundConfirm/FundConfirm.js
@@ -23,6 +23,7 @@ import styled from 'styled-components/native';
 import get from 'lodash.get';
 import { BigNumber } from 'bignumber.js';
 import type { NavigationScreenProp } from 'react-navigation';
+import { createStructuredSelector } from 'reselect';
 
 // actions
 import { estimateTopUpVirtualAccountAction, topUpVirtualAccountAction } from 'actions/smartWalletActions';
@@ -45,6 +46,9 @@ import { formatTransactionFee } from 'utils/common';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { TopUpFee } from 'models/PaymentNetwork';
 
+// selectors
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
+
 // other
 import { PPN_TOKEN } from 'configs/assetsConfig';
 
@@ -55,7 +59,7 @@ type Props = {
   topUpFee: TopUpFee,
   estimateTopUpVirtualAccount: (amount: string) => void,
   topUpVirtualAccount: (amount: string, payForGasWithToken: boolean) => void,
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -110,12 +114,12 @@ class FundConfirm extends React.Component<Props, State> {
 
   getTxFeeInWei = (): BigNumber => {
     const gasTokenCost = get(this.props, 'topUpFee.feeInfo.gasTokenCost');
-    if (this.props.smartWalletAccountSupportsGasToken && gasTokenCost) return gasTokenCost;
+    if (this.props.isSmartWalletAccountGasTokenSupported && gasTokenCost) return gasTokenCost;
     return get(this.props, 'topUpFee.feeInfo.totalCost', 0);
   };
 
   getGasToken = () => {
-    return this.props.smartWalletAccountSupportsGasToken
+    return this.props.isSmartWalletAccountGasTokenSupported
       ? get(this.props, 'topUpFee.feeInfo.gasToken')
       : null;
   };
@@ -168,11 +172,18 @@ class FundConfirm extends React.Component<Props, State> {
 const mapStateToProps = ({
   session: { data: session },
   paymentNetwork: { topUpFee },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }: RootReducerState): $Shape<Props> => ({
   session,
   topUpFee,
-  smartWalletAccountSupportsGasToken,
+});
+
+const structuredSelector = createStructuredSelector({
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
+});
+
+const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
+  ...structuredSelector(state),
+  ...mapStateToProps(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
@@ -183,4 +194,4 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   estimateTopUpVirtualAccount: (amount: string) => dispatch(estimateTopUpVirtualAccountAction(amount)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(FundConfirm);
+export default connect(combinedMapStateToProps, mapDispatchToProps)(FundConfirm);

--- a/src/screens/Tank/FundTank/FundTank.js
+++ b/src/screens/Tank/FundTank/FundTank.js
@@ -61,6 +61,7 @@ import { estimateTopUpVirtualAccountAction } from 'actions/smartWalletActions';
 // selectors
 import { accountBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 
 
 const ActionsWrapper = styled.View`
@@ -102,7 +103,7 @@ type Props = {
   topUpFee: TopUpFee,
   rates: Rates,
   baseFiatCurrency: ?string,
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -164,12 +165,12 @@ class FundTank extends React.Component<Props, State> {
 
   getTxFeeInWei = (): BigNumber => {
     const gasTokenCost = get(this.props, 'topUpFee.feeInfo.gasTokenCost');
-    if (this.props.smartWalletAccountSupportsGasToken && gasTokenCost) return gasTokenCost;
+    if (this.props.isSmartWalletAccountGasTokenSupported && gasTokenCost) return gasTokenCost;
     return get(this.props, 'topUpFee.feeInfo.totalCost', 0);
   };
 
   getGasToken = () => {
-    return this.props.smartWalletAccountSupportsGasToken
+    return this.props.isSmartWalletAccountGasTokenSupported
       ? get(this.props, 'topUpFee.feeInfo.gasToken')
       : null;
   };
@@ -303,18 +304,17 @@ const mapStateToProps = ({
   rates: { data: rates },
   paymentNetwork: { topUpFee },
   appSettings: { data: { baseFiatCurrency } },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }: RootReducerState): $Shape<Props> => ({
   rates,
   session,
   topUpFee,
   baseFiatCurrency,
-  smartWalletAccountSupportsGasToken,
 });
 
 const structuredSelector = createStructuredSelector({
   balances: accountBalancesSelector,
   assets: accountAssetsSelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
+++ b/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
@@ -41,6 +41,7 @@ import Spinner from 'components/Spinner';
 
 // selectors
 import { accountBalancesSelector } from 'selectors/balances';
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 
 // types
 import type { Balances } from 'models/Asset';
@@ -59,7 +60,7 @@ type Props = {
   settleTxFee: SettleTxFee,
   balances: Balances,
   estimateSettleBalance: Function,
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -152,12 +153,12 @@ class SettleBalanceConfirm extends React.Component<Props, State> {
 
   getTxFeeInWei = (): BigNumber => {
     const gasTokenCost = get(this.props, 'settleTxFee.feeInfo.gasTokenCost');
-    if (this.props.smartWalletAccountSupportsGasToken && gasTokenCost) return gasTokenCost;
+    if (this.props.isSmartWalletAccountGasTokenSupported && gasTokenCost) return gasTokenCost;
     return get(this.props, 'settleTxFee.feeInfo.totalCost', 0);
   };
 
   getGasToken = () => {
-    return this.props.smartWalletAccountSupportsGasToken
+    return this.props.isSmartWalletAccountGasTokenSupported
       ? get(this.props, 'settleTxFee.feeInfo.gasToken')
       : null;
   };
@@ -220,15 +221,14 @@ class SettleBalanceConfirm extends React.Component<Props, State> {
 const mapStateToProps = ({
   session: { data: session },
   paymentNetwork: { settleTxFee },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }) => ({
   session,
   settleTxFee,
-  smartWalletAccountSupportsGasToken,
 });
 
 const structuredSelector = createStructuredSelector({
   balances: accountBalancesSelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state) => ({

--- a/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
+++ b/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
@@ -61,6 +61,7 @@ import { estimateWithdrawFromVirtualAccountAction } from 'actions/smartWalletAct
 import { accountBalancesSelector } from 'selectors/balances';
 import { availableStakeSelector } from 'selectors/paymentNetwork';
 import { accountAssetsSelector } from 'selectors/assets';
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 
 
 const ActionsWrapper = styled.View`
@@ -103,7 +104,7 @@ type Props = {
   withdrawalFee: WithdrawalFee,
   rates: Rates,
   baseFiatCurrency: string,
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -167,12 +168,12 @@ class TankWithdrawal extends React.Component<Props, State> {
 
   getTxFeeInWei = (): BigNumber => {
     const gasTokenCost = get(this.props, 'withdrawalFee.feeInfo.gasTokenCost');
-    if (this.props.smartWalletAccountSupportsGasToken && gasTokenCost) return gasTokenCost;
+    if (this.props.isSmartWalletAccountGasTokenSupported && gasTokenCost) return gasTokenCost;
     return get(this.props, 'withdrawalFee.feeInfo.totalCost', 0);
   };
 
   getGasToken = () => {
-    return this.props.smartWalletAccountSupportsGasToken
+    return this.props.isSmartWalletAccountGasTokenSupported
       ? get(this.props, 'withdrawalFee.feeInfo.gasToken')
       : null;
   };
@@ -302,19 +303,18 @@ const mapStateToProps = ({
   rates: { data: rates },
   paymentNetwork: { withdrawalFee },
   appSettings: { data: { baseFiatCurrency } },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }) => ({
   rates,
   session,
   withdrawalFee,
   baseFiatCurrency,
-  smartWalletAccountSupportsGasToken,
 });
 
 const structuredSelector = createStructuredSelector({
   balances: accountBalancesSelector,
   assets: accountAssetsSelector,
   availableStake: availableStakeSelector,
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
 });
 
 const combinedMapStateToProps = (state) => ({

--- a/src/screens/Tank/TankWithdrawalConfirm/TankWithdrawalConfirm.js
+++ b/src/screens/Tank/TankWithdrawalConfirm/TankWithdrawalConfirm.js
@@ -23,6 +23,7 @@ import styled from 'styled-components/native';
 import get from 'lodash.get';
 import type { NavigationScreenProp } from 'react-navigation';
 import { BigNumber } from 'bignumber.js';
+import { createStructuredSelector } from 'reselect';
 
 // actions
 import {
@@ -46,9 +47,13 @@ import { formatTransactionFee } from 'utils/common';
 
 // types
 import type { WithdrawalFee } from 'models/PaymentNetwork';
+import type { RootReducerState } from 'reducers/rootReducer';
 
 // other
 import { PPN_TOKEN } from 'configs/assetsConfig';
+
+// selectors
+import { isSmartWalletAccountGasTokenSupportedSelector } from 'selectors';
 
 
 type Props = {
@@ -57,7 +62,7 @@ type Props = {
   withdrawalFee: WithdrawalFee,
   estimateWithdrawFromVirtualAccount: Function,
   withdrawFromVirtualAccount: Function,
-  smartWalletAccountSupportsGasToken: boolean,
+  isSmartWalletAccountGasTokenSupported: boolean,
 };
 
 type State = {
@@ -112,12 +117,12 @@ class TankWithdrawalConfirm extends React.Component<Props, State> {
 
   getTxFeeInWei = (): BigNumber => {
     const gasTokenCost = get(this.props, 'withdrawalFee.feeInfo.gasTokenCost');
-    if (this.props.smartWalletAccountSupportsGasToken && gasTokenCost) return gasTokenCost;
+    if (this.props.isSmartWalletAccountGasTokenSupported && gasTokenCost) return gasTokenCost;
     return get(this.props, 'withdrawalFee.feeInfo.totalCost', 0);
   };
 
   getGasToken = () => {
-    return this.props.smartWalletAccountSupportsGasToken
+    return this.props.isSmartWalletAccountGasTokenSupported
       ? get(this.props, 'withdrawalFee.feeInfo.gasToken')
       : null;
   };
@@ -173,11 +178,18 @@ class TankWithdrawalConfirm extends React.Component<Props, State> {
 const mapStateToProps = ({
   session: { data: session },
   paymentNetwork: { withdrawalFee },
-  smartWallet: { connectedAccount: { gasTokenSupported: smartWalletAccountSupportsGasToken } },
 }) => ({
   session,
   withdrawalFee,
-  smartWalletAccountSupportsGasToken,
+});
+
+const structuredSelector = createStructuredSelector({
+  isSmartWalletAccountGasTokenSupported: isSmartWalletAccountGasTokenSupportedSelector,
+});
+
+const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
+  ...structuredSelector(state),
+  ...mapStateToProps(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -188,4 +200,4 @@ const mapDispatchToProps = (dispatch) => ({
   estimateWithdrawFromVirtualAccount: (amount: string) => dispatch(estimateWithdrawFromVirtualAccountAction(amount)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(TankWithdrawalConfirm);
+export default connect(combinedMapStateToProps, mapDispatchToProps)(TankWithdrawalConfirm);

--- a/src/selectors/selectors.js
+++ b/src/selectors/selectors.js
@@ -2,7 +2,7 @@
 import get from 'lodash.get';
 import { createSelector } from 'reselect';
 import { getAccountAddress } from 'utils/accounts';
-import { getSmartWalletStatus } from 'utils/smartWallet';
+import { accountHasGasTokenSupport, getSmartWalletStatus } from 'utils/smartWallet';
 import { SMART_WALLET_UPGRADE_STATUSES } from 'constants/smartWalletConstants';
 
 import type { RootReducerState } from 'reducers/rootReducer';
@@ -64,3 +64,7 @@ export const isSmartWalletActivatedSelector = ({
   const smartWalletStatus: SmartWalletStatus = getSmartWalletStatus(accounts, smartWallet);
   return (smartWalletStatus.status === SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE);
 };
+
+export const isSmartWalletAccountGasTokenSupportedSelector = ({
+  smartWallet: { connectedAccount },
+}: RootReducerState) => accountHasGasTokenSupport(connectedAccount);

--- a/src/utils/smartWallet.js
+++ b/src/utils/smartWallet.js
@@ -147,7 +147,7 @@ export const parseSmartWalletTransactions = (
   smartWalletTransactions: IAccountTransaction[],
   supportedAssets: Asset[],
   assets: Asset[],
-  accountHasGasTokenSupport: boolean,
+  isGasTokenSupportedForAccount: boolean,
 ): Transaction[] => smartWalletTransactions
   .reduce((mapped, smartWalletTransaction) => {
     const {
@@ -267,7 +267,7 @@ export const parseSmartWalletTransactions = (
       };
     } else if (transactionType === AccountTransactionTypes.AddDevice) {
       const addedDeviceAddress = get(smartWalletTransaction, 'extra.address');
-      if (!isEmpty(addedDeviceAddress) && accountHasGasTokenSupport) {
+      if (!isEmpty(addedDeviceAddress) && isGasTokenSupportedForAccount) {
         transaction = {
           ...transaction,
           tag: SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER,

--- a/src/utils/smartWallet.js
+++ b/src/utils/smartWallet.js
@@ -147,7 +147,7 @@ export const parseSmartWalletTransactions = (
   smartWalletTransactions: IAccountTransaction[],
   supportedAssets: Asset[],
   assets: Asset[],
-  connectedAccount: ?Object,
+  isSmartWalletAccountGasTokenSupported: boolean,
 ): Transaction[] => smartWalletTransactions
   .reduce((mapped, smartWalletTransaction) => {
     const {
@@ -267,8 +267,7 @@ export const parseSmartWalletTransactions = (
       };
     } else if (transactionType === AccountTransactionTypes.AddDevice) {
       const addedDeviceAddress = get(smartWalletTransaction, 'extra.address');
-      const gasTokenSupported = accountHasGasTokenSupport(connectedAccount);
-      if (!isEmpty(addedDeviceAddress) && gasTokenSupported) {
+      if (!isEmpty(addedDeviceAddress) && isSmartWalletAccountGasTokenSupported) {
         transaction = {
           ...transaction,
           tag: SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER,

--- a/src/utils/smartWallet.js
+++ b/src/utils/smartWallet.js
@@ -147,7 +147,7 @@ export const parseSmartWalletTransactions = (
   smartWalletTransactions: IAccountTransaction[],
   supportedAssets: Asset[],
   assets: Asset[],
-  isSmartWalletAccountGasTokenSupported: boolean,
+  accountHasGasTokenSupport: boolean,
 ): Transaction[] => smartWalletTransactions
   .reduce((mapped, smartWalletTransaction) => {
     const {
@@ -267,7 +267,7 @@ export const parseSmartWalletTransactions = (
       };
     } else if (transactionType === AccountTransactionTypes.AddDevice) {
       const addedDeviceAddress = get(smartWalletTransaction, 'extra.address');
-      if (!isEmpty(addedDeviceAddress) && isSmartWalletAccountGasTokenSupported) {
+      if (!isEmpty(addedDeviceAddress) && accountHasGasTokenSupport) {
         transaction = {
           ...transaction,
           tag: SMART_WALLET_SWITCH_TO_GAS_TOKEN_RELAYER,


### PR DESCRIPTION
Per title. Reason: recent changes caused gas token state check to fail right after initial deployment so per @jsidorenko suggestion I moved its check fully to selector.