### PR TITLE
Fix scroll view ref in WalletView

### DIFF
--- a/src/screens/Assets/WalletView.js
+++ b/src/screens/Assets/WalletView.js
@@ -172,7 +172,7 @@ class WalletView extends React.Component<Props, State> {
       hideInsightForSearch: false,
     };
     this.doAssetsSearch = debounce(this.doAssetsSearch, 500);
-    this.scrollViewRef = React.createRef();
+    this.scrollViewRef = null;
   }
 
   renderFoundTokensList() {


### PR DESCRIPTION
Attempt to fix [this](https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/1666385228/?environment=production&project=1294444&referrer=alert_email) sentry issue.
I can't reproduce this but I think this crash happened because the ref callback wasn't called or the view wasn't re-rendered after ref changed, so we passed empty ref created by `React.createRef`. So now I changed that to simply `null` and we already have check in `AssetsList` if the passed ref is null so we always have a correct ref or null. 