### PR TITLE
[PIL-580] Remove Bitcoin from account selection Part 1/2

### DIFF
--- a/src/actions/__tests__/onboardingActions.test.js
+++ b/src/actions/__tests__/onboardingActions.test.js
@@ -156,6 +156,7 @@ describe('Wallet actions', () => {
       },
       history: { data: {} },
       appSettings: {},
+      bitcoin: { data: { addresses: [], balances: {} } },
     });
     const expectedActions = [
       { type: UPDATE_ACCOUNTS, payload: [] },
@@ -222,6 +223,7 @@ describe('Wallet actions', () => {
       assets: { data: {} },
       history: { data: {} },
       appSettings: {},
+      bitcoin: { data: { addresses: [], balances: {} } },
     });
     const expectedActions = [
       { type: UPDATE_ACCOUNTS, payload: [] },
@@ -301,6 +303,7 @@ describe('Wallet actions', () => {
       assets: { data: {} },
       history: { data: {} },
       appSettings: {},
+      bitcoin: { data: { addresses: [], balances: {} } },
     });
     const expectedActions = [
       { type: UPDATE_ACCOUNTS, payload: [] },

--- a/src/actions/__tests__/onboardingActions.test.js
+++ b/src/actions/__tests__/onboardingActions.test.js
@@ -50,6 +50,7 @@ import { UPDATE_BADGES } from 'constants/badgesConstants';
 import { SET_USER_SETTINGS } from 'constants/userSettingsConstants';
 import { SET_FEATURE_FLAGS } from 'constants/featureFlagsConstants';
 import { SET_USER_EVENTS } from 'constants/userEventsConstants';
+import { SET_BITCOIN_ADDRESSES } from 'constants/bitcoinConstants';
 import { initialAssets as mockInitialAssets } from 'fixtures/assets';
 import { registerWalletAction } from 'actions/onboardingActions';
 import { transformAssetsToObject } from 'utils/assets';
@@ -132,6 +133,10 @@ const mockOnboarding: Object = {
 const mockBackupStatus: Object = {
   isImported: false,
   isBackedUp: false,
+};
+
+const mockGeneratedBTCAddress = {
+  addresses: ['mna1TuYntMJh74XQh6ur5DAQSFhA6fE2zA'],
 };
 
 describe('Wallet actions', () => {
@@ -260,6 +265,10 @@ describe('Wallet actions', () => {
       {
         type: SET_FEATURE_FLAGS,
         payload: { SMART_WALLET_ENABLED: false, BITCOIN_ENABLED: false },
+      },
+      {
+        type: SET_BITCOIN_ADDRESSES,
+        ...mockGeneratedBTCAddress,
       },
       { type: SET_SMART_WALLET_SDK_INIT, payload: true },
       { type: SET_SMART_WALLET_ACCOUNTS, payload: [mockSmartWalletAccountApiData] },

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -77,6 +77,7 @@ import {
   checkIfSmartWalletAccount,
 } from 'utils/accounts';
 import { findMatchingContact } from 'utils/contacts';
+import { satoshisToBtc } from 'utils/bitcoin';
 import { accountBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector, makeAccountEnabledAssetsSelector } from 'selectors/assets';
 import { logEventAction } from 'actions/analyticsActions';
@@ -90,6 +91,7 @@ import { sendTxNoteByContactAction } from './txNoteActions';
 import { showAssetAction } from './userSettingsActions';
 import { fetchAccountAssetsRatesAction, fetchAllAccountsAssetsRatesAction } from './ratesActions';
 import { addEnsRegistryRecordAction } from './ensRegistryActions';
+import { refreshBitcoinBalanceAction } from './bitcoinActions';
 
 type TransactionStatus = {
   isSuccess: boolean,
@@ -380,6 +382,16 @@ export const fetchAccountAssetsBalancesAction = (account: Account, showToastIfIn
       address: walletAddress,
       assets: getAssetsAsList(accountAssets).filter(({ symbol }) => symbol !== 'BTC'),
     });
+
+    if (accountAssets.BTC) {
+      const btcBalance = await dispatch(refreshBitcoinBalanceAction(true));
+      if (btcBalance) {
+        newBalances.push({
+          balance: satoshisToBtc(btcBalance.confirmed).toString(),
+          symbol: 'BTC',
+        });
+      }
+    }
 
     if (!isEmpty(newBalances)) {
       await dispatch(updateAccountBalancesAction(accountId, transformBalancesToObject(newBalances)));

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -33,6 +33,7 @@ import {
   FETCHING_INITIAL,
   FETCH_INITIAL_FAILED,
   ETH,
+  BTC,
   UPDATE_BALANCES,
   UPDATE_SUPPORTED_ASSETS,
   COLLECTIBLES,
@@ -380,7 +381,7 @@ export const fetchAccountAssetsBalancesAction = (account: Account, showToastIfIn
 
     const newBalances = await api.fetchBalances({
       address: walletAddress,
-      assets: getAssetsAsList(accountAssets).filter(({ symbol }) => symbol !== 'BTC'),
+      assets: getAssetsAsList(accountAssets).filter(({ symbol }) => symbol !== BTC),
     });
 
     if (accountAssets.BTC) {
@@ -388,7 +389,7 @@ export const fetchAccountAssetsBalancesAction = (account: Account, showToastIfIn
       if (btcBalance) {
         newBalances.push({
           balance: satoshisToBtc(btcBalance.confirmed).toString(),
-          symbol: 'BTC',
+          symbol: BTC,
         });
       }
     }
@@ -596,8 +597,8 @@ export const loadSupportedAssetsAction = () => {
     // nothing to do if returned empty
     if (isEmpty(supportedAssets)) return;
 
-    if (!supportedAssets.some(e => e.symbol === 'BTC')) {
-      const btcAsset = assetFixtures.find(e => e.symbol === 'BTC');
+    if (!supportedAssets.some(e => e.symbol === BTC)) {
+      const btcAsset = assetFixtures.find(e => e.symbol === BTC);
       if (btcAsset) {
         supportedAssets.push(btcAsset);
       }

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -203,7 +203,6 @@ export const loginAction = (
         dispatch(signalInitAction({ ...signalCredentials, ...oAuthTokens }));
 
         const smartWalletFeatureEnabled = get(getState(), 'featureFlags.data.SMART_WALLET_ENABLED');
-        const bitcoinFeatureEnabled = get(getState(), 'featureFlags.data.BITCOIN_ENABLED');
 
         // init smart wallet
         if (smartWalletFeatureEnabled && wallet.privateKey && userHasSmartWallet(accounts)) {
@@ -214,8 +213,7 @@ export const loginAction = (
         // if we disable feature flag or end beta testing program
         // while user has set PPN or BTC as active network
         const revertToDefaultNetwork =
-          (!smartWalletFeatureEnabled && blockchainNetwork === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK) ||
-          (!bitcoinFeatureEnabled && blockchainNetwork === BLOCKCHAIN_NETWORK_TYPES.BITCOIN);
+          !smartWalletFeatureEnabled && blockchainNetwork === BLOCKCHAIN_NETWORK_TYPES.PILLAR_NETWORK;
 
         let newBlockchainNetwork = blockchainNetwork;
 

--- a/src/actions/bitcoinActions.js
+++ b/src/actions/bitcoinActions.js
@@ -241,7 +241,7 @@ const getKeyPairFromWallet = async (wallet: EthereumWallet) => {
   return root.derivePath(finalPath);
 };
 
-export const initializeBitcoinWalletAction = (wallet: EthereumWallet) => {
+export const initializeBitcoinWalletAction = (wallet: EthereumWallet | Object) => {
   return async (dispatch: Dispatch) => {
     const keyPair = await getKeyPairFromWallet(wallet);
     const address = keyPairAddress(keyPair);

--- a/src/actions/bitcoinActions.js
+++ b/src/actions/bitcoinActions.js
@@ -409,7 +409,7 @@ export const refreshBitcoinBalanceAction = (force: boolean) => {
 
     const addressesToUpdate = force ? addresses : outdatedAddresses(addresses);
     if (!addressesToUpdate.length) {
-      return;
+      return null;
     }
 
     await Promise.all(addressesToUpdate.map(({ address }) => {
@@ -420,6 +420,7 @@ export const refreshBitcoinBalanceAction = (force: boolean) => {
 
     const { bitcoin: { data: { balances } } } = getState();
     dispatch(saveDbAction('bitcoinBalances', { balances }, true));
+    return Promise.resolve(balances[addresses[0].address]);
   };
 };
 

--- a/src/actions/bitcoinActions.js
+++ b/src/actions/bitcoinActions.js
@@ -141,7 +141,7 @@ import {
   UPDATE_UNSPENT_TRANSACTIONS,
   UPDATE_BITCOIN_TRANSACTIONS,
 } from 'constants/bitcoinConstants';
-import { UPDATE_SUPPORTED_ASSETS, UPDATE_ASSETS } from 'constants/assetsConstants';
+import { UPDATE_SUPPORTED_ASSETS, UPDATE_ASSETS, BTC } from 'constants/assetsConstants';
 import { ETHEREUM_PATH, NON_STANDARD_ETHEREUM_PATH } from 'constants/derivationPathConstants';
 import {
   keyPairAddress,
@@ -431,8 +431,8 @@ export const addBTCAssetsAction = () => {
       assets: { data: assets, supportedAssets },
       bitcoin: { data: { addresses } },
     } = getState();
-    if (supportedAssets && !supportedAssets.some(e => e.symbol === 'BTC')) {
-      const btcAsset = initialAssets.find(e => e.symbol === 'BTC');
+    if (supportedAssets && !supportedAssets.some(e => e.symbol === BTC)) {
+      const btcAsset = initialAssets.find(e => e.symbol === BTC);
       if (btcAsset) {
         const updatedSupportedAssets = supportedAssets.concat(btcAsset);
         assets[addresses[0].address] = { BTC: btcAsset };

--- a/src/actions/historyActions.js
+++ b/src/actions/historyActions.js
@@ -482,12 +482,9 @@ export const fetchTransactionsHistoryAction = () => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const {
       accounts: { data: accounts },
-      appSettings: { data: { blockchainNetwork } = {} },
     } = getState();
 
-    if (blockchainNetwork && blockchainNetwork === 'BITCOIN') {
-      return dispatch(fetchBTCTransactionsHistoryAction());
-    }
+    await dispatch(fetchBTCTransactionsHistoryAction());
 
     const activeAccount = getActiveAccount(accounts);
     if (!activeAccount) return Promise.resolve();

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -89,6 +89,7 @@ import { labelUserAsLegacyAction } from 'actions/userActions';
 import { setRatesAction } from 'actions/ratesActions';
 import { resetAppState } from 'actions/authActions';
 import { updateConnectionsAction } from 'actions/connectionsActions';
+import { initializeBitcoinWalletAction } from 'actions/bitcoinActions';
 
 // types
 import type { Dispatch, GetState } from 'reducers/rootReducer';
@@ -212,6 +213,7 @@ const finishRegistration = async ({
 
   const smartWalletFeatureEnabled = get(getState(), 'featureFlags.data.SMART_WALLET_ENABLED', false);
   if (smartWalletFeatureEnabled) {
+    await dispatch(initializeBitcoinWalletAction({ mnemonic, privateKey }));
     // create smart wallet account only for new wallets
     const createNewAccount = !isImported;
     await dispatch(initSmartWalletSdkAction(privateKey));

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -60,7 +60,7 @@ import { getActiveAccount, getAccountName } from 'utils/accounts';
 import { images } from 'utils/images';
 
 // constants
-import { defaultFiatCurrency, ETH } from 'constants/assetsConstants';
+import { defaultFiatCurrency, ETH, BTC } from 'constants/assetsConstants';
 import {
   TYPE_RECEIVED,
   TYPE_ACCEPTED,
@@ -404,7 +404,7 @@ class EventDetail extends React.Component<Props, State> {
   viewOnTheBlockchain = () => {
     const { hash, asset } = this.props.event;
     let url = TX_DETAILS_URL + hash;
-    if (asset && asset === 'BTC') {
+    if (asset && asset === BTC) {
       url = BITCOIN_TX_DETAILS_URL + hash;
     }
     Linking.openURL(url);

--- a/src/fixtures/assets.js
+++ b/src/fixtures/assets.js
@@ -70,7 +70,6 @@ export const initialAssets = [
     website: 'https://pillarproject.io/',
     whitepaper: '',
     isDefault: true,
-    balance: 0,
   },
 ];
 

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -117,7 +117,6 @@ type Props = {|
   assets: Assets,
   baseFiatCurrency: ?string,
   smartWalletFeatureEnabled: boolean,
-  bitcoinFeatureEnabled: boolean,
   availableStake: number,
   isTankInitialised: boolean,
   accounts: Accounts,

--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -47,7 +47,7 @@ import { fetchReferralRewardsIssuerAddressesAction } from 'actions/referralsActi
 
 // constants
 import { EXCHANGE, SEND_TOKEN_FROM_ASSET_FLOW } from 'constants/navigationConstants';
-import { defaultFiatCurrency, SYNTHETIC, NONSYNTHETIC } from 'constants/assetsConstants';
+import { defaultFiatCurrency, SYNTHETIC, NONSYNTHETIC, BTC } from 'constants/assetsConstants';
 import { TRANSACTION_EVENT } from 'constants/historyConstants';
 import { PAYMENT_NETWORK_TX_SETTLEMENT } from 'constants/paymentNetworkConstants';
 
@@ -361,7 +361,7 @@ class AssetScreen extends React.Component<Props, State> {
         }}
         inset={{ bottom: 0 }}
       >
-        {token !== 'BTC' &&
+        {token !== BTC &&
         <ScrollWrapper
           onScrollEndDrag={this.handleScrollWrapperEndDrag}
           refreshControl={
@@ -427,7 +427,7 @@ class AssetScreen extends React.Component<Props, State> {
           />}
         </ScrollWrapper>
         }
-        {token === 'BTC' &&
+        {token === BTC &&
           <BTCView />
         }
         <ReceiveModal

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -318,13 +318,17 @@ class AssetsList extends React.Component<Props, State> {
         {symbol === 'BTC' &&
           <>
             <ListItemWithImage
-              actionLabel="BTC Wallet"
               onPress={() => {
               this.navigateToBTCAsset({ ...props, tokenType: TOKENS });
             }}
               address={props.address}
               label={name}
               avatarUrl={fullIconUrl}
+              balance={{
+                balance: formatAmount(balance),
+                value: formattedBalanceInFiat,
+                token: symbol,
+              }}
               fallbackToGenericToken
             />
             <CheckAuth
@@ -369,9 +373,9 @@ class AssetsList extends React.Component<Props, State> {
       .map(id => assets[id])
       .map(({ symbol, ...rest }) => ({
         symbol,
-        balance: getBalance(balances, symbol),
         paymentNetworkBalance: getBalance(paymentNetworkBalances, symbol),
         ...rest,
+        balance: getBalance(balances, symbol),
       }))
       .map(({ balance, symbol, paymentNetworkBalance, ...rest }) => ({ // eslint-disable-line
         balance,

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -36,7 +36,7 @@ import Toast from 'components/Toast';
 import CheckAuth from 'components/CheckAuth';
 
 // constants
-import { defaultFiatCurrency, TOKENS, ETH, PLR } from 'constants/assetsConstants';
+import { defaultFiatCurrency, TOKENS, ETH, PLR, BTC } from 'constants/assetsConstants';
 import { ASSET, ASSETS } from 'constants/navigationConstants';
 import { BLOCKCHAIN_NETWORK_TYPES } from 'constants/blockchainNetworkConstants';
 // actions
@@ -292,7 +292,7 @@ class AssetsList extends React.Component<Props, State> {
           if (scrollViewRef) scrollViewRef.setNativeProps({ scrollEnabled: shouldAllowScroll });
         }}
       >
-        {symbol !== 'BTC' &&
+        {symbol !== BTC &&
           <ListItemWithImage
             onPress={() => {
               navigation.navigate(ASSET,
@@ -315,7 +315,7 @@ class AssetsList extends React.Component<Props, State> {
             fallbackToGenericToken
           />
         }
-        {symbol === 'BTC' &&
+        {symbol === BTC &&
           <>
             <ListItemWithImage
               onPress={() => {

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -196,19 +196,17 @@ class AssetsList extends React.Component<Props, State> {
 
   initialiseBTC = (assetData: Object) => {
     return async (_: string, wallet: EthereumWallet) => {
-      const { navigation, setActiveBlockchainNetwork, initializeBitcoinWallet } = this.props;
+      const { navigation, initializeBitcoinWallet } = this.props;
       this.setState({ showPinModal: false });
       await initializeBitcoinWallet(wallet);
-      setActiveBlockchainNetwork(BLOCKCHAIN_NETWORK_TYPES.BITCOIN);
       navigation.navigate(ASSET, { assetData, onBackPress: this.onBackPress });
     };
   }
 
   navigateToBTCAsset = (assetData: Object) => {
-    const { navigation, setActiveBlockchainNetwork, bitcoinAddresses } = this.props;
+    const { navigation, bitcoinAddresses } = this.props;
     const isInitialised = bitcoinAddresses.length > 0;
     if (isInitialised) {
-      setActiveBlockchainNetwork(BLOCKCHAIN_NETWORK_TYPES.BITCOIN);
       navigation.navigate(ASSET, { assetData, onBackPress: this.onBackPress });
       return;
     }

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -49,7 +49,7 @@ import { hasSeenExchangeIntroAction } from 'actions/appSettingsActions';
 
 // constants
 import { EXCHANGE_INFO } from 'constants/navigationConstants';
-import { defaultFiatCurrency, ETH, POPULAR_EXCHANGE_TOKENS, POPULAR_SWAPS } from 'constants/assetsConstants';
+import { defaultFiatCurrency, ETH, POPULAR_EXCHANGE_TOKENS, POPULAR_SWAPS, BTC } from 'constants/assetsConstants';
 import { SMART_WALLET_UPGRADE_STATUSES } from 'constants/smartWalletConstants';
 import { ACCOUNT_TYPES } from 'constants/accountsConstants';
 
@@ -619,7 +619,7 @@ class ExchangeScreen extends React.Component<Props, State> {
   }));
 
   generateBTCAssetOption = () => {
-    const symbol = 'BTC';
+    const symbol = BTC;
     const {
       btcAddresses,
       btcBalances,
@@ -663,7 +663,7 @@ class ExchangeScreen extends React.Component<Props, State> {
           assetBalance,
           formattedBalanceInFiat,
         };
-      }).filter(asset => asset.key !== 'BTC');
+      }).filter(asset => asset.key !== BTC);
   };
 
   handleFormChange = (value: Object) => {

--- a/src/screens/Exchange/ExchangeOffers.js
+++ b/src/screens/Exchange/ExchangeOffers.js
@@ -47,7 +47,7 @@ import OfferCard from 'components/OfferCard/OfferCard';
 // constants
 import { EXCHANGE, PROVIDER_SHAPESHIFT } from 'constants/exchangeConstants';
 import { EXCHANGE_CONFIRM, FIAT_EXCHANGE, SEND_TOKEN_PIN_CONFIRM } from 'constants/navigationConstants';
-import { defaultFiatCurrency, ETH, SPEED_TYPES } from 'constants/assetsConstants';
+import { defaultFiatCurrency, ETH, SPEED_TYPES, BTC } from 'constants/assetsConstants';
 
 // services
 import { wyreWidgetUrl } from 'services/sendwyre';
@@ -488,7 +488,7 @@ class ExchangeOffers extends React.Component<Props, State> {
     const { code: toAssetCode } = toAsset;
 
     let destAddress;
-    if (toAssetCode === 'BTC') {
+    if (toAssetCode === BTC) {
       destAddress = btcAddresses[0].address;
     } else {
       destAddress = getActiveAccountAddress(accounts);

--- a/src/screens/FiatExchange/FiatExchange.js
+++ b/src/screens/FiatExchange/FiatExchange.js
@@ -29,6 +29,7 @@ import {
 import ContainerWithHeader from 'components/Layout/ContainerWithHeader';
 import { Wrapper } from 'components/Layout';
 import ErrorMessage from 'components/ErrorMessage';
+import { BTC } from 'constants/assetsConstants';
 import { setBrowsingWebViewAction } from 'actions/appSettingsActions';
 import { getActiveAccountAddress } from 'utils/accounts';
 
@@ -78,7 +79,7 @@ class FiatExchange extends React.Component<Props, State> {
     const { email = '' } = user;
 
     let destAddress;
-    if (destCurrency === 'BTC') {
+    if (destCurrency === BTC) {
       destAddress = btcAddresses[0].address;
     } else {
       destAddress = getActiveAccountAddress(accounts);

--- a/src/screens/Home/ActionButtons.js
+++ b/src/screens/Home/ActionButtons.js
@@ -60,7 +60,6 @@ type Props = {
   baseFiatCurrency: ?string,
   rates: Rates,
   balances: BalancesStore,
-  bitcoinFeatureEnabled: boolean,
   bitcoinBalances: BitcoinBalance,
   bitcoinAddresses: BitcoinAddress[],
   supportedAssets: Asset[],
@@ -299,12 +298,11 @@ class ActionButtons extends React.Component<Props, State> {
     const {
       balances,
       bitcoinBalances,
-      bitcoinFeatureEnabled,
       bitcoinAddresses,
     } = this.props;
     const modalActions = this.getModalActions();
     const isSendButtonActive = !!Object.keys(balances).length ||
-      (bitcoinFeatureEnabled && bitcoinAddresses.length > 0 && !!Object.keys(bitcoinBalances).length);
+      (bitcoinAddresses.length > 0 && !!Object.keys(bitcoinBalances).length);
 
     return (
       <React.Fragment>
@@ -347,11 +345,6 @@ const mapStateToProps = ({
   appSettings: { data: { baseFiatCurrency, blockchainNetwork } },
   rates: { data: rates },
   balances: { data: balances },
-  featureFlags: {
-    data: {
-      BITCOIN_ENABLED: bitcoinFeatureEnabled,
-    },
-  },
   bitcoin: { data: { addresses: bitcoinAddresses, balances: bitcoinBalances } },
   assets: {
     supportedAssets,
@@ -361,7 +354,6 @@ const mapStateToProps = ({
   blockchainNetwork,
   rates,
   balances,
-  bitcoinFeatureEnabled,
   bitcoinBalances,
   bitcoinAddresses,
   supportedAssets,

--- a/src/screens/Home/ActionButtons.js
+++ b/src/screens/Home/ActionButtons.js
@@ -45,6 +45,7 @@ import { setActiveBlockchainNetworkAction } from 'actions/blockchainNetworkActio
 import { calculateBalanceInFiat } from 'utils/assets';
 import { formatFiat } from 'utils/common';
 import { calculateBitcoinBalanceInFiat } from 'utils/bitcoin';
+import { findFirstSmartAccount } from 'utils/accounts';
 
 // models, types
 import type { Account } from 'models/Account';
@@ -234,6 +235,7 @@ class ActionButtons extends React.Component<Props, State> {
       changeWalletAction,
       blockchainNetwork,
       setActiveBlockchainNetwork,
+      wallets,
     } = this.props;
     const { type: walletType } = acc;
     const { type: activeAccType } = activeWallet;
@@ -262,7 +264,8 @@ class ActionButtons extends React.Component<Props, State> {
         break;
 
       case BLOCKCHAIN_NETWORK_TYPES.BITCOIN:
-        changeWalletAction(acc, () => {
+        const smartAcc = findFirstSmartAccount(wallets);
+        changeWalletAction(smartAcc || acc, () => {
           if (navigateTo === SEND_BITCOIN_FLOW) {
             const btcToken = supportedAssets.find(asset => asset.symbol === BTC);
             if (!btcToken) {

--- a/src/screens/Home/WalletsPart.js
+++ b/src/screens/Home/WalletsPart.js
@@ -35,8 +35,6 @@ import { BLOCKCHAIN_NETWORK_TYPES } from 'constants/blockchainNetworkConstants';
 
 // actions
 import { switchAccountAction } from 'actions/accountsActions';
-import { refreshBitcoinBalanceAction } from 'actions/bitcoinActions';
-import { setActiveBlockchainNetworkAction } from 'actions/blockchainNetworkActions';
 import { toggleBalanceAction } from 'actions/appSettingsActions';
 
 // utils
@@ -117,18 +115,17 @@ class WalletsPart extends React.Component<Props, State> {
 
   getNextWalletInLine = () => {
     const { availableWallets } = this.props;
-    const currentActiveType = getActiveAccountType(availableWallets);
-    const currentWalletIndex = availableWallets.findIndex(({ type }) => type === currentActiveType);
-    const nextIndex = (currentWalletIndex + 1) % availableWallets.length;
+    const filteredWallets = availableWallets.filter(({ type }) => type !== BLOCKCHAIN_NETWORK_TYPES.BITCOIN);
+    const currentActiveType = getActiveAccountType(filteredWallets);
+    const currentWalletIndex = filteredWallets.findIndex(({ type }) => type === currentActiveType);
+    const nextIndex = (currentWalletIndex + 1) % filteredWallets.length;
 
-    return availableWallets[nextIndex] || {};
+    return filteredWallets[nextIndex] || {};
   };
 
   changeAcc = (nextWallet: Account, callback?: () => void, noFullScreenLoader?: boolean) => {
     const {
       switchAccount,
-      setActiveBlockchainNetwork,
-      refreshBitcoinBalance,
       handleWalletChange,
     } = this.props;
 
@@ -143,11 +140,6 @@ class WalletsPart extends React.Component<Props, State> {
       case ACCOUNT_TYPES.SMART_WALLET:
       case ACCOUNT_TYPES.KEY_BASED:
         switchAccount(id);
-        if (callback) callback();
-        break;
-      case BLOCKCHAIN_NETWORK_TYPES.BITCOIN:
-        setActiveBlockchainNetwork(BLOCKCHAIN_NETWORK_TYPES.BITCOIN);
-        refreshBitcoinBalance();
         if (callback) callback();
         break;
       default:
@@ -211,8 +203,6 @@ const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
 
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   switchAccount: (accountId: string) => dispatch(switchAccountAction(accountId)),
-  setActiveBlockchainNetwork: (id: string) => dispatch(setActiveBlockchainNetworkAction(id)),
-  refreshBitcoinBalance: () => dispatch(refreshBitcoinBalanceAction(false)),
   toggleBalance: () => dispatch(toggleBalanceAction()),
 });
 

--- a/src/screens/SendToken/SendTokenAssets.js
+++ b/src/screens/SendToken/SendTokenAssets.js
@@ -207,7 +207,7 @@ class SendTokenAssetsScreen extends React.Component<Props, State> {
 
   renderAssets = () => {
     const { assets, balances } = this.props;
-    const assetsArray = getAssetsAsList(assets);
+    const assetsArray = getAssetsAsList(assets).filter(({ symbol }) => symbol !== 'BTC');
     const nonEmptyAssets = assetsArray.filter((asset: any) => {
       return getBalance(balances, asset.symbol) !== 0;
     });

--- a/src/screens/SendToken/SendTokenAssets.js
+++ b/src/screens/SendToken/SendTokenAssets.js
@@ -49,7 +49,7 @@ import {
   SEND_COLLECTIBLE_CONFIRM,
   SEND_TOKEN_ASSETS,
 } from 'constants/navigationConstants';
-import { ETH, TOKENS, COLLECTIBLES } from 'constants/assetsConstants';
+import { ETH, TOKENS, COLLECTIBLES, BTC } from 'constants/assetsConstants';
 
 import assetsConfig from 'configs/assetsConfig';
 
@@ -207,7 +207,7 @@ class SendTokenAssetsScreen extends React.Component<Props, State> {
 
   renderAssets = () => {
     const { assets, balances } = this.props;
-    const assetsArray = getAssetsAsList(assets).filter(({ symbol }) => symbol !== 'BTC');
+    const assetsArray = getAssetsAsList(assets).filter(({ symbol }) => symbol !== BTC);
     const nonEmptyAssets = assetsArray.filter((asset: any) => {
       return getBalance(balances, asset.symbol) !== 0;
     });

--- a/src/selectors/history.js
+++ b/src/selectors/history.js
@@ -17,10 +17,7 @@ export const accountHistorySelector = createSelector(
   accountAssetsSelector,
   (history, activeAccountId, activeBlockchainNetwork, bitcoinAddresses, activeAssets) => {
     let mergedHistory = [];
-    if (activeBlockchainNetwork
-      && bitcoinAddresses.length
-      && (activeAssets.BTC || activeBlockchainNetwork === 'BITCOIN')
-    ) {
+    if (bitcoinAddresses.length && (activeAssets.BTC || activeBlockchainNetwork === 'BITCOIN')) {
       mergedHistory = [...(history[bitcoinAddresses[0].address] || [])];
     }
     if (!activeAccountId) return [];

--- a/src/selectors/history.js
+++ b/src/selectors/history.js
@@ -14,10 +14,12 @@ export const accountHistorySelector = createSelector(
   activeBlockchainSelector,
   bitcoinAddressSelector,
   (history, activeAccountId, activeBlockchainNetwork, bitcoinAddresses) => {
-    if (activeBlockchainNetwork && activeBlockchainNetwork === 'BITCOIN' && bitcoinAddresses.length) {
-      return orderBy(history[bitcoinAddresses[0].address] || [], ['createdAt'], ['desc']);
+    let mergedHistory = [];
+    if (activeBlockchainNetwork && bitcoinAddresses.length) {
+      mergedHistory = [...(history[bitcoinAddresses[0].address] || [])];
     }
     if (!activeAccountId) return [];
-    return orderBy(history[activeAccountId] || [], ['createdAt'], ['desc']);
+    mergedHistory = [...mergedHistory, ...(history[activeAccountId] || [])];
+    return orderBy(mergedHistory, ['createdAt'], ['desc']);
   },
 );

--- a/src/selectors/history.js
+++ b/src/selectors/history.js
@@ -7,15 +7,20 @@ import {
   activeBlockchainSelector,
   bitcoinAddressSelector,
 } from './selectors';
+import { accountAssetsSelector } from './assets';
 
 export const accountHistorySelector = createSelector(
   historySelector,
   activeAccountIdSelector,
   activeBlockchainSelector,
   bitcoinAddressSelector,
-  (history, activeAccountId, activeBlockchainNetwork, bitcoinAddresses) => {
+  accountAssetsSelector,
+  (history, activeAccountId, activeBlockchainNetwork, bitcoinAddresses, activeAssets) => {
     let mergedHistory = [];
-    if (activeBlockchainNetwork && bitcoinAddresses.length) {
+    if (activeBlockchainNetwork
+      && bitcoinAddresses.length
+      && (activeAssets.BTC || activeBlockchainNetwork === 'BITCOIN')
+    ) {
       mergedHistory = [...(history[bitcoinAddresses[0].address] || [])];
     }
     if (!activeAccountId) return [];

--- a/src/selectors/wallets.js
+++ b/src/selectors/wallets.js
@@ -41,7 +41,7 @@ export const availableWalletsSelector = createSelector(
   activeBlockchainSelector,
   (accounts, bitcoinAddresses, featureFlags, activeBlockchainNetwork) => {
     const isBitcoinActive = isBitcoinNetwork(activeBlockchainNetwork);
-    const { SMART_WALLET_ENABLED: smartWalletFeatureEnabled, BITCOIN_ENABLED: bitcoinFeatureEnabled } = featureFlags;
+    const { SMART_WALLET_ENABLED: smartWalletFeatureEnabled } = featureFlags;
     const keyWallet = accounts.find(({ type }) => type === ACCOUNT_TYPES.KEY_BASED) || {};
     const availableWallets = [{ ...keyWallet, isActive: !isBitcoinActive && keyWallet.isActive }];
 
@@ -55,7 +55,7 @@ export const availableWalletsSelector = createSelector(
       }
     }
 
-    if (bitcoinFeatureEnabled && bitcoinAddresses.length > 0) {
+    if (bitcoinAddresses.length > 0) {
       availableWallets.push(getBitcoinObject(bitcoinAddresses[0].address, isBitcoinActive));
     }
     return availableWallets;

--- a/src/utils/bitcoin.js
+++ b/src/utils/bitcoin.js
@@ -27,7 +27,7 @@ import { getRate } from 'utils/assets';
 export const satoshisToBtc = (satoshis: number): number => satoshis * 0.00000001;
 export const btcToSatoshis = (btc: number): number => Math.floor(btc * 100000000);
 
-const totalBitcoinBalance = (balances: BitcoinBalance) => {
+export const totalBitcoinBalance = (balances: BitcoinBalance) => {
   const addressesBalances = Object.keys(balances).map(key => balances[key]);
 
   return addressesBalances.reduce((acc, { confirmed: balance }) => acc + balance, 0);

--- a/src/utils/bitcoin.js
+++ b/src/utils/bitcoin.js
@@ -83,7 +83,7 @@ export const extractBitcoinTransactions = (address: string, transactions: BTCTra
       to: toAddress,
       from: fromAddress,
       createdAt: new Date(tx.details.blockTime).getTime() / 1000,
-      asset: 'BTC',
+      asset: BTC,
       nbConfirmations: tx.details.confirmations,
       status,
       value,

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -45,6 +45,8 @@ import {
   CURRENCY_SYMBOLS,
   ETHEREUM_ADDRESS_PREFIX,
   BITCOIN_ADDRESS_PREFIX,
+  ETH,
+  BTC,
 } from 'constants/assetsConstants';
 import * as NAVSCREENS from 'constants/navigationConstants';
 
@@ -207,9 +209,9 @@ export const isValidNumber = (amount: string = '0') => {
 
 export const getDecimalPlaces = (assetSymbol: ?string): number => {
   switch (assetSymbol) {
-    case 'ETH':
+    case ETH:
       return 4;
-    case 'BTC':
+    case BTC:
       return 8;
     default:
       return 2;


### PR DESCRIPTION
- Merges balance in balances of an account (SW/KW) if the Bitcoin asset is enabled and BTC is initialized
- Merges the history of transactions by adjusting the history selector
- Filters out BTC in SendAssets screen (TODO optional: find a way to select a contact's btc address and change this back)
- Remove BTC from Accounts and the Account Switcher 9c7710a
- Init BTC on onboarding and graduate it out of featureFlags efac83d

~TODO: Initialize BTC and limit featureflags~

~TODO: remove BTC Wallet from Accounts and Home Switch, and see if the activeNetwork check is necessary everywhere in the app~
