### PR TITLE
PIL-588 Fix/WC-accept

### DIFF
--- a/src/screens/WalletConnect/Requests.js
+++ b/src/screens/WalletConnect/Requests.js
@@ -19,6 +19,7 @@
 */
 import * as React from 'react';
 import { FlatList } from 'react-native';
+import { withNavigation, type NavigationScreenProp } from 'react-navigation';
 import styled, { withTheme } from 'styled-components/native';
 import { CachedImage } from 'react-native-cached-image';
 import { MediumText, BaseText } from 'components/Typography';
@@ -29,13 +30,14 @@ import { spacing, fontSizes } from 'utils/variables';
 import { getThemeColors } from 'utils/themes';
 import type { CallRequest } from 'models/WalletConnect';
 import type { Theme } from 'models/Theme';
+import { WALLETCONNECT_CALL_REQUEST_SCREEN } from 'constants/navigationConstants';
 import withWCRequests from './withWCRequests';
 
 
 type Props = {
+  navigation: NavigationScreenProp<*>,
   requests: CallRequest[],
   rejectWCRequest: (request: CallRequest) => void,
-  acceptWCRequest: (request: CallRequest) => void,
   theme: Theme,
   showLastOneOnly?: boolean,
 };
@@ -69,7 +71,7 @@ const Header = styled(MediumText)`
 
 class Requests extends React.Component<Props> {
   renderRequest = ({ item }) => {
-    const { theme, acceptWCRequest, rejectWCRequest } = this.props;
+    const { theme, rejectWCRequest, navigation } = this.props;
     const { name, icon } = item;
     const colors = getThemeColors(theme);
 
@@ -100,7 +102,7 @@ class Requests extends React.Component<Props> {
               accept
               icon="check"
               fontSize={fontSizes.small}
-              onPress={() => acceptWCRequest(item)}
+              onPress={() => navigation.navigate(WALLETCONNECT_CALL_REQUEST_SCREEN, { callId: item.callId })}
             />
           </ItemContainer>
         </ShadowedCard>
@@ -129,4 +131,4 @@ class Requests extends React.Component<Props> {
   }
 }
 
-export default withWCRequests(withTheme(Requests));
+export default withNavigation(withWCRequests(withTheme(Requests)));

--- a/src/screens/WalletConnect/withWCRequests.js
+++ b/src/screens/WalletConnect/withWCRequests.js
@@ -70,7 +70,7 @@ export default function withWCRequests(WrappedComponent: React.ComponentType<*>)
       note: null,
     };
 
-    getTransactionDetails = (request) => {
+    getTransactionDetails = (request: CallRequest) => {
       if (!request) return {};
 
       const { supportedAssets } = this.props;
@@ -122,12 +122,12 @@ export default function withWCRequests(WrappedComponent: React.ComponentType<*>)
       return isTokenTransfer(data) && contractAddress === '';
     };
 
-    getTransactionPayload = (estimatePart, request): TokenTransactionPayload => {
+    getTransactionPayload = (estimatePart: Object, request: CallRequest): TokenTransactionPayload => {
       const transaction = this.getTransactionDetails(request);
       return { ...estimatePart, ...transaction };
     };
 
-    acceptWCRequest = (request: any, transactionPayload?: TokenTransactionPayload) => {
+    acceptWCRequest = (request: CallRequest, transactionPayload?: TokenTransactionPayload) => {
       const { navigation } = this.props;
 
       switch (request.method) {
@@ -152,7 +152,7 @@ export default function withWCRequests(WrappedComponent: React.ComponentType<*>)
       }
     };
 
-    rejectWCRequest = request => this.props.rejectCallRequest(request.callId);
+    rejectWCRequest = (request: CallRequest) => this.props.rejectCallRequest(request.callId);
 
     handleNoteChange = (text) => this.setState({ note: text });
 


### PR DESCRIPTION
The bug occured only if the user tried to accept a TX via the small WC request card on Home/Connect screens. This PR changes the card to navigate to `WalletConnectCallRequest` instead of trying to accept the request straight away. This is for two reasons:
1) This solution is fast and easy, and I think the issue is urgent. 
2) The card itself is badly thought/designed. Consider this scenario:
 - User receives a WC TX which cannot be accepted, e.g. because they have no funds for fee
 - User escapes the popup `WalletConnectCallRequest` with "back" arrow, or doesn't see it for whatever reason
 - The card is still there, with a pretty blue "accept" icon, so user tries to accept the TX which will obviously fail, without even notifying the user about what happened. The card also stays there if `WalletConnectCallRequest` randomly displays "Unsupported" for valid TXs (another bug...), which must be confusing to users. 

If we want the card to accept requests straight away, we'll need to write proper logic for it, for now I think we should use this PR at least as a temporary solution. 