### PR TITLE
Fix/ios sentry sourcemap attempt

### DIFF
--- a/App.js
+++ b/App.js
@@ -28,6 +28,7 @@ import styled, { ThemeProvider } from 'styled-components/native';
 import { AppearanceProvider } from 'react-native-appearance';
 import { SENTRY_DSN, BUILD_TYPE, SHOW_THEME_TOGGLE, SHOW_ONLY_STORYBOOK } from 'react-native-dotenv';
 import NetInfo, { NetInfoState, NetInfoSubscription } from '@react-native-community/netinfo';
+import DeviceInfo from 'react-native-device-info';
 
 // actions
 import { initAppAndRedirectAction } from 'actions/appActions';
@@ -98,7 +99,14 @@ class App extends React.Component<Props, *> {
   constructor(props: Props) {
     super(props);
     if (!__DEV__) {
-      Sentry.init({ dsn: SENTRY_DSN });
+      const appVersion = DeviceInfo.getVersion();
+      const appBundleId = DeviceInfo.getBundleId();
+      const buildNumber = DeviceInfo.getBuildNumber();
+      Sentry.init({
+        dsn: SENTRY_DSN,
+        release: `${appBundleId}-${appVersion}`,
+        dist: buildNumber,
+      });
       Sentry.setTags({ environment: BUILD_TYPE });
     }
   }

--- a/src/components/SystemInfoModal/SystemInfoModal.js
+++ b/src/components/SystemInfoModal/SystemInfoModal.js
@@ -18,6 +18,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import * as React from 'react';
+import { TouchableOpacity } from 'react-native';
 import {
   BUILD_NUMBER,
   BCX_URL,
@@ -30,6 +31,7 @@ import {
 } from 'react-native-dotenv';
 import styled from 'styled-components/native';
 import DeviceInfo from 'react-native-device-info';
+import * as Sentry from '@sentry/react-native';
 
 // components
 import { Wrapper } from 'components/Layout';
@@ -38,6 +40,7 @@ import { MediumText } from 'components/Typography';
 // utils
 import { fontStyles } from 'utils/variables';
 import { themedColors } from 'utils/themes';
+import { reportLog } from 'utils/common';
 
 
 const LabeledRow = styled.View`
@@ -95,7 +98,15 @@ const SystemInfoModal = () => {
       </LabeledRow>
       <LabeledRow>
         <Label>NATIVE</Label>
-        <Value>{appBundleId}-{appVersion} ({buildNumber})</Value>
+        <TouchableOpacity
+          onPress={() => {
+            reportLog('Sentry report check #1!', { err1: true });
+            reportLog('Sentry report check #2!', { err2: true }, Sentry.Severity.Error);
+            throw new Error('Sentry report check #3!');
+          }}
+        >
+          <Value>{appBundleId}-{appVersion} ({buildNumber})</Value>
+        </TouchableOpacity>
       </LabeledRow>
     </Wrapper>
   );

--- a/src/components/SystemInfoModal/SystemInfoModal.js
+++ b/src/components/SystemInfoModal/SystemInfoModal.js
@@ -29,10 +29,16 @@ import {
   OPEN_SEA_API,
 } from 'react-native-dotenv';
 import styled from 'styled-components/native';
+import DeviceInfo from 'react-native-device-info';
+
+// components
 import { Wrapper } from 'components/Layout';
 import { MediumText } from 'components/Typography';
+
+// utils
 import { fontStyles } from 'utils/variables';
 import { themedColors } from 'utils/themes';
+
 
 const LabeledRow = styled.View`
   margin: 6px 0;
@@ -50,6 +56,9 @@ const Value = styled(MediumText)`
 
 
 const SystemInfoModal = () => {
+  const appVersion = DeviceInfo.getVersion();
+  const appBundleId = DeviceInfo.getBundleId();
+  const buildNumber = DeviceInfo.getBuildNumber();
   return (
     <Wrapper regularPadding>
       <LabeledRow>
@@ -83,6 +92,10 @@ const SystemInfoModal = () => {
       <LabeledRow>
         <Label>OPEN_SEA_API</Label>
         <Value>{OPEN_SEA_API}</Value>
+      </LabeledRow>
+      <LabeledRow>
+        <Label>NATIVE</Label>
+        <Value>{appBundleId}-{appVersion} ({buildNumber})</Value>
       </LabeledRow>
     </Wrapper>
   );


### PR DESCRIPTION
Currently we're still experiencing issues with iOS source maps not linked on Sentry for most of crashes, but not all of them (excluding manual reports, which is weird). Sentry documentation (https://docs.sentry.io/platforms/react-native/#setting-release--dist) suggests to set `dist` and `release` values manually so errors thrown in bundled JS can get linked with the ones that are being(!) uploaded to Sentry.

Included additional manned crash so we can test this.