### PR TITLE
Fix/Filter BTC out of asset search

### DIFF
--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -551,6 +551,7 @@ export const getSupportedTokens = (supportedAssets: Asset[], accountsAssets: Ass
 
   const updatedAccountAssets = supportedAssets
     .filter(asset => accountAssetsTickers.includes(asset.symbol))
+    .filter(({ symbol }) => symbol !== BTC) // remove BTC if it is already shown in SW/KW
     .reduce((memo, asset) => ({ ...memo, [asset.symbol]: asset }), {});
   return { id: accountId, ...updatedAccountAssets };
 };

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -37,6 +37,7 @@ import {
   UPDATE_SUPPORTED_ASSETS,
   COLLECTIBLES,
   PLR,
+  BTC,
 } from 'constants/assetsConstants';
 import { UPDATE_TX_COUNT } from 'constants/txCountConstants';
 import { ADD_TRANSACTION, TX_CONFIRMED_STATUS, TX_PENDING_STATUS } from 'constants/historyConstants';
@@ -512,7 +513,7 @@ export const searchAssetsAction = (query: string) => {
 
     const filteredAssets = supportedAssets.filter(({ name, symbol }) => {
       return name.toUpperCase().includes(search) || symbol.toUpperCase().includes(search);
-    });
+    }).filter(({ symbol }) => symbol !== BTC);
 
     if (filteredAssets.length > 0) {
       dispatch({

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -513,8 +513,8 @@ export const searchAssetsAction = (query: string) => {
     const search = query.toUpperCase();
 
     const filteredAssets = supportedAssets.filter(({ name, symbol }) => {
-      return name.toUpperCase().includes(search) || symbol.toUpperCase().includes(search);
-    }).filter(({ symbol }) => symbol !== BTC);
+      return (name.toUpperCase().includes(search) || symbol.toUpperCase().includes(search)) && symbol !== BTC;
+    });
 
     if (filteredAssets.length > 0) {
       dispatch({
@@ -549,10 +549,9 @@ export const getSupportedTokens = (supportedAssets: Asset[], accountsAssets: Ass
   // HACK: Dirty fix for users who removed somehow ETH and PLR from their assets list
   if (!accountAssetsTickers.includes(ETH)) accountAssetsTickers.push(ETH);
   if (!accountAssetsTickers.includes(PLR)) accountAssetsTickers.push(PLR);
-
+  // remove BTC if it is already shown in SW/KW
   const updatedAccountAssets = supportedAssets
-    .filter(asset => accountAssetsTickers.includes(asset.symbol))
-    .filter(({ symbol }) => symbol !== BTC) // remove BTC if it is already shown in SW/KW
+    .filter(({ symbol }) => accountAssetsTickers.includes(symbol) && symbol !== BTC)
     .reduce((memo, asset) => ({ ...memo, [asset.symbol]: asset }), {});
   return { id: accountId, ...updatedAccountAssets };
 };
@@ -587,8 +586,8 @@ export const loadSupportedAssetsAction = () => {
     // nothing to do if returned empty
     if (isEmpty(supportedAssets)) return;
 
-    if (!supportedAssets.some(e => e.symbol === 'BTC')) {
-      const btcAsset = assetFixtures.find(e => e.symbol === 'BTC');
+    if (!supportedAssets.some(e => e.symbol === BTC)) {
+      const btcAsset = assetFixtures.find(e => e.symbol === BTC);
       if (btcAsset) {
         supportedAssets.push(btcAsset);
       }


### PR DESCRIPTION
Filter BTC out of asset search in Smart Wallet or Key Wallet.
This was discussed that it confuses users to see Bitcoin in their assets list if they show it.