### PR TITLE
websocket chat message listener optimization

### DIFF
--- a/src/actions/notificationsActions.js
+++ b/src/actions/notificationsActions.js
@@ -412,16 +412,15 @@ export const startListeningChatWebSocketAction = () => {
     const { session: { data: { isOnline } } } = getState();
     if (!isOnline) return;
     const chatWebSocket = chat.getWebSocketInstance();
-    chatWebSocket.onMessage(async webSocketMessage => {
+    chatWebSocket.start(({
+      type: messageType,
+      response: messageResponse,
+      request: messageRequest,
+      receivedSignalMessage,
+    }) => {
       const {
         contacts: { data: contacts },
       } = getState();
-      const {
-        type: messageType,
-        response: messageResponse,
-        request: messageRequest,
-        receivedSignalMessage,
-      } = webSocketMessage;
       if (messageType === WEBSOCKET_MESSAGE_TYPES.RESPONSE) {
         if (messageResponse.message.toLowerCase() === 'gone') {
           const {

--- a/src/actions/notificationsActions.js
+++ b/src/actions/notificationsActions.js
@@ -412,8 +412,6 @@ export const startListeningChatWebSocketAction = () => {
     const { session: { data: { isOnline } } } = getState();
     if (!isOnline) return;
     const chatWebSocket = chat.getWebSocketInstance();
-    await chatWebSocket.listen();
-    chatWebSocket.onOpen();
     chatWebSocket.onMessage(async webSocketMessage => {
       const {
         contacts: { data: contacts },

--- a/src/actions/signalClientActions.js
+++ b/src/actions/signalClientActions.js
@@ -20,13 +20,21 @@
 import get from 'lodash.get';
 import isEmpty from 'lodash.isempty';
 
-import ChatService from 'services/chat';
+// actions
 import { updateSignalInitiatedStateAction } from 'actions/sessionActions';
-import { getActiveAccountAddress } from 'utils/accounts';
-import { firebaseMessaging } from 'services/firebase';
+import { startListeningChatWebSocketAction } from 'actions/notificationsActions';
 
+// utils
+import { getActiveAccountAddress } from 'utils/accounts';
+
+// services
+import { firebaseMessaging } from 'services/firebase';
+import ChatService from 'services/chat';
+
+// types
 import type { Dispatch, GetState } from 'reducers/rootReducer';
 import type { SignalCredentials } from 'models/Config';
+
 
 const chat = new ChatService();
 
@@ -70,6 +78,7 @@ export const signalInitAction = (credentials?: SignalCredentials) => {
     await chat.init(credentials)
       .then(() => chat.client.registerAccount())
       .then(() => fcmToken && chat.client.setFcmId(fcmToken))
+      .then(() => dispatch(startListeningChatWebSocketAction()))
       .then(() => dispatch(updateSignalInitiatedStateAction(true)))
       .catch(() => null);
   };

--- a/src/navigation/appNavigation.js
+++ b/src/navigation/appNavigation.js
@@ -750,7 +750,6 @@ class AppFlow extends React.Component<Props, State> {
     const {
       startListeningNotifications,
       startListeningIntercomNotifications,
-      startListeningChatWebSocket,
       fetchInviteNotifications,
       fetchTransactionsHistoryNotifications,
       fetchAllAccountsBalances,
@@ -765,7 +764,6 @@ class AppFlow extends React.Component<Props, State> {
     fetchTransactionsHistoryNotifications();
     getExistingChats();
     fetchAllCollectiblesData();
-    startListeningChatWebSocket();
     initWalletConnect();
     addAppStateChangeListener(this.handleAppStateChange);
   }
@@ -777,7 +775,6 @@ class AppFlow extends React.Component<Props, State> {
       wallet,
       removePrivateKeyFromMemory,
       isOnline,
-      startListeningChatWebSocket,
       stopListeningChatWebSocket,
       initSignal,
     } = this.props;
@@ -789,9 +786,12 @@ class AppFlow extends React.Component<Props, State> {
 
     if (prevIsOnline !== isOnline) {
       if (isOnline) {
-        // try initializing Signal in case of user user logged to wallet while being offline and then switched
+        /**
+         * try initializing Signal in case of user user logged
+         * to wallet while being offline and then switched,
+         * this action also includes chat websocket listener action
+         */
         initSignal();
-        startListeningChatWebSocket();
       } else {
         stopListeningChatWebSocket();
       }

--- a/src/services/__tests__/chat.test.js
+++ b/src/services/__tests__/chat.test.js
@@ -1,4 +1,22 @@
 // @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 import ChatWebSocketService from 'services/chatWebSocket';
 import ChatService from 'services/chat';
 import { WebSocket, Server } from 'mock-socket';
@@ -12,8 +30,6 @@ SignalClient.prepareApiBody = () => {
     message: 'hello there',
     userId: null,
     targetUserId: null,
-    sourceIdentityKey: null,
-    targetIdentityKey: null,
   }));
 };
 
@@ -42,6 +58,7 @@ describe('chat service', () => {
       websocket = new ChatWebSocketService(creds);
       creds.errorTrackingDSN = SENTRY_DSN;
       creds.isSendingLogs = false;
+      websocket.init();
       return client.init(credentials);
     }),
     getWebSocketInstance: () => {
@@ -65,11 +82,11 @@ describe('chat service', () => {
       expect(socket).toBeTruthy();
       done();
     });
+
     await chatMock.init(credentials)
       .then(() => chatMock.client.registerAccount())
       .then(() => chatMock.client.setFcmId(credentials.fcmToken))
       .catch(() => null);
-    await websocket.listen();
   });
 
   it('Should successfully send a chat message to a target', async (done) => {
@@ -81,12 +98,11 @@ describe('chat service', () => {
         }
       });
     });
+
     await chatMock.init(credentials)
       .then(() => chatMock.client.registerAccount())
       .then(() => chatMock.client.setFcmId(credentials.fcmToken))
       .catch(() => null);
-
-    await websocket.listen();
 
     chatMock.getWebSocketInstance = () => {
       return websocket;

--- a/src/services/__tests__/chat.test.js
+++ b/src/services/__tests__/chat.test.js
@@ -58,7 +58,6 @@ describe('chat service', () => {
       websocket = new ChatWebSocketService(creds);
       creds.errorTrackingDSN = SENTRY_DSN;
       creds.isSendingLogs = false;
-      websocket.init();
       return client.init(credentials);
     }),
     getWebSocketInstance: () => {
@@ -87,6 +86,8 @@ describe('chat service', () => {
       .then(() => chatMock.client.registerAccount())
       .then(() => chatMock.client.setFcmId(credentials.fcmToken))
       .catch(() => null);
+
+    websocket.start();
   });
 
   it('Should successfully send a chat message to a target', async (done) => {
@@ -103,6 +104,8 @@ describe('chat service', () => {
       .then(() => chatMock.client.registerAccount())
       .then(() => chatMock.client.setFcmId(credentials.fcmToken))
       .catch(() => null);
+
+    websocket.start();
 
     chatMock.getWebSocketInstance = () => {
       return websocket;

--- a/src/services/__tests__/chatWebSocket.test.js
+++ b/src/services/__tests__/chatWebSocket.test.js
@@ -1,4 +1,22 @@
 // @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 import ChatWebSocketService from 'services/chatWebSocket';
 import { WebSocket, Server } from 'mock-socket';
 
@@ -33,6 +51,8 @@ describe('chatWebSocket service', () => {
     mockServer = new Server(fakeURL.replace('https', 'wss'));
     websocket1 = new ChatWebSocketService(credentials1);
     websocket2 = new ChatWebSocketService(credentials2);
+    websocket1.init();
+    websocket2.init();
   });
 
   afterEach(() => {
@@ -47,8 +67,6 @@ describe('chatWebSocket service', () => {
         socket.send(data);
       });
     });
-    await websocket1.listen();
-    await websocket2.listen();
     expect(websocket1.ws).toBeTruthy();
     expect(websocket2.ws).toBeTruthy();
     expect(websocket1.running).toBe(true);
@@ -71,38 +89,34 @@ describe('chatWebSocket service', () => {
       });
     });
 
-    await websocket1.listen();
-    await websocket2.listen();
-
     const requestId = (new Date()).getTime();
-    const mockRequest = await websocket1.prepareRequest(
-      requestId,
-      'PUT',
-      '/v1/messages/websocket1',
-      JSON.stringify({
-        username: 'websocket1',
-        message: 'hello there',
-        userId: null,
-        targetUserId: null,
-        sourceIdentityKey: null,
-        targetIdentityKey: null,
-      }),
-      ['content-type:application/json;'],
-    ) || new Uint8Array(0);
 
-    websocket1.onMessage((msgs) => {
-      expect(msgs).toBeTruthy();
-      if (msgs.type === 2) {
+    let mockRequest;
+    try {
+      mockRequest = await websocket1.prepareRequest(
+        requestId,
+        'PUT',
+        '/v1/messages/websocket1',
+        JSON.stringify({
+          username: 'websocket1',
+          message: 'hello there',
+          userId: null,
+          targetUserId: null,
+        }),
+      );
+    } catch (e) {
+      //
+    }
+
+    expect(mockRequest).toBeTruthy();
+
+    websocket1.onMessage((message) => {
+      expect(message).toBeTruthy();
+      if (message.type === 2) {
         done();
       }
     });
 
-    websocket1.onOpen(() => {
-      websocket2.onOpen(() => {
-        setTimeout(() => {
-          websocket2.send(mockRequest);
-        }, 50);
-      });
-    });
+    if (mockRequest) websocket2.send(mockRequest);
   });
 });

--- a/src/services/__tests__/chatWebSocket.test.js
+++ b/src/services/__tests__/chatWebSocket.test.js
@@ -51,8 +51,6 @@ describe('chatWebSocket service', () => {
     mockServer = new Server(fakeURL.replace('https', 'wss'));
     websocket1 = new ChatWebSocketService(credentials1);
     websocket2 = new ChatWebSocketService(credentials2);
-    websocket1.init();
-    websocket2.init();
   });
 
   afterEach(() => {
@@ -67,6 +65,8 @@ describe('chatWebSocket service', () => {
         socket.send(data);
       });
     });
+    websocket1.start();
+    websocket2.start();
     expect(websocket1.ws).toBeTruthy();
     expect(websocket2.ws).toBeTruthy();
     expect(websocket1.running).toBe(true);
@@ -110,13 +110,14 @@ describe('chatWebSocket service', () => {
 
     expect(mockRequest).toBeTruthy();
 
-    websocket1.onMessage((message) => {
+    websocket1.start((message) => {
       expect(message).toBeTruthy();
       if (message.type === 2) {
         done();
       }
     });
 
+    websocket2.start();
     if (mockRequest) websocket2.send(mockRequest);
   });
 });

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -52,8 +52,6 @@ export default class Chat {
       //
     }
 
-    webSocketInstance.init();
-
     return this.client.init(credentials);
   }
 

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -51,6 +51,9 @@ export default class Chat {
     } catch (e) {
       //
     }
+
+    webSocketInstance.init();
+
     return this.client.init(credentials);
   }
 

--- a/src/services/chatWebSocket.js
+++ b/src/services/chatWebSocket.js
@@ -46,7 +46,7 @@ export default class ChatWebSocket {
     this.running = false;
   }
 
-  init() {
+  start(onMessageCallback?: Function) {
     this.stop();
     if (!this.credentials.host || !this.credentials.accessToken) return;
     const wsUrl = `${this.credentials.host
@@ -66,6 +66,43 @@ export default class ChatWebSocket {
       this.ws.onerror = () => {
         this.setRunning(false);
       };
+      this.ws.onmessage = async (incoming: Object) => {
+        const buffer = new Uint8Array(incoming.data);
+        if (buffer === undefined || !buffer.length) return;
+        const received = this.WebSocketMessage.decode(buffer);
+        const message = this.WebSocketMessage.toObject(received, {
+          bytes: String,
+        });
+        const receivedType = message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST ? 'request' : 'response';
+        if (typeof message[receivedType].body !== 'undefined'
+          && message[receivedType].body.trim() !== '') {
+          if (message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST
+            && message[receivedType].verb === 'PUT'
+            && message[receivedType].path === '/api/v1/message') {
+            const encryptedBody = message[receivedType].body;
+            const b64EncodedBytes = await SignalClient.decryptReceivedBody(encryptedBody)
+              .catch(() => null);
+            const decodedBytes = Buffer.from(b64EncodedBytes, 'base64');
+            if (decodedBytes !== undefined && decodedBytes.length) {
+              const textSecureEnvelope = this.TextSecureEnvelope.decode(decodedBytes);
+              message.receivedSignalMessage = this.TextSecureEnvelope.toObject(textSecureEnvelope, {
+                bytes: String,
+              });
+            }
+          } else {
+            message[receivedType].body = Buffer.from(message[receivedType].body, 'base64')
+              .toString('utf8');
+          }
+        }
+        if (message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST
+          && message.request.path !== '/api/v1/message') {
+          const webSocketResponse = this.prepareResponse(message.request.id, 200, 'OK');
+          if (webSocketResponse != null) {
+            this.send(webSocketResponse);
+          }
+        }
+        if (typeof onMessageCallback === 'function') onMessageCallback(message);
+      };
       this.setRunning(true);
     } catch (e) {
       this.setRunning(false);
@@ -78,47 +115,6 @@ export default class ChatWebSocket {
     if (request == null) return;
     this.send(request);
     keepaliveTimer = setTimeout(() => this.keepalive(), 60000); // 60s keepalive
-  }
-
-  onMessage(callback?: Function) {
-    if (!this.isRunning()) return;
-    this.ws.onmessage = async (incoming: Object) => {
-      const buffer = new Uint8Array(incoming.data);
-      if (buffer === undefined || !buffer.length) return;
-      const received = this.WebSocketMessage.decode(buffer);
-      const message = this.WebSocketMessage.toObject(received, {
-        bytes: String,
-      });
-      const receivedType = message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST ? 'request' : 'response';
-      if (typeof message[receivedType].body !== 'undefined'
-        && message[receivedType].body.trim() !== '') {
-        if (message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST
-          && message[receivedType].verb === 'PUT'
-          && message[receivedType].path === '/api/v1/message') {
-          const encryptedBody = message[receivedType].body;
-          const b64EncodedBytes = await SignalClient.decryptReceivedBody(encryptedBody)
-            .catch(() => null);
-          const decodedBytes = Buffer.from(b64EncodedBytes, 'base64');
-          if (decodedBytes !== undefined && decodedBytes.length) {
-            const textSecureEnvelope = this.TextSecureEnvelope.decode(decodedBytes);
-            message.receivedSignalMessage = this.TextSecureEnvelope.toObject(textSecureEnvelope, {
-              bytes: String,
-            });
-          }
-        } else {
-          message[receivedType].body = Buffer.from(message[receivedType].body, 'base64')
-            .toString('utf8');
-        }
-      }
-      if (message.type === WEBSOCKET_MESSAGE_TYPES.REQUEST
-        && message.request.path !== '/api/v1/message') {
-        const webSocketResponse = this.prepareResponse(message.request.id, 200, 'OK');
-        if (webSocketResponse != null) {
-          this.send(webSocketResponse);
-        }
-      }
-      if (typeof callback === 'function') callback(message);
-    };
   }
 
   send(data: Uint8Array, callback?: Function) {


### PR DESCRIPTION
Includes:
- Removed `startListeningChatWebSocketAction` from `appNavigation`'s `componentDidUpdate` and `componentDidMount` (kept only in background state handler because we want to toggle WebSocket listener when app travels between device background/foreground) and added the action to `signalInitAction` which is more obvious – whenever we have Signal credentials changed we should reinit chat WebSocket instance and THEN reassign the listener. Added this because in development I was experiencing weird issue when `startListeningChatWebSocketAction` was dispatched before `signalInitAction` and therefore caused listener to fail (no WebSocket message handler set).
- Combined chat web socket `onOpen`, `onMessage` and `listen` to single `start`.