### PR TITLE
init smart wallet sdk action without being active

### DIFF
--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -287,7 +287,7 @@ export const initOnLoginSmartWalletAccountAction = (
 
     const inactiveAccounts = getInactiveUserAccounts(accounts);
     const activeAccount = getActiveAccount(accounts);
-    const smartWalletAccount = getAccountType(activeAccount) === ACCOUNT_TYPES.SMART_WALLET
+    const smartWalletAccount = activeAccount && getAccountType(activeAccount) === ACCOUNT_TYPES.SMART_WALLET
       ? activeAccount
       : findFirstSmartAccount(inactiveAccounts);
 

--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -46,7 +46,13 @@ import { migrateTxHistoryToAccountsFormat } from 'services/dataMigration/history
 import { migrateCollectiblesToAccountsFormat } from 'services/dataMigration/collectibles';
 import { migrateAssetsToAccountsFormat } from 'services/dataMigration/assets';
 import { migrateCollectiblesHistoryToAccountsFormat } from 'services/dataMigration/collectiblesHistory';
-import { getAccountId, getActiveAccount, getActiveAccountType, getInactiveUserAccounts } from 'utils/accounts';
+import {
+  findFirstSmartAccount,
+  getAccountId,
+  getAccountType,
+  getActiveAccount,
+  getInactiveUserAccounts,
+} from 'utils/accounts';
 import { BLOCKCHAIN_NETWORK_TYPES, SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
 import { navigate } from 'services/navigation';
 
@@ -280,9 +286,10 @@ export const initOnLoginSmartWalletAccountAction = (
     } = getState();
 
     const inactiveAccounts = getInactiveUserAccounts(accounts);
-    const smartWalletAccount = getActiveAccountType(accounts) === ACCOUNT_TYPES.SMART_WALLET
-      ? getActiveAccount(accounts)
-      : inactiveAccounts.find(({ type }) => type === ACCOUNT_TYPES.SMART_WALLET);
+    const activeAccount = getActiveAccount(accounts);
+    const smartWalletAccount = getAccountType(activeAccount) === ACCOUNT_TYPES.SMART_WALLET
+      ? activeAccount
+      : findFirstSmartAccount(inactiveAccounts);
 
     if (!smartWalletAccount) return;
 

--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -46,10 +46,9 @@ import { migrateTxHistoryToAccountsFormat } from 'services/dataMigration/history
 import { migrateCollectiblesToAccountsFormat } from 'services/dataMigration/collectibles';
 import { migrateAssetsToAccountsFormat } from 'services/dataMigration/assets';
 import { migrateCollectiblesHistoryToAccountsFormat } from 'services/dataMigration/collectiblesHistory';
-import { findFirstSmartAccount, getAccountId } from 'utils/accounts';
+import { findFirstSmartAccount, getAccountId, getActiveAccountType } from 'utils/accounts';
 import { BLOCKCHAIN_NETWORK_TYPES, SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
 import { navigate } from 'services/navigation';
-import { getActiveAccountType } from '../utils/accounts';
 
 import type { AccountExtra, AccountTypes } from 'models/Account';
 import type { Dispatch, GetState } from 'reducers/rootReducer';
@@ -284,7 +283,7 @@ export const initOnLoginSmartWalletAccountAction = (privateKey: string) => {
     await dispatch(initSmartWalletSdkAction(privateKey));
 
     const activeAccountType = getActiveAccountType(accounts);
-    const setAccountActive = activeAccountType !== ACCOUNT_TYPES.SMART_WALLET;
+    const setAccountActive = activeAccountType === ACCOUNT_TYPES.SMART_WALLET; // set to active routine
     await dispatch(connectSmartWalletAccountAction(smartWalletAccountId, setAccountActive));
     dispatch(fetchVirtualAccountBalanceAction());
 

--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -49,6 +49,7 @@ import { migrateCollectiblesHistoryToAccountsFormat } from 'services/dataMigrati
 import { findFirstSmartAccount, getAccountId } from 'utils/accounts';
 import { BLOCKCHAIN_NETWORK_TYPES, SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
 import { navigate } from 'services/navigation';
+import { getActiveAccountType } from '../utils/accounts';
 
 import type { AccountExtra, AccountTypes } from 'models/Account';
 import type { Dispatch, GetState } from 'reducers/rootReducer';
@@ -269,10 +270,7 @@ export const switchAccountAction = (accountId: string) => {
   };
 };
 
-export const initOnLoginSmartWalletAccountAction = (
-  privateKey: string,
-  setAccountActive: boolean = true,
-) => {
+export const initOnLoginSmartWalletAccountAction = (privateKey: string) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const {
       appSettings: { data: { blockchainNetwork } },
@@ -285,6 +283,8 @@ export const initOnLoginSmartWalletAccountAction = (
     const smartWalletAccountId = getAccountId(smartWalletAccount);
     await dispatch(initSmartWalletSdkAction(privateKey));
 
+    const activeAccountType = getActiveAccountType(accounts);
+    const setAccountActive = activeAccountType !== ACCOUNT_TYPES.SMART_WALLET;
     await dispatch(connectSmartWalletAccountAction(smartWalletAccountId, setAccountActive));
     dispatch(fetchVirtualAccountBalanceAction());
 

--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -46,13 +46,7 @@ import { migrateTxHistoryToAccountsFormat } from 'services/dataMigration/history
 import { migrateCollectiblesToAccountsFormat } from 'services/dataMigration/collectibles';
 import { migrateAssetsToAccountsFormat } from 'services/dataMigration/assets';
 import { migrateCollectiblesHistoryToAccountsFormat } from 'services/dataMigration/collectiblesHistory';
-import {
-  findFirstSmartAccount,
-  getAccountId,
-  getAccountType,
-  getActiveAccount,
-  getInactiveUserAccounts,
-} from 'utils/accounts';
+import { findFirstSmartAccount, getAccountId } from 'utils/accounts';
 import { BLOCKCHAIN_NETWORK_TYPES, SET_ACTIVE_NETWORK } from 'constants/blockchainNetworkConstants';
 import { navigate } from 'services/navigation';
 
@@ -285,12 +279,7 @@ export const initOnLoginSmartWalletAccountAction = (
       accounts: { data: accounts },
     } = getState();
 
-    const inactiveAccounts = getInactiveUserAccounts(accounts);
-    const activeAccount = getActiveAccount(accounts);
-    const smartWalletAccount = activeAccount && getAccountType(activeAccount) === ACCOUNT_TYPES.SMART_WALLET
-      ? activeAccount
-      : findFirstSmartAccount(inactiveAccounts);
-
+    const smartWalletAccount = findFirstSmartAccount(accounts);
     if (!smartWalletAccount) return;
 
     const smartWalletAccountId = getAccountId(smartWalletAccount);

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -215,7 +215,7 @@ export const loginAction = (
 
         // init smart wallet
         if (wallet.privateKey && userHasSmartWallet(accounts)) {
-          await dispatch(initOnLoginSmartWalletAccountAction(wallet.privateKey));
+          await dispatch(initOnLoginSmartWalletAccountAction(wallet.privateKey, false));
         }
 
         /**

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -215,7 +215,7 @@ export const loginAction = (
 
         // init smart wallet
         if (wallet.privateKey && userHasSmartWallet(accounts)) {
-          await dispatch(initOnLoginSmartWalletAccountAction(wallet.privateKey, false));
+          await dispatch(initOnLoginSmartWalletAccountAction(wallet.privateKey));
         }
 
         /**

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -719,7 +719,6 @@ export const initSmartWalletSdkAction = (walletPrivateKey: string) => {
       type: SET_SMART_WALLET_SDK_INIT,
       payload: initialized,
     });
-    console.log('initSmartWalletSdkAction finished!');
   };
 };
 

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -243,7 +243,10 @@ export const resetSmartWalletDeploymentDataAction = () => {
   };
 };
 
-export const connectSmartWalletAccountAction = (accountId: string) => {
+export const connectSmartWalletAccountAction = (
+  accountId: string,
+  setAccountActive: boolean = true,
+) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     if (!smartWalletService || !smartWalletService.sdkInitialized) return;
     let { smartWallet: { connectedAccount } } = getState();
@@ -265,7 +268,7 @@ export const connectSmartWalletAccountAction = (accountId: string) => {
       });
     }
 
-    dispatch(setActiveAccountAction(accountId));
+    if (setAccountActive) dispatch(setActiveAccountAction(accountId));
   };
 };
 
@@ -716,6 +719,7 @@ export const initSmartWalletSdkAction = (walletPrivateKey: string) => {
       type: SET_SMART_WALLET_SDK_INIT,
       payload: initialized,
     });
+    console.log('initSmartWalletSdkAction finished!');
   };
 };
 

--- a/src/utils/accounts.js
+++ b/src/utils/accounts.js
@@ -46,13 +46,17 @@ export const getAccountId = (account: Account): string => {
   return get(account, 'id', '');
 };
 
+export const getAccountType = (account: Account): ?AccountTypes => {
+  return account.type;
+};
+
 export const getActiveAccountType = (accounts: Accounts): ?AccountTypes => {
   const activeAccount = getActiveAccount(accounts);
   if (!activeAccount) {
     return null;
   }
 
-  return activeAccount.type;
+  return getAccountType(activeAccount);
 };
 
 export const getAccountAddress = (account: Account): string => {
@@ -80,6 +84,7 @@ export const hasLegacyAccountBalance = (accounts: Accounts, balances: BalancesSt
   const accountBalances: Balances = balances[account.id];
   return Object.keys(accountBalances).some(token => getBalance(accountBalances, token) > 0);
 };
+
 export const findFirstSmartAccount = (accounts: Accounts): ?Account => {
   return accounts.find(({ type }) => type === ACCOUNT_TYPES.SMART_WALLET);
 };


### PR DESCRIPTION
The problem was that on auth login we were dispatching smart wallet account init action, but in the action itself there was a check that it should only init smart wallet if smart wallet account is active therefore leading to not initiate the Smart Wallet and then any other calls that calls Smart Wallet SDK fails. Failure easy to replicate: close the app in key based account active and reopen.