### PR TITLE
Disable Sentry ANR reports

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -108,6 +108,9 @@
         <!-- Branch init -->
         <meta-data android:name="io.branch.sdk.BranchKey" android:value="@string/branch_io_key_live" />
         <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="@string/branch_io_key_test" />
+
+        <!-- disable Sentry ANR reports -->
+        <meta-data android:name="io.sentry.anr.enable" android:value="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
ANR (Application Not Respond) is thrown once anything in working thread takes more than 4 seconds to perform and Sentry identifies this as ANR error which causes a lot of noise in Sentry logs. This might even happen if heavy native operation is performed on low end device which takes longer time than usual.