### PR TITLE
hold app ui until connectivity checked

### DIFF
--- a/App.js
+++ b/App.js
@@ -125,13 +125,14 @@ class App extends React.Component<Props, *> {
     Linking.removeEventListener('url', this.handleDeepLinkEvent);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     const {
       fetchAppSettingsAndRedirect,
       startListeningOnOpenNotification,
       startReferralsListener,
     } = this.props;
-    NetInfo.fetch()
+    // hold the UI and wait until network status finished for later app connectivity checks
+    await NetInfo.fetch()
       .then((netInfoState) => this.setOnlineStatus(netInfoState.isInternetReachable))
       .catch(() => null);
     this.removeNetInfoEventListener = NetInfo.addEventListener(this.handleConnectivityChange);


### PR DESCRIPTION
This will make sure network status is propagated into reducer. This was initial approach, but then we changed when improving app performance. Currently this is being called async and therefore when `loginAction` is called them online status is not detected which causes multiple issues such as Smart Wallet SDK not initated or FCM token not updated during `loginAction`.