### PR TITLE
Fix listKey error in Home screen

### DIFF
--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -600,6 +600,7 @@ class HomeScreen extends React.Component<Props, State> {
                           keyExtractor={(item) => item.symbol}
                           renderItem={this.renderDepositedAsset}
                           initialNumToRender={5}
+                          listKey="aave_deposits"
                         />
                       }
                       onPress={toggleLendingDeposits}
@@ -616,6 +617,7 @@ class HomeScreen extends React.Component<Props, State> {
                         keyExtractor={(item) => item.symbol}
                         renderItem={this.renderPoolTogetherItem}
                         initialNumToRender={2}
+                        listKey="pool_together"
                       />
                     }
                     onPress={togglePoolTogether}


### PR DESCRIPTION
When you have both Aave deposit and PoolTogether ticket the following error appears on Home screen:

![Screenshot 2020-07-08 at 19 35 19](https://user-images.githubusercontent.com/6280457/86951760-40fca680-c152-11ea-817c-11be457e9804.png)
