### PR TITLE
Changes to Fastfiles and config.yml to automate stores release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,6 +502,8 @@ jobs:
           no_output_timeout: 20m
           name: Upload to TestFlight
           command: |
+            chmod +x setReleaseInfo.sh
+            . ./setReleaseInfo.sh
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             cd ios && bundle exec fastlane deploy_prod APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Wallet"
@@ -644,10 +646,13 @@ jobs:
       - run:
           name: Fastlane deploy to Google Play
           command: |
+            chmod +x setReleaseInfo.sh
+            . ./setReleaseInfo.sh
             cd android
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             export GOOGLE_JSON_DATA=$(echo "$GOOGLE_JSON_BASE64_ENCODED" | base64 --decode)
+            echo $RELEASE_DESCRIPTION > fastlane/metadata/android/en-US/changelogs/$APP_BUILD_NUMBER.txt
             bundle exec fastlane deploy_internal --verbose
           environment:
             BUNDLE_PATH: vendor/bundle

--- a/android/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,1 @@
+Bug fixes and performance improvements

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -51,7 +51,8 @@ platform :ios do
     #sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.mobileprovision'"
 
     commit = last_git_commit
-    upload_to_testflight(changelog: commit[:message],
+    upload_to_testflight(
+      changelog: ENV['RELEASE_DESCRIPTION'],
       skip_waiting_for_build_processing: true,
     )
   end


### PR DESCRIPTION
We need new RC for this to be tested. 
It **should** add release notes to the builds sent to Testflight and internal Play Store so we don't have to manually add them.