### PR TITLE
fix/missing-i18n-string

### DIFF
--- a/src/translations/locales/en/auth.json
+++ b/src/translations/locales/en/auth.json
@@ -27,7 +27,8 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "yesPlease": "Yes, please",
-    "okToUsePinCodeOnly": "I'm happy with PIN only"
+    "okToUsePinCodeOnly": "I'm happy with PIN only",
+    "createAccount": "Create Account"
   },
 
   "error": {


### PR DESCRIPTION
- Added missing i18n string for app sigh in screen for the "Create Account" button.