### PR TITLE
Release Candidate 2.14.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,8 +502,6 @@ jobs:
           no_output_timeout: 20m
           name: Upload to TestFlight
           command: |
-            chmod +x setReleaseInfo.sh
-            . ./setReleaseInfo.sh
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             cd ios && bundle exec fastlane deploy_prod APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Wallet"
@@ -646,13 +644,10 @@ jobs:
       - run:
           name: Fastlane deploy to Google Play
           command: |
-            chmod +x setReleaseInfo.sh
-            . ./setReleaseInfo.sh
             cd android
             export buildNumber=$(cat ~/pillarwallet/buildNumber.txt)
             export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
             export GOOGLE_JSON_DATA=$(echo "$GOOGLE_JSON_BASE64_ENCODED" | base64 --decode)
-            echo $RELEASE_DESCRIPTION > fastlane/metadata/android/en-US/changelogs/$APP_BUILD_NUMBER.txt
             bundle exec fastlane deploy_internal --verbose
           environment:
             BUNDLE_PATH: vendor/bundle

--- a/android/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,1 +1,0 @@
-Bug fixes and performance improvements

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -52,7 +52,7 @@ platform :ios do
 
     commit = last_git_commit
     upload_to_testflight(
-      changelog: ENV['RELEASE_DESCRIPTION'],
+      changelog: commit[:message],
       skip_waiting_for_build_processing: true,
     )
   end


### PR DESCRIPTION
**Release Candidate 2.14.1:**
- This patch release reverts a deployment pipeline feature. No app code has been changed from 2.14.0.

**Release Candidate 2.14.0:**
- New launcher icons and splash screens to reflect our new branding
- New receive screen
- New internationalisation ground work
- New Ramp Network service
- New Wyre service
- Improved reliability of Smart Wallet
- Improved the way we move our release notes to the app stores
- Improved how Aave deposits are sorted by Annual Percentage Yield