### PR TITLE
Optimize Uniswap tokens query

### DIFF
--- a/src/actions/exchangeActions.js
+++ b/src/actions/exchangeActions.js
@@ -323,7 +323,7 @@ export const getExchangeSupportedAssetsAction = () => {
     } = getState();
 
     const oneInchAssetsSymbols = fetch1inchSupportedTokens();
-    const uniswapAssetsSymbols = fetchUniswapSupportedTokens();
+    const uniswapAssetsSymbols = fetchUniswapSupportedTokens(supportedAssets.map(({ symbol }) => symbol));
 
     const assetsSymbols = await Promise.all([oneInchAssetsSymbols, uniswapAssetsSymbols]);
 

--- a/src/services/uniswap.js
+++ b/src/services/uniswap.js
@@ -313,15 +313,20 @@ export const createUniswapAllowanceTx = async (fromAssetAddress: string, clientA
   };
 };
 
-export const fetchUniswapSupportedTokens = async (): Promise<string[]> => {
+export const fetchUniswapSupportedTokens = async (supportedAssetCodes: string[]): Promise<string[]> => {
   let finished = false;
   let i = 0;
   let results = [];
+  const parsedAssetCodes = supportedAssetCodes.map(a => `"${a}"`);
   while (!finished) {
     /* eslint-disable no-await-in-loop */
     const query = `
       {
-        tokens(first: 1000, skip: ${i * 1000}) {
+        tokens(first: 1000, skip: ${i * 1000},
+          where: { 
+            symbol_in: [${parsedAssetCodes.toString()}]
+          }
+        ) {
           symbol
         }
       }


### PR DESCRIPTION
Limit our query for Uniswap supported tokens to the tokens we support on our side. This _dramatically_ shortens the fetching time.
I'm leaving the `while` loop and support for multiple queries in case we support more than 1k tokens in the future. 
Credits to the brilliant @poocart .