### PR TITLE
Upgrade/node version ios vm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,10 @@ aliases:
     run:
       name: Install coureutils
       command: |
+        brew update
+        brew upgrade yarn
         brew install coreutils
+        node -v
   - &homebrew_restore_cache
     restore_cache:
       name: Restore homebrew cache
@@ -263,12 +266,6 @@ jobs:
       - *homebrew_restore_cache
       - *homebrew_install
       - *homebrew_save_cache
-
-      - run:
-          name: Upgrade node version for module dependency
-          command: |
-            brew unlink node
-            brew install node@14
 
       - *node_restore_cache
       - *node_artifactory_authenticate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -740,7 +740,7 @@ workflows:
           filters:
             branches:
               only:
-                - upgrade/node-version-ios-vm
+                - develop
       - appcenter_android:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,12 @@ jobs:
       - *homebrew_install
       - *homebrew_save_cache
 
+      - run:
+          name: Upgrade node version for module dependency
+          command: |
+            brew unling node
+            brew install node@14
+
       - *node_restore_cache
       - *node_artifactory_authenticate
       - *node_artifactory_set_registry
@@ -737,7 +743,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - upgrade/node-version-ios-vm
       - appcenter_android:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
       - run:
           name: Upgrade node version for module dependency
           command: |
-            brew unling node
+            brew unlink node
             brew install node@14
 
       - *node_restore_cache


### PR DESCRIPTION
Fix the node version issue we currently have with the new babel module dependencies.
This is a "hack" until we can upgrade to a newer xcode VM in circleci, which will be 11.5.0 which has node version 14.2.0