### PR TITLE
updated modal hidden behaviour for ios

### DIFF
--- a/src/actions/connectedDevicesActions.js
+++ b/src/actions/connectedDevicesActions.js
@@ -166,7 +166,7 @@ export const confirmConnectedDeviceRemoveAction = (device: ConnectedDevice) => {
         if (!smartWalletAccountDevice) {
           Toast.show({
             message: t('toast.linkedDeviceNotFound'),
-            emoji: 'woman_shrugging',
+            emoji: 'woman-shrugging',
             supportLink: true,
             autoClose: false,
           });

--- a/src/components/ContactDetailsModal/ContactDetailsModal.js
+++ b/src/components/ContactDetailsModal/ContactDetailsModal.js
@@ -60,6 +60,7 @@ type Props = {
   title?: string,
   contacts: Contact[],
   showQRScanner?: boolean,
+  onModalHidden?: () => void,
 };
 
 const InputWrapper = styled.View`
@@ -136,6 +137,7 @@ const ContactDetailsModal = ({
   title,
   contacts,
   showQRScanner,
+  onModalHidden,
 }: Props) => {
   const [addressValue, setAddressValue] = useState('');
   const [nameValue, setNameValue] = useState('');
@@ -233,6 +235,7 @@ const ContactDetailsModal = ({
     <ModalBox
       isVisible={isVisible}
       onModalHide={onModalHide}
+      onModalHidden={onModalHidden}
       showModalClose
       noBoxMinHeight
     >

--- a/src/components/ModalBox/ModalBox.js
+++ b/src/components/ModalBox/ModalBox.js
@@ -36,6 +36,7 @@ type Props = {
   modalStyle?: StyleSheet.Styles,
   showModalClose?: boolean,
   noBoxMinHeight?: boolean,
+  onModalHidden?: () => void,
 };
 
 const Wrapper = styled.KeyboardAvoidingView`
@@ -56,11 +57,12 @@ const Box = styled.View`
 
 const ModalCloseButton = styled.TouchableOpacity`
   position: absolute;
-  top: 0px;
-  right: 0px;
+  top: 15px;
+  right: -15px;
   border-radius: 15px;
-  height: 30px;
-  width: 30px;
+  height: 60px;
+  width: 60px;
+  padding: 15px;
   justify-content: center;
   align-items: center;
   opacity: 0.5;
@@ -73,24 +75,26 @@ const ModalBox = ({
   children,
   showModalClose,
   noBoxMinHeight,
+  onModalHidden,
 }: Props) => (
   <Modal
     isVisible={isVisible}
     hasBackdrop
     backdropOpacity={0.7}
-    onModalHide={onModalHide}
+    onModalHide={onModalHidden}
     onBackdropPress={onModalHide}
     style={modalStyle}
   >
-    {showModalClose && (
-      <ModalCloseButton onPress={onModalHide}>
-        <Icon name="rounded-close" style={{ color: '#fff', fontSize: 25 }} />
-      </ModalCloseButton>
-    )}
     <Wrapper
       enabled
       behavior={Platform.OS === 'ios' ? 'padding' : null}
+      style={{ flex: 1 }}
     >
+      {showModalClose && (
+        <ModalCloseButton onPress={onModalHide}>
+          <Icon name="rounded-close" style={{ color: '#fff', fontSize: 25 }} />
+        </ModalCloseButton>
+      )}
       <Box noBoxMinHeight={noBoxMinHeight}>
         {children}
       </Box>

--- a/src/components/SelectorOptions/SelectorOptions.js
+++ b/src/components/SelectorOptions/SelectorOptions.js
@@ -316,15 +316,17 @@ class SelectorOptions extends React.Component<Props, State> {
 
   resetOptions = () => {
     const { onHidden } = this.props;
-    this.setState({ query: null });
-    Keyboard.dismiss();
-    if (onHidden) onHidden();
+    this.setState({ query: null }, () => {
+      if (onHidden) onHidden();
+    });
   };
 
   closeOptions = () => {
     const { onHide } = this.props;
-    this.resetOptions();
-    if (onHide) onHide();
+    this.setState({ query: null }, () => {
+      Keyboard.dismiss();
+      if (onHide) onHide();
+    });
   };
 
   selectValue = (selectedValue) => {

--- a/src/screens/SendSynthetic/SendSyntheticAmount.js
+++ b/src/screens/SendSynthetic/SendSyntheticAmount.js
@@ -154,7 +154,7 @@ class SendSyntheticAmount extends React.Component<Props, State> {
     if (!receiver) {
       Toast.show({
         message: t('toast.ensNameNotFound'),
-        emoji: 'woman_shrugging',
+        emoji: 'woman-shrugging',
       });
       stateToUpdate = { selectedContact: null, receiver: '', receiverEnsName: '' };
     } else {

--- a/src/utils/contacts.js
+++ b/src/utils/contacts.js
@@ -43,7 +43,7 @@ export const getReceiverWithEnsName = async (ethAddress: ?string, showNotificati
     if (!resolvedAddress && showNotification) {
       Toast.show({
         message: t('toast.ensNameNotFound'),
-        emoji: 'woman_shrugging',
+        emoji: 'woman-shrugging',
       });
       return { receiverEnsName, receiver };
     }


### PR DESCRIPTION
Includes:
- Fix for as token send flow modals including updated contact details modal to show each if others are hidden as `react-native-modal` does not allow to have multiple modals open and it is needed to wait until visible is completely hidden before presenting another.
- Small fix for 🤷‍♀️  emoji as per `react-native-emoji` library it had different code and was failing to render as actual emoji.