### PR TITLE
Fix sablier keyboard

### DIFF
--- a/src/screens/Sablier/NewStream.js
+++ b/src/screens/Sablier/NewStream.js
@@ -328,7 +328,7 @@ class NewStream extends React.Component<Props, State> {
         inset={{ bottom: 'never' }}
         headerProps={{ centerItems: [{ title: t('sablierContent.title.newStreamScreen') }] }}
         putContentInScrollView
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps="handled"
       >
         <Selector
           label={t('label.to')}


### PR DESCRIPTION
The keyboard covers the next button and on iOS you can't hide it 