### PR TITLE
Fix toasts not closing on button press

### DIFF
--- a/src/components/Toast/AnimatedToastList.js
+++ b/src/components/Toast/AnimatedToastList.js
@@ -93,8 +93,8 @@ const isSwipeGesture = ({ vx, dx }) =>
 const defaultSwipeResponderOptions = {
   onStartShouldSetPanResponder: () => false,
   onStartShouldSetPanResponderCapture: () => false,
-  onMoveShouldSetPanResponder: () => true,
-  onMoveShouldSetPanResponderCapture: () => true,
+  onMoveShouldSetPanResponder: (_, { dx }) => Math.abs(dx) > 5,
+  onMoveShouldSetPanResponderCapture: () => false,
   onPanResponderMove: noop,
   onPanResponderTerminationRequest: () => true,
   onPanResponderRelease: noop,


### PR DESCRIPTION
Adds a threshold that must be passed before a toast starts being swiped -- otherwise pressing the close button or the toast itself with a slight movement is not recognised.