### PR TITLE
PIL-856: fix bignumber exponential values for gas token display values

### DIFF
--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -272,7 +272,7 @@ describe('Common utils', () => {
 
   describe('getFormattedTransactionFeeValue', () => {
     it('should parse from BigNumber', () => {
-      const txWeeInWei = new BigNumber(1234500000000000000);
+      const txFeeInWei = new BigNumber(1234500000000000000);
       const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
       const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
       expect(formattedEth).toBe('1.2345');

--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -33,7 +33,14 @@ import {
   formatFiat,
   extractJwtPayload,
   parseTokenAmount,
+  getFormattedTransactionFeeValue,
 } from '../common';
+
+const gasToken = {
+  address: '0x0',
+  decimals: 18,
+  symbol: 'PLR',
+};
 
 describe('Common utils', () => {
   describe('delay', () => {
@@ -260,6 +267,38 @@ describe('Common utils', () => {
     it('should parse from 100 as 100 with 0 decimals', () => {
       const expectedValue = 100;
       expect(parseTokenAmount('100', 0)).toBe(expectedValue);
+    });
+  });
+
+  describe('getFormattedTransactionFeeValue', () => {
+    it('should parse from BigNumber', () => {
+      const txWeeInWei = new BigNumber(1234500000000000000);
+      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      expect(formattedEth).toBe('1.2345');
+      expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
+    });
+    it('should parse from BigNumber that has exponential value', () => {
+      const txWeeInWei = new BigNumber(0x41d1d9bfc6ee79e9e9); // parses from hex
+      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      expect(txWeeInWei.toString()).toBe('1.2141596928761193e+21'); // exponential
+      expect(formattedEth).toBe('1214.159692');
+      expect(formattedGasToken).toBe('1214.15'); // method has 2 decimals precision for gasToken
+    });
+    it('should parse from numeric', () => {
+      const txWeeInWei = 1234500000000000000;
+      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      expect(formattedEth).toBe('1.2345');
+      expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
+    });
+    it('should parse from string', () => {
+      const txWeeInWei = '1234500000000000000';
+      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      expect(formattedEth).toBe('1.2345');
+      expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
     });
   });
 });

--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -273,30 +273,30 @@ describe('Common utils', () => {
   describe('getFormattedTransactionFeeValue', () => {
     it('should parse from BigNumber', () => {
       const txFeeInWei = new BigNumber(1234500000000000000);
-      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
-      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      const formattedEth = getFormattedTransactionFeeValue(txFeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txFeeInWei, gasToken);
       expect(formattedEth).toBe('1.2345');
       expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
     });
     it('should parse from BigNumber that has exponential value', () => {
-      const txWeeInWei = new BigNumber(0x41d1d9bfc6ee79e9e9); // parses from hex
-      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
-      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
-      expect(txWeeInWei.toString()).toBe('1.2141596928761193e+21'); // exponential
+      const txFeeInWei = new BigNumber(0x41d1d9bfc6ee79e9e9); // parses from hex
+      const formattedEth = getFormattedTransactionFeeValue(txFeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txFeeInWei, gasToken);
+      expect(txFeeInWei.toString()).toBe('1.2141596928761193e+21'); // exponential
       expect(formattedEth).toBe('1214.159692');
       expect(formattedGasToken).toBe('1214.15'); // method has 2 decimals precision for gasToken
     });
     it('should parse from numeric', () => {
-      const txWeeInWei = 1234500000000000000;
-      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
-      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      const txFeeInWei = 1234500000000000000;
+      const formattedEth = getFormattedTransactionFeeValue(txFeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txFeeInWei, gasToken);
       expect(formattedEth).toBe('1.2345');
       expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
     });
     it('should parse from string', () => {
-      const txWeeInWei = '1234500000000000000';
-      const formattedEth = getFormattedTransactionFeeValue(txWeeInWei);
-      const formattedGasToken = getFormattedTransactionFeeValue(txWeeInWei, gasToken);
+      const txFeeInWei = '1234500000000000000';
+      const formattedEth = getFormattedTransactionFeeValue(txFeeInWei);
+      const formattedGasToken = getFormattedTransactionFeeValue(txFeeInWei, gasToken);
       expect(formattedEth).toBe('1.2345');
       expect(formattedGasToken).toBe('1.23'); // method has 2 decimals precision for gasToken
     });

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -593,7 +593,8 @@ export const getDeviceWidth = () => {
 
 export const getFormattedTransactionFeeValue = (feeInWei: string | number | BigNumber, gasToken: ?GasToken): string => {
   // fixes exponential values with BigNumber.toPrecision()
-  const parsedFeeInWei = typeof feeInWei === 'object' // BigNumber
+  // TODO: fix with BigNumber.toFixed() when updating BigNumber lib
+  const parsedFeeInWei = BigNumber.isBigNumber(feeInWei)
     ? feeInWei.toPrecision()
     : feeInWei.toString();
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -591,18 +591,26 @@ export const getDeviceWidth = () => {
   return Dimensions.get('window').width;
 };
 
-export const formatTransactionFee = (feeInWei: string | number, gasToken: ?GasToken): string => {
-  if (!feeInWei) return '';
+export const getFormattedTransactionFeeValue = (feeInWei: string | number | BigNumber, gasToken: ?GasToken): string => {
+  // fixes exponential values with BigNumber.toPrecision()
+  const parsedFeeInWei = typeof feeInWei === 'object' // BigNumber
+    ? feeInWei.toPrecision()
+    : feeInWei.toString();
 
   if (gasToken && !isEmpty(gasToken)) {
-    const { symbol, decimals } = gasToken;
-    return t('tokenValue', {
-      value: formatAmount(utils.formatUnits(feeInWei.toString(), decimals), 2),
-      token: symbol,
-    });
+    return formatAmount(utils.formatUnits(parsedFeeInWei, gasToken.decimals), 2);
   }
 
-  return t('tokenValue', { value: formatAmount(utils.formatEther(feeInWei.toString())), token: ETH });
+  return formatAmount(utils.formatEther(parsedFeeInWei));
+};
+
+export const formatTransactionFee = (feeInWei: string | number | BigNumber, gasToken: ?GasToken): string => {
+  if (!feeInWei) return '';
+
+  const token = gasToken?.symbol || ETH;
+  const value = getFormattedTransactionFeeValue(feeInWei, gasToken);
+
+  return t('tokenValue', { value, token });
 };
 
 export const humanizeHexString = (hexString: ?string) => {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -594,7 +594,7 @@ export const getDeviceWidth = () => {
 export const getFormattedTransactionFeeValue = (feeInWei: string | number | BigNumber, gasToken: ?GasToken): string => {
   // fixes exponential values with BigNumber.toPrecision()
   // TODO: fix with BigNumber.toFixed() when updating BigNumber lib
-  const parsedFeeInWei = BigNumber.isBigNumber(feeInWei)
+  const parsedFeeInWei = typeof feeInWei === 'object' && BigNumber.isBigNumber(feeInWei)
     ? feeInWei.toPrecision()
     : feeInWei.toString();
 


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-856/white-screend-when-paying-with-plr

Note: separated value parser code from `formatTransactionFee` as `getFormattedTransactionFeeValue` since it's hard to test values with translations added on top.