### PR TITLE
PIL-867: sync sw acc deployment state on acc connect

### DIFF
--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -284,7 +284,7 @@ export const connectSmartWalletAccountAction = (
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     if (!smartWalletService || !smartWalletService.sdkInitialized) return;
-    let { smartWallet: { connectedAccount } } = getState();
+    let { smartWallet: { connectedAccount, upgrade } } = getState();
 
     if (isEmpty(connectedAccount)) {
       connectedAccount = await smartWalletService.connectAccount(accountId);
@@ -301,6 +301,13 @@ export const connectSmartWalletAccountAction = (
     }
 
     if (setAccountActive) dispatch(setActiveAccountAction(accountId));
+
+    // sync deployed account state
+    const connectedAccountState = connectedAccount?.state;
+    if (upgrade?.status !== SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE
+      && connectedAccountState === sdkConstants.AccountStates.Deployed) {
+      dispatch(setSmartWalletUpgradeStatusAction(SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE));
+    }
   };
 };
 

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -284,7 +284,7 @@ export const connectSmartWalletAccountAction = (
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     if (!smartWalletService || !smartWalletService.sdkInitialized) return;
-    let { smartWallet: { connectedAccount, upgrade } } = getState();
+    let { smartWallet: { connectedAccount } } = getState();
 
     if (isEmpty(connectedAccount)) {
       connectedAccount = await smartWalletService.connectAccount(accountId);
@@ -304,7 +304,8 @@ export const connectSmartWalletAccountAction = (
 
     // sync deployed account state
     const connectedAccountState = connectedAccount?.state;
-    if (upgrade?.status !== SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE
+    const currentUpgradeStatus = getState().smartWallet.upgrade?.status;
+    if (currentUpgradeStatus !== SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE
       && connectedAccountState === sdkConstants.AccountStates.Deployed) {
       dispatch(setSmartWalletUpgradeStatusAction(SMART_WALLET_UPGRADE_STATUSES.DEPLOYMENT_COMPLETE));
     }


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-867/account-deployment-state-issue

Smart Wallet account deployment state is synced on deployment transaction confirmed event and when Smart Wallet account is set as active (previously we had Key based as second account).

Currently account set as active action is no longer dispatched after account is set as active (as we only have one Smart Wallet account) therefore the only Smart Wallet account state sync that remains is on transaction event, which is not triggered (TODO: find out why) in scenario of interrupting app online state (close/open app, toggle network) during Smart Wallet deployment process.

Added Smart Wallet account deployment state sync to action when account is being connected which is triggered on each app successful auth.