### PR TITLE
get explorer link from smart wallet sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@react-native-firebase/perf": "^7.2.2",
     "@react-native-firebase/remote-config": "^8.0.0",
     "@sentry/react-native": "1.7.1",
-    "@smartwallet/sdk": "2.2.0",
+    "@smartwallet/sdk": "2.3.0",
     "@tradle/react-native-http": "^2.0.0",
     "@uniswap/sdk": "^3.0.3",
     "@walletconnect/react-native": "^1.0.0-beta.47",

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -473,7 +473,7 @@ export class EventDetail extends React.Component<Props, State> {
     this.props.onClose();
   };
 
-  viewOnTheBlockchain = async () => {
+  viewOnTheBlockchain = () => {
     const { hash } = this.props.event;
     if (!hash) {
       Toast.show({
@@ -485,7 +485,7 @@ export class EventDetail extends React.Component<Props, State> {
       return;
     }
 
-    const explorerLink = await smartWalletInstance.getConnectedAccountTransactionExplorerLink(hash);
+    const explorerLink = smartWalletInstance.getConnectedAccountTransactionExplorerLink(hash);
     if (!explorerLink) {
       Toast.show({
         message: t('toast.cannotGetBlockchainExplorerLink'),

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -29,7 +29,6 @@ import { CachedImage } from 'react-native-cached-image';
 import { utils } from 'ethers';
 import get from 'lodash.get';
 import isEmpty from 'lodash.isempty';
-import { getEnv } from 'configs/envConfig';
 import t from 'translations/translate';
 
 // components
@@ -44,6 +43,7 @@ import SWActivationModal from 'components/SWActivationModal';
 import CollectibleImage from 'components/CollectibleImage';
 import Spinner from 'components/Spinner';
 import ProfileImage from 'components/ProfileImage';
+import Toast from 'components/Toast';
 
 // utils
 import { spacing, fontStyles, fontSizes } from 'utils/variables';
@@ -70,6 +70,9 @@ import { findTransactionAcrossAccounts } from 'utils/history';
 import { isAaveTransactionTag } from 'utils/aave';
 import { isPoolTogetherAddress } from 'utils/poolTogether';
 import { getFormattedValue } from 'utils/strings';
+
+// services
+import smartWalletInstance from 'services/smartWallet';
 
 // constants
 import { defaultFiatCurrency, ETH, DAI } from 'constants/assetsConstants';
@@ -470,10 +473,30 @@ export class EventDetail extends React.Component<Props, State> {
     this.props.onClose();
   };
 
-  viewOnTheBlockchain = () => {
+  viewOnTheBlockchain = async () => {
     const { hash } = this.props.event;
-    const url = getEnv().TX_DETAILS_URL + hash;
-    Linking.openURL(url);
+    if (!hash) {
+      Toast.show({
+        message: t('toast.cannotFindTransactionHash'),
+        emoji: 'woman-shrugging',
+        supportLink: true,
+        autoClose: false,
+      });
+      return;
+    }
+
+    const explorerLink = await smartWalletInstance.getConnectedAccountTransactionExplorerLink(hash);
+    if (!explorerLink) {
+      Toast.show({
+        message: t('toast.cannotGetBlockchainExplorerLink'),
+        emoji: 'woman-shrugging',
+        supportLink: true,
+        autoClose: false,
+      });
+      return;
+    }
+
+    Linking.openURL(explorerLink);
   };
 
   viewBadge = () => {

--- a/src/screens/Assets/WalletActivation.js
+++ b/src/screens/Assets/WalletActivation.js
@@ -21,13 +21,19 @@
 import * as React from 'react';
 import { ScrollView, Linking } from 'react-native';
 import styled from 'styled-components/native';
-import { getEnv } from 'configs/envConfig';
 import t from 'translations/translate';
 
+// utils
 import { fontStyles } from 'utils/variables';
+
+// services
+import smartWalletInstance from 'services/smartWallet';
+
+// components
 import { BaseText, MediumText } from 'components/Typography';
 import Button from 'components/Button';
 import { Spacing } from 'components/Layout';
+import Toast from 'components/Toast';
 
 
 const Title = styled(MediumText)`
@@ -56,11 +62,30 @@ class WalletActivation extends React.PureComponent<Props> {
     Linking.openURL('https://help.pillarproject.io/en/articles/3935106-smart-wallet-faq');
   };
 
-  handleEtherscan = () => {
+  handleEtherscan = async () => {
     const { deploymentHash } = this.props;
-    if (deploymentHash) {
-      Linking.openURL(`${getEnv().TX_DETAILS_URL}${deploymentHash}`);
+    if (!deploymentHash) {
+      Toast.show({
+        message: t('toast.cannotFindDeploymentHash'),
+        emoji: 'woman-shrugging',
+        supportLink: true,
+        autoClose: false,
+      });
+      return;
     }
+
+    const explorerLink = await smartWalletInstance.getConnectedAccountTransactionExplorerLink(deploymentHash);
+    if (!explorerLink) {
+      Toast.show({
+        message: t('toast.cannotGetBlockchainExplorerLink'),
+        emoji: 'woman-shrugging',
+        supportLink: true,
+        autoClose: false,
+      });
+      return;
+    }
+
+    Linking.openURL(explorerLink);
   };
 
   render() {

--- a/src/screens/Assets/WalletActivation.js
+++ b/src/screens/Assets/WalletActivation.js
@@ -62,7 +62,7 @@ class WalletActivation extends React.PureComponent<Props> {
     Linking.openURL('https://help.pillarproject.io/en/articles/3935106-smart-wallet-faq');
   };
 
-  handleEtherscan = async () => {
+  handleEtherscan = () => {
     const { deploymentHash } = this.props;
     if (!deploymentHash) {
       Toast.show({
@@ -74,7 +74,7 @@ class WalletActivation extends React.PureComponent<Props> {
       return;
     }
 
-    const explorerLink = await smartWalletInstance.getConnectedAccountTransactionExplorerLink(deploymentHash);
+    const explorerLink = smartWalletInstance.getConnectedAccountTransactionExplorerLink(deploymentHash);
     if (!explorerLink) {
       Toast.show({
         message: t('toast.cannotGetBlockchainExplorerLink'),

--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -576,6 +576,13 @@ class SmartWallet {
     return this.getSdk().removeAccountDevice(address).catch(() => null);
   }
 
+  getConnectedAccountTransactionExplorerLink(hash: string) {
+    return this.getSdk().getConnectedAccountTransactionExplorerLink(hash).catch(() => {
+      this.reportError('getConnectedAccountTransactionExplorerLink failed to return result', { hash });
+      return null;
+    });
+  }
+
   handleError(error: any) {
     reportOrWarn('SmartWallet handleError: ', error, 'critical');
   }

--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -576,11 +576,8 @@ class SmartWallet {
     return this.getSdk().removeAccountDevice(address).catch(() => null);
   }
 
-  getConnectedAccountTransactionExplorerLink(hash: string) {
-    return this.getSdk().getConnectedAccountTransactionExplorerLink(hash).catch(() => {
-      this.reportError('getConnectedAccountTransactionExplorerLink failed to return result', { hash });
-      return null;
-    });
+  getConnectedAccountTransactionExplorerLink(hash: string): string {
+    return this.getSdk().getConnectedAccountTransactionExplorerLink(hash); // not a promise
   }
 
   handleError(error: any) {

--- a/src/translations/locales/en/common.json
+++ b/src/translations/locales/en/common.json
@@ -1341,7 +1341,10 @@
     "smartWalletActivationUnavailable": "Activation is temporarily unavailable. Please try again later",
     "failedToUploadImage": "Failed to get image from the gallery. Please try again.",
     "failedToDeleteAvatar": "Failed to delete avatar. Please try again.",
-    "failedToCreateOrder": "An error occured. This offer cannot be accepted. Please try again."
+    "failedToCreateOrder": "An error occured. This offer cannot be accepted. Please try again.",
+    "cannotFindDeploymentHash": "Cannot find deployment hash. Please try again.",
+    "cannotFindTransactionHash": "Cannot find transaction hash. Please try again.",
+    "cannotGetBlockchainExplorerLink": "Cannot get blockchain explorer link. Please try again."
   },
 
   "exchangeContent": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,10 +2231,10 @@
     openzeppelin-solidity "2.1.2"
     solidity-bytes-utils "0.0.8"
 
-"@smartwallet/sdk@2.2.0":
-  version "2.2.0"
-  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@smartwallet/sdk/-/sdk-2.2.0.tgz#0d6370e7d8c43bc432024c8e206f17444c6a383c"
-  integrity sha1-DWNw59jEO8QyAkyOIG8XRExqODw=
+"@smartwallet/sdk@2.3.0":
+  version "2.3.0"
+  resolved "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/@smartwallet/sdk/-/sdk-2.3.0.tgz#04724b4bb0358fd0f97ee28ff3920ff30ef4f0a3"
+  integrity sha1-BHJLS7A1j9D5fuKP85IP8w708KM=
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@netgum/types" "^0.1.8"


### PR DESCRIPTION
Recent @jsidorenko change in Archanova indexer allowed to reorder transactions which results in replaced hashes of original transaction. Part of this change was SDK method that allows to retrieve blockchain explorer (etherscan) link for latest transaction hash by using original one. This PR includes implementation of this method.