### PR TITLE
Revert to fastlane 2.162.0

### DIFF
--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 gem 'rake'
-gem "fastlane"
+gem "fastlane", "2.162.0"
 gem 'fastlane-plugin-get_version_name'
 gem 'fastlane-plugin-property_file_read'
 gem 'fastlane-plugin-appcenter'


### PR DESCRIPTION
Set the fastlane version in order to look at the failing `register_devices` action in our pipeline.