### PR TITLE
Fix/username error tooltip [PIL-886]

### DIFF
--- a/src/components/Layout/ContainerWithHeader.js
+++ b/src/components/Layout/ContainerWithHeader.js
@@ -141,7 +141,11 @@ class ContainerWithHeader extends React.Component<Props, State> {
       }
 
       return (
-        <ScrollView style={{ flex: 1 }} keyboardShouldPersistTaps={keyboardShouldPersistTaps}>
+        <ScrollView
+          style={{ flex: 1 }}
+          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
           {children}
         </ScrollView>
       );

--- a/src/components/UsernameFailed/UsernameFailed.js
+++ b/src/components/UsernameFailed/UsernameFailed.js
@@ -57,6 +57,7 @@ const ContentWrapper = styled.View`
 const StyledWrapper = styled.View`
   flex-grow: 1;
   padding: 32px ${spacing.layoutSides}px ${spacing.layoutSides}px;
+  min-height: 180px; ${''/* to add screen estate for error toast */}
 `;
 
 const FooterWrapper = styled.View`

--- a/src/screens/NewProfile/NewProfile.js
+++ b/src/screens/NewProfile/NewProfile.js
@@ -76,6 +76,7 @@ const ContentWrapper = styled.View`
 const StyledWrapper = styled.View`
   flex-grow: 1;
   padding: 32px ${spacing.layoutSides}px ${spacing.layoutSides}px;
+  min-height: 180px; ${''/* to add screen estate for error toast */}
 `;
 
 const CheckboxText = styled(BaseText)`


### PR DESCRIPTION
PR to fix error tooltip (of error on new username) being cut.

I've extended scrollview of ContainerWithHeader content height.
But it isn't enough as toast is absolute, hence it does not extend layout height and it isn't scrollable enough to allow user to see the toast when keyboard is visible.

For this I've added min-height for a wrapper.
It could also be solved in more complex way -by listening for toast layout changes and getting its height and then applying it as a bottom padding to the wrapper. If you'd prefer this approach - I'm happy to add it.