### PR TITLE
fix for coingecko endpoint prices

### DIFF
--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -243,7 +243,7 @@ export const setupAppServicesAction = (privateKey: ?string) => {
 
     // user might not be registered at this point
     if (walletId) {
-      const rates = await getExchangeRates(Object.keys(defaultInitialAssets));
+      const rates = await getExchangeRates(defaultInitialAssets);
       dispatch(setRatesAction(rates));
       dispatch(fetchBadgesAction(false));
       dispatch(fetchReferralRewardAction());

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -44,7 +44,7 @@ import ERC721_CONTRACT_ABI_TRANSFER_FROM from 'abi/erc721_transferFrom.json';
 import BALANCE_CHECKER_CONTRACT_ABI from 'abi/balanceChecker.json';
 
 // services
-import { getCoinGeckoTokenPrices } from 'services/coinGecko';
+import { getCoinGeckoEtherPrice, getCoinGeckoTokenPrices } from 'services/coinGecko';
 import { firebaseRemoteConfig } from 'services/firebase';
 
 // types
@@ -385,6 +385,12 @@ export async function getExchangeRates(assets: Assets): Promise<?Object> {
   let rates = useLegacyCryptoCompare
     ? await getLegacyExchangeRates(assetSymbols)
     : await getCoinGeckoTokenPrices(assets);
+
+  // ether price fetched separately as it doesn't fit into CoinGecko token price endpoint
+  const etherPrice = await getCoinGeckoEtherPrice();
+  if (etherPrice) {
+    rates = { ...rates, [ETH]: etherPrice };
+  }
 
   // by any mean if CoinGecko failed let's try legacy way
   if (!useLegacyCryptoCompare && isEmpty(rates)) {

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -386,15 +386,18 @@ export async function getExchangeRates(assets: Assets): Promise<?Object> {
     ? await getLegacyExchangeRates(assetSymbols)
     : await getCoinGeckoTokenPrices(assets);
 
-  // ether price fetched separately as it doesn't fit into CoinGecko token price endpoint
-  const etherPrice = await getCoinGeckoEtherPrice();
-  if (etherPrice) {
-    rates = { ...rates, [ETH]: etherPrice };
-  }
-
-  // by any mean if CoinGecko failed let's try legacy way
-  if (!useLegacyCryptoCompare && isEmpty(rates)) {
-    rates = await getLegacyExchangeRates(assetSymbols);
+  if (!useLegacyCryptoCompare) {
+    if (isEmpty(rates)) {
+      // by any mean if CoinGecko failed let's try legacy way
+      rates = await getLegacyExchangeRates(assetSymbols);
+    } else {
+      /**
+       * if CoinGecko didn't fail, fill rest of CoinGecko rates with ether
+       * because ether price doesn't fit into CoinGecko token price endpoint
+       */
+      const etherPrice = await getCoinGeckoEtherPrice();
+      rates = { ...rates, [ETH]: etherPrice };
+    }
   }
 
   if (!rates) {

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -48,7 +48,7 @@ import { getCoinGeckoTokenPrices } from 'services/coinGecko';
 import { firebaseRemoteConfig } from 'services/firebase';
 
 // types
-import type { Asset } from 'models/Asset';
+import type { Asset, Assets } from 'models/Asset';
 
 
 type Address = string;
@@ -371,7 +371,9 @@ export function getLegacyExchangeRates(assets: string[]): Promise<?Object> {
     });
 }
 
-export async function getExchangeRates(assetSymbols: string[]): Promise<?Object> {
+export async function getExchangeRates(assets: Assets): Promise<?Object> {
+  const assetSymbols = Object.keys(assets);
+
   if (isEmpty(assetSymbols)) {
     reportLog('getExchangeRates received empty assetSymbols array', { assetSymbols });
     return null;
@@ -382,7 +384,7 @@ export async function getExchangeRates(assetSymbols: string[]): Promise<?Object>
 
   let rates = useLegacyCryptoCompare
     ? await getLegacyExchangeRates(assetSymbols)
-    : await getCoinGeckoTokenPrices(assetSymbols);
+    : await getCoinGeckoTokenPrices(assets);
 
   // by any mean if CoinGecko failed let's try legacy way
   if (!useLegacyCryptoCompare && isEmpty(rates)) {

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -390,9 +390,9 @@ export async function getExchangeRates(assets: Assets): Promise<?Object> {
     if (isEmpty(rates)) {
       // by any mean if CoinGecko failed let's try legacy way
       rates = await getLegacyExchangeRates(assetSymbols);
-    } else {
+    } else if (assetSymbols.includes(ETH)) {
       /**
-       * if CoinGecko didn't fail, fill rest of CoinGecko rates with ether
+       * if CoinGecko didn't fail, fill rest of CoinGecko rates with ether (if requested)
        * because ether price doesn't fit into CoinGecko token price endpoint
        */
       const etherPrice = await getCoinGeckoEtherPrice();

--- a/src/services/coinGecko.js
+++ b/src/services/coinGecko.js
@@ -18,15 +18,17 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import axios, { AxiosResponse } from 'axios';
+
+// utils
+import { getAssetsAsList } from 'utils/assets';
 import { isCaseInsensitiveMatch, reportErrorLog } from 'utils/common';
+
+// constants
 import { ETH, supportedFiatCurrencies } from 'constants/assetsConstants';
 
+// types
+import type { Asset, Assets } from 'models/Asset';
 
-type CoinGeckoAsset = {
-  id: string,
-  symbol: string,
-  name: string,
-};
 
 type CoinGeckoAssetsPrices = {
   [coinGeckoAssetId: string]: {
@@ -43,31 +45,6 @@ const requestConfig = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
-};
-
-let cachedCoinGeckoAssets = null;
-
-// note: there is no pagination for /coins/list endpoint
-export const getCoinGeckoAssets = async (assetSymbols: string[]): Promise<?CoinGeckoAsset[]> => {
-  if (!cachedCoinGeckoAssets) {
-    // cache for current running instance as it's huge list that changes rarely
-    cachedCoinGeckoAssets = await axios
-      .get(`${COINGECKO_API_URL}/coins/list`, requestConfig)
-      .then(({ data: responseData }: AxiosResponse) => responseData)
-      .catch((error) => {
-        reportErrorLog('getCoinGeckoAssets failed: API request error', { error, assetSymbols });
-        return null;
-      });
-  }
-
-  if (!cachedCoinGeckoAssets || !Array.isArray(cachedCoinGeckoAssets)) {
-    reportErrorLog('getCoinGeckoAssets failed: unexpected data', { data: cachedCoinGeckoAssets, assetSymbols });
-    return null;
-  }
-
-  return cachedCoinGeckoAssets.filter((coinGeckoAsset: CoinGeckoAsset) => assetSymbols.find(
-    (assetSymbol) => isCaseInsensitiveMatch(assetSymbol, coinGeckoAsset.symbol)),
-  );
 };
 
 const mapWalletAndCoinGeckoCurrencies = (
@@ -87,53 +64,52 @@ const mapWalletAndCoinGeckoCurrencies = (
 
 const mapWalletAndCoinGeckoAssetsPrices = (
   responseData: CoinGeckoAssetsPrices,
-  assetSymbols: string[],
+  assetsList: Asset[],
   walletCurrencies: string[],
-  coinGeckoAssets: CoinGeckoAsset[],
-) => Object.keys(responseData).reduce((mappedResponseData, coinGeckoAssetId) => {
-  const coinGeckoAsset = coinGeckoAssets.find(({ id }) => id === coinGeckoAssetId);
-
-  // map asset symbol
-  if (coinGeckoAsset) {
-    const assetSymbol = assetSymbols.find((symbol) => isCaseInsensitiveMatch(coinGeckoAsset.symbol, symbol));
-    if (assetSymbol) {
-      // map currencies
-      mappedResponseData[assetSymbol] = mapWalletAndCoinGeckoCurrencies(
-        responseData[coinGeckoAssetId],
-        walletCurrencies,
-      );
-    }
+) => Object.keys(responseData).reduce((mappedResponseData, contractAddress) => {
+  const walletAsset = assetsList.find(({ address }) => isCaseInsensitiveMatch(address, contractAddress));
+  if (walletAsset) {
+    const { symbol } = walletAsset;
+    // map currencies
+    mappedResponseData[symbol] = mapWalletAndCoinGeckoCurrencies(
+      responseData[contractAddress],
+      walletCurrencies,
+    );
   }
-
   return mappedResponseData;
 }, {});
 
-export const getCoinGeckoTokenPrices = async (assetSymbols: string[]): Promise<?Object> => {
-  const coinGeckoAssets = await getCoinGeckoAssets(assetSymbols);
-  if (!coinGeckoAssets) {
-    // report not needed
-    return null;
-  }
+export const getCoinGeckoTokenPrices = async (assets: Assets): Promise<?Object> => {
+  const assetsList = getAssetsAsList(assets);
+  const assetsContractAddresses = assetsList.map(({ address }) => address);
 
   const walletCurrencies = supportedFiatCurrencies.concat(ETH);
 
-  const coinGeckoAssetIdsQuery = coinGeckoAssets.map(({ id }) => id).join(',');
+  const contractAddressesQuery = assetsContractAddresses.join(',');
   const vsCurrenciesQuery = walletCurrencies.map((currency) => currency.toLowerCase()).join(',');
 
   return axios.get(
-    `${COINGECKO_API_URL}/simple/price?ids=${coinGeckoAssetIdsQuery}&vs_currencies=${vsCurrenciesQuery}`,
+    `${COINGECKO_API_URL}/simple/token_price/ethereum`
+    + `?contract_addresses=${contractAddressesQuery}`
+    + `&vs_currencies=${vsCurrenciesQuery}`,
     requestConfig,
   )
     .then(({ data: responseData }: AxiosResponse) => {
       if (!responseData) {
-        reportErrorLog('getCoinGeckoTokenPrices failed: unexpected response', { response: responseData, assetSymbols });
+        reportErrorLog('getCoinGeckoTokenPrices failed: unexpected response', {
+          response: responseData,
+          assetsContractAddresses,
+        });
         return null;
       }
 
-      return mapWalletAndCoinGeckoAssetsPrices(responseData, assetSymbols, walletCurrencies, coinGeckoAssets);
+      return mapWalletAndCoinGeckoAssetsPrices(responseData, assetsList, walletCurrencies);
     })
     .catch((error) => {
-      reportErrorLog('getCoinGeckoTokenPrices failed: API request error', { error, assetSymbols });
+      reportErrorLog('getCoinGeckoTokenPrices failed: API request error', {
+        error,
+        assetsContractAddresses,
+      });
       return null;
     });
 };

--- a/src/services/coinGecko.js
+++ b/src/services/coinGecko.js
@@ -130,14 +130,14 @@ export const getCoinGeckoEtherPrice = async (): Promise<?Object> => {
   )
     .then(({ data: responseData }: AxiosResponse) => {
       if (!responseData) {
-        reportErrorLog('getCoinGeckoEthereumPrice failed: unexpected response', { response: responseData });
+        reportErrorLog('getCoinGeckoEtherPrice failed: unexpected response', { response: responseData });
         return null;
       }
 
       return mapWalletAndCoinGeckoCurrencies(responseData[coinGeckoEtherAssetId], walletCurrencies);
     })
     .catch((error) => {
-      reportErrorLog('getCoinGeckoEthereumPrice failed: API request error', { error });
+      reportErrorLog('getCoinGeckoEtherPrice failed: API request error', { error });
       return null;
     });
 };

--- a/src/services/coinGecko.js
+++ b/src/services/coinGecko.js
@@ -120,7 +120,7 @@ export const getCoinGeckoTokenPrices = async (assets: Assets): Promise<?Object> 
 
 export const getCoinGeckoEtherPrice = async (): Promise<?Object> => {
   const coinGeckoEtherAssetId = 'ethereum'; // eslint-disable-line i18next/no-literal-string
-  const walletCurrencies = supportedFiatCurrencies.concat(ETH);
+  const walletCurrencies = supportedFiatCurrencies.concat(ETH); // for consistency, price returned is 1:1
   const vsCurrenciesQuery = walletCurrencies.map((currency) => currency.toLowerCase()).join(',');
   return axios.get(
     `${COINGECKO_API_URL}/simple/price`

--- a/src/testUtils/jestSetup.js
+++ b/src/testUtils/jestSetup.js
@@ -206,12 +206,23 @@ jest.setMock('react-native-vector-icons', {
   createIconSet: () => mockView,
 });
 
-export const mockExchangeRates = {
-  ETH: {
-    EUR: 624.21,
-    GBP: 544.57,
-    USD: 748.92,
+const mockTokensExchangeRates = {
+  PLR: {
+    EUR: 1.21,
+    GBP: 1.10,
+    USD: 1.42,
   },
+};
+
+const mockEtherExchangeRates = {
+  EUR: 624.21,
+  GBP: 544.57,
+  USD: 748.92,
+};
+
+export const mockExchangeRates = {
+  ...mockTokensExchangeRates,
+  ETH: mockEtherExchangeRates,
 };
 
 jest.setMock('cryptocompare', {
@@ -378,5 +389,6 @@ export const mockUserBadges = [{
 jest.setMock('configs/localeConfig', localeConfigMock);
 
 jest.setMock('services/coinGecko', {
-  getCoinGeckoTokenPrices: () => Promise.resolve(mockExchangeRates),
+  getCoinGeckoTokenPrices: () => Promise.resolve(mockTokensExchangeRates),
+  getCoinGeckoEtherPrice: () => Promise.resolve(mockEtherExchangeRates),
 });


### PR DESCRIPTION
Fixes CoinGecko token price parsing for multiple matching token symbols. Initial approach used fetch by symbols, this approach replaces prices endpoint to fetch by token contract addresses.