### PR TITLE
initiate SDK before pin success callback

### DIFF
--- a/src/utils/oAuth.js
+++ b/src/utils/oAuth.js
@@ -32,11 +32,8 @@ export type OAuthTokens = {
 };
 
 export const updateOAuthTokensCB = (dispatch: Dispatch) => {
-  return async (oAuthTokens: OAuthTokens) => {
-    dispatch({
-      type: UPDATE_OAUTH_TOKENS,
-      payload: oAuthTokens,
-    });
+  return (oAuthTokens: OAuthTokens) => {
+    dispatch({ type: UPDATE_OAUTH_TOKENS, payload: oAuthTokens });
     dispatch(saveDbAction('oAuthTokens', { oAuthTokens }, true));
   };
 };


### PR DESCRIPTION
SDK must be initiated before onLoginSuccess in case OAuth tokens fail/expire since it's used to update front-end with new tokens.