### PR TITLE
fix exchange navigation

### DIFF
--- a/src/constants/navigationConstants.js
+++ b/src/constants/navigationConstants.js
@@ -108,6 +108,7 @@ export const HOME = 'HOME';
 export const HOME_TAB = 'HOME_TAB';
 
 // EXCHANGE FLOW
+export const EXCHANGE_FLOW = 'EXCHANGE_FLOW';
 export const EXCHANGE = 'EXCHANGE';
 export const EXCHANGE_CONFIRM = 'EXCHANGE_CONFIRM';
 export const EXCHANGE_INFO = 'EXCHANGE_INFO';

--- a/src/navigation/appNavigation.js
+++ b/src/navigation/appNavigation.js
@@ -264,6 +264,7 @@ import {
   SABLIER_WITHDRAW,
   SABLIER_WITHDRAW_REVIEW,
   SENDWYRE_INPUT,
+  EXCHANGE_FLOW,
 } from 'constants/navigationConstants';
 
 // utils
@@ -332,23 +333,27 @@ const assetsFlow = createStackNavigator(
     [ASSET]: AssetScreen,
     [ASSET_SEARCH]: AssetSearchScreen,
     [COLLECTIBLE]: CollectibleScreen,
-    [EXCHANGE]: ExchangeScreen,
-    [EXCHANGE_CONFIRM]: ExchangeConfirmScreen,
     [WALLET_SETTINGS]: WalletSettingsScreen,
-    [EXCHANGE_INFO]: ExchangeInfoScreen,
   },
   StackNavigatorConfig,
 );
 
 assetsFlow.navigationOptions = hideTabNavigatorOnChildView;
 
-// SERVICES FLOW
-const servicesFlow = createStackNavigator({
-  [SERVICES]: ServicesScreen,
+const exchangeFlow = createStackNavigator({
   [EXCHANGE]: ExchangeScreen,
   [EXCHANGE_CONFIRM]: ExchangeConfirmScreen,
   [EXCHANGE_RECEIVE_EXPLAINED]: ExchangeReceiveExplained,
   [EXCHANGE_INFO]: ExchangeInfoScreen,
+  [SEND_TOKEN_PIN_CONFIRM]: SendTokenPinConfirmScreen,
+  [SEND_TOKEN_TRANSACTION]: SendTokenTransactionScreen,
+}, StackNavigatorConfig);
+
+exchangeFlow.navigationOptions = hideTabNavigatorOnChildView;
+
+// SERVICES FLOW
+const servicesFlow = createStackNavigator({
+  [SERVICES]: ServicesScreen,
   [SENDWYRE_INPUT]: SendwyreInputScreen,
 }, StackNavigatorConfig);
 
@@ -379,8 +384,6 @@ const homeFlow = createStackNavigator({
   [REFER_FLOW]: ReferFriendsScreen,
   [STORYBOOK]: StorybookScreen,
   [WALLET_SETTINGS]: WalletSettingsScreen,
-  [EXCHANGE]: ExchangeScreen,
-  [EXCHANGE_CONFIRM]: ExchangeConfirmScreen,
   [ADD_EDIT_USER]: AddOrEditUserScreen,
   [SEND_TOKEN_AMOUNT]: SendTokenAmountScreen,
   [POOLTOGETHER_PURCHASE]: PoolTogetherPurchaseScreen,
@@ -743,6 +746,7 @@ const AppFlowNavigation = createStackNavigator(
     [KEY_BASED_ASSET_TRANSFER_STATUS]: KeyBasedAssetTransferStatusScreen,
     [CONTACTS_FLOW]: contactsFlow,
     [SABLIER_FLOW]: sablierFlow,
+    [EXCHANGE_FLOW]: exchangeFlow,
   },
   modalTransition,
 );


### PR DESCRIPTION
This fixes Exchange navigation in such scenarios:
1. Navigating from Home screen up to transaction confirm (or success) can be navigated back in same flow.
2. Navigating from single Asset screen up to transaction confirm (or success) can be navigated back in same flow.
3. Navigating from Services up to transaction confirm (or success) can be navigated back in same flow and on transaction success navigates back to Services.
4. Fixes current issue for 3rd scenario where it's unable to navigate back at all.