### PR TITLE
Fix keyboard stuck on text inputs

### DIFF
--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -20,6 +20,7 @@
 
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import { Keyboard } from 'react-native';
 import { createStructuredSelector } from 'reselect';
 import styled, { withTheme } from 'styled-components/native';
 import t from 'translations/translate';
@@ -205,6 +206,8 @@ export const ValueInputComponent = (props: Props) => {
         collectibles: true,
       }]
       : undefined;
+
+    Keyboard.dismiss();
 
     Modal.open(() => (
       <SelectorOptions


### PR DESCRIPTION
To reproduce, do the following steps on exchange screen or sablier or any similar screen with value input:
- focus the text field, the keyboard goes up, at that moment it's not yet stuck, you can dismiss it
- select asset
- upon returning to the screen with text input, the keyboard will be still up and stuck
So I'm hiding the keyboard before opening the modal, just like here: https://github.com/pillarwallet/pillarwallet/blob/develop/src/components/TextInput/TextInput.js#L324