### PR TITLE
Fix estimations of sequence transactions

### DIFF
--- a/src/actions/transactionEstimateActions.js
+++ b/src/actions/transactionEstimateActions.js
@@ -74,8 +74,11 @@ export const estimateTransactionAction = (
     let transaction: AccountTransaction = {
       recipient: recipientAddress,
       value,
-      sequential,
     };
+
+    if (sequential) {
+      transaction.sequentialTransactions = sequential;
+    }
 
     if (assetData?.tokenType === COLLECTIBLES && !data && assetData) {
       const provider = getEthereumProvider(getEnv().COLLECTIBLES_NETWORK);


### PR DESCRIPTION
Because of this bug transactions estimations on Aave and Sablier are way too low, because only the first (allowance) transaction is estimated and the second one (an actual deposit) is not.