### PR TITLE
Rename "feature flags" to "remote config"

### DIFF
--- a/App.js
+++ b/App.js
@@ -53,7 +53,7 @@ import { changeLanguageAction, updateTranslationResourceOnContextChangeAction } 
 // constants
 import { DARK_THEME, LIGHT_THEME } from 'constants/appSettingsConstants';
 import { STAGING } from 'constants/envConstants';
-import { FEATURE_FLAGS, INITIAL_FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG, INITIAL_REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // components
 import { Container } from 'components/Layout';
@@ -174,7 +174,7 @@ class App extends React.Component<Props, *> {
      */
 
     remoteConfig()
-      .setDefaults(INITIAL_FEATURE_FLAGS)
+      .setDefaults(INITIAL_REMOTE_CONFIG)
       .then(() => log.info('Firebase Config: Defaults loaded and available.'))
       .catch(e => log.error('Firebase Config: An error occurred loading defaults:', e));
 
@@ -193,7 +193,7 @@ class App extends React.Component<Props, *> {
       .activate()
       .then((r) => {
         log.info('Firebase Config: Activation result was:', r);
-        if (sessionLanguageVersion !== firebaseRemoteConfig.getString(FEATURE_FLAGS.APP_LOCALES_LATEST_TIMESTAMP)) {
+        if (sessionLanguageVersion !== firebaseRemoteConfig.getString(REMOTE_CONFIG.APP_LOCALES_LATEST_TIMESTAMP)) {
           updateTranslationResourceOnContextChange();
         }
       })

--- a/src/actions/__tests__/appActions.test.js
+++ b/src/actions/__tests__/appActions.test.js
@@ -24,7 +24,7 @@ import ReduxAsyncQueue from 'redux-async-queue';
 import { RESET_APP_LOADED, UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
 import { UPDATE_SESSION } from 'constants/sessionConstants';
 import { CACHE_STATUS, SET_CACHED_URLS } from 'constants/cacheConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 import Storage from 'services/storage';
 import { initAppAndRedirectAction } from 'actions/appActions';
@@ -55,10 +55,10 @@ const initialCacheState = {
 
 const mockedFirebaseConfigGetString = (key) => {
   switch (key) {
-    case FEATURE_FLAGS.APP_LOCALES_LATEST_TIMESTAMP:
+    case REMOTE_CONFIG.APP_LOCALES_LATEST_TIMESTAMP:
       return TEST_TRANSLATIONS_TIME_STAMP;
 
-    case FEATURE_FLAGS.APP_LOCALES_URL:
+    case REMOTE_CONFIG.APP_LOCALES_URL:
       return TEST_TRANSLATIONS_BASE_URL;
 
     default:
@@ -81,7 +81,7 @@ describe('App actions', () => {
     `${TEST_TRANSLATIONS_BASE_URL}${defaultLanguage}/common_${TEST_TRANSLATIONS_TIME_STAMP}.json`;
 
 
-  it(`initAppAndRedirectAction - should trigger the app settings updated 
+  it(`initAppAndRedirectAction - should trigger the app settings updated
   with any redirection due to the empty storage`, async () => {
     await storage.save('storageSettings', { storageSettings: { pouchDBMigrated: true } });
     const expectedActions = [

--- a/src/actions/__tests__/assetsActions.test.js
+++ b/src/actions/__tests__/assetsActions.test.js
@@ -32,7 +32,7 @@ import {
 import type { Assets, AssetsByAccount } from 'models/Asset';
 import PillarSdk from 'services/api';
 import { sendAssetAction, fetchAssetsBalancesAction, getSupportedTokens } from 'actions/assetsActions';
-import { INITIAL_FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { INITIAL_REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 import { mockSupportedAssets } from 'testUtils/jestSetup';
 
 const pillarSdk = new PillarSdk();
@@ -117,7 +117,7 @@ const initialState = {
   wallet: { data: { address: mockWallet.address } },
   accounts: { data: mockAccounts },
   balances: { data: {} },
-  featureFlags: { data: INITIAL_FEATURE_FLAGS },
+  featureFlags: { data: INITIAL_REMOTE_CONFIG },
 };
 
 describe('Assets actions', () => {

--- a/src/actions/__tests__/localisationActions.test.js
+++ b/src/actions/__tests__/localisationActions.test.js
@@ -33,7 +33,7 @@ import localeConfig from 'configs/localeConfig';
 import { UPDATE_SESSION } from 'constants/sessionConstants';
 import { firebaseRemoteConfig } from 'services/firebase';
 import { UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 import { CACHE_STATUS } from 'constants/cacheConstants';
 import {
   EN_EXTERNAL_TEST_TRANSLATION,
@@ -205,10 +205,10 @@ const cachedEnTranslations = {
 
 const mockedFirebaseConfigGetUrlAndTimeStampString = (key) => {
   switch (key) {
-    case FEATURE_FLAGS.APP_LOCALES_LATEST_TIMESTAMP:
+    case REMOTE_CONFIG.APP_LOCALES_LATEST_TIMESTAMP:
       return TEST_TRANSLATIONS_TIME_STAMP;
 
-    case FEATURE_FLAGS.APP_LOCALES_URL:
+    case REMOTE_CONFIG.APP_LOCALES_URL:
       return TEST_TRANSLATIONS_BASE_URL;
 
     default:

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -89,7 +89,7 @@ import {
 import { fetchSmartWalletTransactionsAction } from './historyActions';
 import { setAppThemeAction, initialDeeplinkExecutedAction, setAppLanguageAction } from './appSettingsActions';
 import { setActiveBlockchainNetworkAction } from './blockchainNetworkActions';
-import { loadFeatureFlagsAction } from './featureFlagsActions';
+import { loadRemoteConfigAction } from './remoteConfigActions';
 import { getExchangeSupportedAssetsAction } from './exchangeActions';
 import { fetchReferralRewardAction } from './referralsActions';
 import { executeDeepLinkAction } from './deepLinkActions';
@@ -259,7 +259,7 @@ export const loginAction = (
 
       if (isOnline) {
         // Dispatch action to try and get the latest remote config values...
-        dispatch(loadFeatureFlagsAction());
+        dispatch(loadRemoteConfigAction());
 
         // to get exchange supported assets in order to show only supported assets on exchange selectors
         // and show exchange button on supported asset screen only

--- a/src/actions/localisationActions.js
+++ b/src/actions/localisationActions.js
@@ -46,7 +46,7 @@ import type { Dispatch, GetState } from 'reducers/rootReducer';
 
 import { reportErrorLog, reportLog } from 'utils/common';
 import { getCachedTranslationResources } from 'utils/cache';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 import { CACHE_STATUS } from 'constants/cacheConstants';
 
 
@@ -105,8 +105,8 @@ const getLocalTranslations = (language: string) => {
 const getTranslationsResources = async (props: GetTranslationResourcesProps) => {
   const { language, dispatch, getState } = props;
   let resources;
-  let version = firebaseRemoteConfig.getString(FEATURE_FLAGS.APP_LOCALES_LATEST_TIMESTAMP);
-  const baseUrl = firebaseRemoteConfig.getString(FEATURE_FLAGS.APP_LOCALES_URL);
+  let version = firebaseRemoteConfig.getString(REMOTE_CONFIG.APP_LOCALES_LATEST_TIMESTAMP);
+  const baseUrl = firebaseRemoteConfig.getString(REMOTE_CONFIG.APP_LOCALES_URL);
 
   const missingNsArray = [];
   const translationsData = getTranslationData(language, baseUrl, version);
@@ -341,7 +341,7 @@ export const updateTranslationResourceOnContextChangeAction = () => {
 
     if (!isFetched) return;
 
-    const baseUrl = firebaseRemoteConfig.getString(FEATURE_FLAGS.APP_LOCALES_URL);
+    const baseUrl = firebaseRemoteConfig.getString(REMOTE_CONFIG.APP_LOCALES_URL);
 
     if (!translationsInitialised || !localeConfig.isEnabled || !baseUrl) return;
 

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -70,7 +70,7 @@ import { fetchSmartWalletTransactionsAction } from 'actions/historyActions';
 import { logEventAction } from 'actions/analyticsActions';
 import { fetchBadgesAction } from 'actions/badgesActions';
 import { getWalletsCreationEventsAction } from 'actions/userEventsActions';
-import { loadFeatureFlagsAction } from 'actions/featureFlagsActions';
+import { loadRemoteConfigAction } from 'actions/remoteConfigActions';
 import { setRatesAction } from 'actions/ratesActions';
 import { resetAppServicesAction, resetAppStateAction } from 'actions/authActions';
 import { fetchReferralRewardAction } from 'actions/referralsActions';
@@ -239,7 +239,7 @@ export const setupAppServicesAction = (privateKey: ?string) => {
     // all the calls below require user to be online
     if (!isOnline) return;
 
-    dispatch(loadFeatureFlagsAction());
+    dispatch(loadRemoteConfigAction());
 
     // user might not be registered at this point
     if (walletId) {

--- a/src/actions/remoteConfigActions.js
+++ b/src/actions/remoteConfigActions.js
@@ -23,7 +23,7 @@ import { reportOrWarn } from 'utils/common';
 import { log } from 'utils/logger';
 import { isTest } from 'utils/environment';
 
-export const loadFeatureFlagsAction = () => {
+export const loadRemoteConfigAction = () => {
   return () => {
     /**
      * Instruct Remote Config to fetch the latest config

--- a/src/components/FeeLabelToggle/FeeLabelToggle.js
+++ b/src/components/FeeLabelToggle/FeeLabelToggle.js
@@ -37,7 +37,7 @@ import Modal from 'components/Modal';
 
 // constants
 import { defaultFiatCurrency, ETH } from 'constants/assetsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // utils
 import { formatTransactionFee, getCurrencySymbol } from 'utils/common';
@@ -116,7 +116,7 @@ const FeeLabelToggle = ({
   const labelValue = isFiatValueVisible ? feeInFiatDisplayValue : feeDisplayValue;
 
   showRelayerMigration = showRelayerMigration &&
-    firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.APP_FEES_PAID_WITH_PLR) &&
+    firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.APP_FEES_PAID_WITH_PLR) &&
     !isGasTokenSupported;
 
   const openRelayerMigrationModal = () => {

--- a/src/components/Modals/HTMLContentModal/HTMLContentModal.js
+++ b/src/components/Modals/HTMLContentModal/HTMLContentModal.js
@@ -34,7 +34,7 @@ import { getThemeColors } from 'utils/themes';
 import { reportErrorLog } from 'utils/common';
 
 // constants
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // services
 import { firebaseRemoteConfig } from 'services/firebase';
@@ -117,7 +117,7 @@ class HTMLContentModal extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const endpointPrefix = firebaseRemoteConfig.getString(FEATURE_FLAGS.LEGAL_HTML_ENDPOINT_PREFIX);
+    const endpointPrefix = firebaseRemoteConfig.getString(REMOTE_CONFIG.LEGAL_HTML_ENDPOINT_PREFIX);
     const { htmlEndpoint } = this.props;
     // eslint-disable-next-line i18next/no-literal-string
     const htmlEndpointFull = `${endpointPrefix}${htmlEndpoint}.html`;

--- a/src/components/SWActivationModal/SWActivationModal.js
+++ b/src/components/SWActivationModal/SWActivationModal.js
@@ -41,7 +41,7 @@ import FeeLabelToggle from 'components/FeeLabelToggle';
 // constants
 import { ASSETS } from 'constants/navigationConstants';
 import { ETH } from 'constants/assetsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // utils
 import { images } from 'utils/images';
@@ -93,7 +93,7 @@ const SWActivationModal = ({
   balances,
   isOnline,
 }: Props) => {
-  const paidByPillar = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.SMART_WALLET_ACTIVATION_PAID_BY_PILLAR);
+  const paidByPillar = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.SMART_WALLET_ACTIVATION_PAID_BY_PILLAR);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/src/constants/remoteConfigConstants.js
+++ b/src/constants/remoteConfigConstants.js
@@ -18,18 +18,19 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-// Services screen features
-export const FEATURE_FLAGS = {
-  OFFERS_ENGINE: 'feature_services_offers_engine',
-  AAVE: 'feature_services_aave',
-  POOL_TOGETHER: 'feature_services_pool_together',
-  RAMP: 'feature_services_ramp',
-  WYRE: 'feature_services_wyre',
-  PEER_TO_PEER: 'feature_services_peer_to_peer',
+// Feature flags for Services screen items and other constants fetched from
+// Firebase Remote Config
+export const REMOTE_CONFIG = {
+  FEATURE_OFFERS_ENGINE: 'feature_services_offers_engine',
+  FEATURE_AAVE: 'feature_services_aave',
+  FEATURE_POOL_TOGETHER: 'feature_services_pool_together',
+  FEATURE_RAMP: 'feature_services_ramp',
+  FEATURE_WYRE: 'feature_services_wyre',
+  FEATURE_PEER_TO_PEER: 'feature_services_peer_to_peer',
+  FEATURE_ALTALIX: 'feature_services_altalix',
+  FEATURE_SABLIER: 'feature_services_sablier',
   KEY_BASED_ASSETS_MIGRATION: 'app_assets_show_kw_migration',
-  SABLIER: 'feature_services_sablier',
   SABLIER_TIME_START_TOLERANCE: 'feature_services_sablier_time_start_tolerance',
-  ALTALIX: 'feature_services_altalix',
   SMART_WALLET_ACTIVATION_PAID_BY_PILLAR: 'app_smart_wallet_paid_for_by_pillar',
   APP_FEES_PAID_WITH_PLR: 'app_fees_paid_with_plr',
   USE_LEGACY_CRYPTOCOMPARE_TOKEN_PRICES: 'use_legacy_cryptocompare_token_prices',
@@ -39,20 +40,20 @@ export const FEATURE_FLAGS = {
 };
 
 // These are used as a fallback in case firebase fails to fetch actual values
-export const INITIAL_FEATURE_FLAGS = {
-  [FEATURE_FLAGS.OFFERS_ENGINE]: true,
-  [FEATURE_FLAGS.RAMP]: true,
-  [FEATURE_FLAGS.WYRE]: true,
-  [FEATURE_FLAGS.AAVE]: true,
-  [FEATURE_FLAGS.POOL_TOGETHER]: true,
-  [FEATURE_FLAGS.PEER_TO_PEER]: true,
-  [FEATURE_FLAGS.KEY_BASED_ASSETS_MIGRATION]: true,
-  [FEATURE_FLAGS.ALTALIX]: true,
-  [FEATURE_FLAGS.SABLIER]: true,
-  [FEATURE_FLAGS.SABLIER_TIME_START_TOLERANCE]: 5,
-  [FEATURE_FLAGS.APP_FEES_PAID_WITH_PLR]: false,
-  [FEATURE_FLAGS.USE_LEGACY_CRYPTOCOMPARE_TOKEN_PRICES]: false,
-  [FEATURE_FLAGS.APP_LOCALES_URL]: 'test',
-  [FEATURE_FLAGS.APP_LOCALES_LATEST_TIMESTAMP]: '1',
-  [FEATURE_FLAGS.LEGAL_HTML_ENDPOINT_PREFIX]: 'https://s3.eu-west-2.amazonaws.com/pillar-prod-core-profile-images/legal/',
+export const INITIAL_REMOTE_CONFIG = {
+  [REMOTE_CONFIG.FEATURE_OFFERS_ENGINE]: true,
+  [REMOTE_CONFIG.FEATURE_RAMP]: true,
+  [REMOTE_CONFIG.FEATURE_WYRE]: true,
+  [REMOTE_CONFIG.FEATURE_AAVE]: true,
+  [REMOTE_CONFIG.FEATURE_POOL_TOGETHER]: true,
+  [REMOTE_CONFIG.FEATURE_PEER_TO_PEER]: true,
+  [REMOTE_CONFIG.FEATURE_ALTALIX]: true,
+  [REMOTE_CONFIG.FEATURE_SABLIER]: true,
+  [REMOTE_CONFIG.KEY_BASED_ASSETS_MIGRATION]: true,
+  [REMOTE_CONFIG.SABLIER_TIME_START_TOLERANCE]: 5,
+  [REMOTE_CONFIG.APP_FEES_PAID_WITH_PLR]: false,
+  [REMOTE_CONFIG.USE_LEGACY_CRYPTOCOMPARE_TOKEN_PRICES]: false,
+  [REMOTE_CONFIG.APP_LOCALES_URL]: 'test',
+  [REMOTE_CONFIG.APP_LOCALES_LATEST_TIMESTAMP]: '1',
+  [REMOTE_CONFIG.LEGAL_HTML_ENDPOINT_PREFIX]: 'https://s3.eu-west-2.amazonaws.com/pillar-prod-core-profile-images/legal/',
 };

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -47,7 +47,7 @@ import { responsiveSize } from 'utils/ui';
 import { ASSETS, KEY_BASED_ASSET_TRANSFER_CHOOSE } from 'constants/navigationConstants';
 import { BLOCKCHAIN_NETWORK_TYPES } from 'constants/blockchainNetworkConstants';
 import { defaultFiatCurrency } from 'constants/assetsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // actions
 import { setActiveBlockchainNetworkAction } from 'actions/blockchainNetworkActions';
@@ -201,7 +201,7 @@ const AccountsScreen = ({
       };
     });
 
-  const isKeyBasedAssetsMigrationEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.KEY_BASED_ASSETS_MIGRATION);
+  const isKeyBasedAssetsMigrationEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.KEY_BASED_ASSETS_MIGRATION);
   if (isKeyBasedAssetsMigrationEnabled && keyBasedWalletHasPositiveBalance) {
     walletsToShow.push({
       type: ITEM_TYPE.BUTTON,

--- a/src/screens/Menu/AppSettings.js
+++ b/src/screens/Menu/AppSettings.js
@@ -38,7 +38,7 @@ import Modal from 'components/Modal';
 // constants
 import { defaultFiatCurrency, ETH, PLR } from 'constants/assetsConstants';
 import { DARK_THEME, LIGHT_THEME } from 'constants/appSettingsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 import { MANAGE_CONNECTED_DEVICES } from 'constants/navigationConstants';
 
 // utils
@@ -120,7 +120,7 @@ class AppSettings extends React.Component<Props, State> {
 
     const hasOtherDevicesLinked = !!devices.length
       && !!devices.filter(({ address }) => !addressesEqual(activeDeviceAddress, address)).length;
-    const showGasTokenOption = isSmartAccount && firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.APP_FEES_PAID_WITH_PLR);
+    const showGasTokenOption = isSmartAccount && firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.APP_FEES_PAID_WITH_PLR);
 
     return [
       {

--- a/src/screens/Menu/Menu.js
+++ b/src/screens/Menu/Menu.js
@@ -55,7 +55,7 @@ import {
   KEY_BASED_ASSET_TRANSFER_STATUS,
   CONTACTS_FLOW,
 } from 'constants/navigationConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // actions
 import { lockScreenAction, logoutAction } from 'actions/authActions';
@@ -161,7 +161,7 @@ const Menu = ({
   const isBackedUp = backupStatus.isImported || backupStatus.isBackedUp || __DEV__;
   const colors = getThemeColors(theme);
 
-  const isKeyBasedAssetsMigrationEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.KEY_BASED_ASSETS_MIGRATION);
+  const isKeyBasedAssetsMigrationEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.KEY_BASED_ASSETS_MIGRATION);
   const isKeyBasedAssetsMigrationHidden = !isKeyBasedAssetsMigrationEnabled || (
     !hasKeyBasedAssetsTransferInProgress && !keyBasedWalletHasPositiveBalance
   );

--- a/src/screens/Sablier/NewStream.js
+++ b/src/screens/Sablier/NewStream.js
@@ -47,7 +47,7 @@ import { isEnsName } from 'utils/validators';
 // constants
 import { DAI, ETH } from 'constants/assetsConstants';
 import { SABLIER_NEW_STREAM_REVIEW } from 'constants/navigationConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 import { DATE_PICKER } from 'constants/sablierConstants';
 
 // services
@@ -114,7 +114,7 @@ class NewStream extends React.Component<Props, State> {
 
   getMinimalDate = () => {
     // default to 5 minutes
-    const delayInMinutes = firebaseRemoteConfig.getNumber(FEATURE_FLAGS.SABLIER_TIME_START_TOLERANCE) || 5;
+    const delayInMinutes = firebaseRemoteConfig.getNumber(REMOTE_CONFIG.SABLIER_TIME_START_TOLERANCE) || 5;
     return addMinutes(new Date(), delayInMinutes);
   }
 

--- a/src/screens/Services/Services.js
+++ b/src/screens/Services/Services.js
@@ -44,7 +44,7 @@ import {
   SABLIER_STREAMS,
   SENDWYRE_INPUT,
 } from 'constants/navigationConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // utils
 import { getThemeColors } from 'utils/themes';
@@ -107,14 +107,14 @@ class ServicesScreen extends React.Component<Props> {
     /**
      * Retrieve boolean flags for services from Remote Config.
      */
-    isOffersEngineEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.OFFERS_ENGINE);
-    isAaveEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.AAVE);
-    isPoolTogetherEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.POOL_TOGETHER);
-    isPeerToPeerEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.PEER_TO_PEER);
-    isWyreEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.WYRE);
-    isRampEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.RAMP);
-    isSablierEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.SABLIER);
-    isAltalixEnabled = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.ALTALIX);
+    isOffersEngineEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_OFFERS_ENGINE);
+    isAaveEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_AAVE);
+    isPoolTogetherEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_POOL_TOGETHER);
+    isPeerToPeerEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_PEER_TO_PEER);
+    isWyreEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_WYRE);
+    isRampEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_RAMP);
+    isSablierEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_SABLIER);
+    isAltalixEnabled = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.FEATURE_ALTALIX);
 
     if (isAltalixAvailable === null) loadAltalixInfo();
   }

--- a/src/selectors/smartWallet.js
+++ b/src/selectors/smartWallet.js
@@ -23,7 +23,7 @@ import { createSelector } from 'reselect';
 // constants
 import { ETH } from 'constants/assetsConstants';
 import { SMART_WALLET_UPGRADE_STATUSES } from 'constants/smartWalletConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // utils
 import { accountHasGasTokenSupport, getSmartWalletStatus } from 'utils/smartWallet';
@@ -54,7 +54,7 @@ export const isGasTokenSupportedSelector = ({ smartWallet: { connectedAccount } 
 };
 
 export const preferredGasTokenSelector = ({ appSettings: { data: { preferredGasToken } } }: RootReducerState) => {
-  if (!firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.APP_FEES_PAID_WITH_PLR)) return ETH;
+  if (!firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.APP_FEES_PAID_WITH_PLR)) return ETH;
   return preferredGasToken || ETH;
 };
 

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -25,7 +25,7 @@ import isEmpty from 'lodash.isempty';
 // constants
 import { ETH, HOT, HOLO, supportedFiatCurrencies } from 'constants/assetsConstants';
 import { ERROR_TYPE } from 'constants/transactionsConstants';
-import { FEATURE_FLAGS } from 'constants/featureFlagsConstants';
+import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // utils
 import {
@@ -380,7 +380,7 @@ export async function getExchangeRates(assets: Assets): Promise<?Object> {
   }
 
   // CryptoCompare is legacy price oracle, however, the change to new one is feature flagged
-  const useLegacyCryptoCompare = firebaseRemoteConfig.getBoolean(FEATURE_FLAGS.USE_LEGACY_CRYPTOCOMPARE_TOKEN_PRICES);
+  const useLegacyCryptoCompare = firebaseRemoteConfig.getBoolean(REMOTE_CONFIG.USE_LEGACY_CRYPTOCOMPARE_TOKEN_PRICES);
 
   let rates = useLegacyCryptoCompare
     ? await getLegacyExchangeRates(assetSymbols)


### PR DESCRIPTION
With time, more remote config values were added, and it no longer makes sense to have them all under the name of "feature flags". 

The issue came up after the refactor of modals, and this is a separate PR containing only the renaming of files and variables.