### PR TITLE
Translations/flag to disable external translations for devs

### DIFF
--- a/src/configs/buildConfig.js
+++ b/src/configs/buildConfig.js
@@ -40,4 +40,5 @@ export const devOptions = {
   SHOW_THEME_TOGGLE_IN_STORYBOOK: undefined,
   SHOW_LANG_TOGGLE: undefined,
   DEFAULT_PIN: undefined,
+  DISABLE_EXTERNAL_TRANSLATIONS_ON_DEV: undefined,
 };

--- a/src/configs/localeConfig.js
+++ b/src/configs/localeConfig.js
@@ -24,6 +24,7 @@ import {
   PUNCTUATION_POSTPROCESSOR,
   SUFFIX_PREFIX_POSTPROCESSOR,
 } from 'constants/localesConstants';
+import { devOptions } from './buildConfig';
 
 // EN
 const EN_COMMON = require('../locales/en/common.json');
@@ -61,7 +62,7 @@ type LocalisationConfig = {
 };
 
 export default ({
-  isEnabled: true,
+  isEnabled: !__DEV__ || !devOptions.DISABLE_EXTERNAL_TRANSLATIONS_ON_DEV, // to always keep enabled in production
   defaultLanguage: DEFAULT_LANGUAGE_CODE,
   // pairs of language code and language name in native language
   supportedLanguages: {

--- a/src/services/localisation/README.md
+++ b/src/services/localisation/README.md
@@ -5,6 +5,7 @@
 ### Translations setup
 Translations feature is managed by setting `isEnabled` to `true` in `configs/localeConfigs` **OR** providing `baseUrl`
 to fetch external translations.
+_(to disable it in development, adjust `DISABLE_EXTERNAL_TRANSLATIONS_ON_DEV` value in `buildConfig`)_
 If the first requirement is not met, locally stored default language's (set in `configs/localeConfigs` as `defaultLanguage`) translations are being used.
 If the second one is not provided - locally stored translations are used.
 


### PR DESCRIPTION
Small PR to add flag to manage translations feature on dev environment 
(added extra safety measure to force external translations fetching in production
if we decide to disable external translations in development as default).

So: 
setting `DISABLE_EXTERNAL_TRANSLATIONS_ON_DEV` in `buildConfig` will disable translations feature and translations from local (en) files will be used - so any updates on current values will be visible instead of the ones in the server).