### PR TITLE
Fix/app launch theme fix

### DIFF
--- a/App.js
+++ b/App.js
@@ -373,7 +373,7 @@ const AppRoot = () => (
   <Suspense fallback={<View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}><Spinner /></View>}>
     <Provider store={store}>
       <PersistGate
-        loading={<Container defaultTheme={defaultTheme}><LoadingSpinner /></Container>}
+        loading={<Container defaultTheme={defaultTheme}><LoadingSpinner theme={defaultTheme} /></Container>}
         persistor={persistor}
       >
         {getEnv().SHOW_ONLY_STORYBOOK ? <Storybook /> : <AppWithNavigationState />}

--- a/App.js
+++ b/App.js
@@ -370,7 +370,13 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
 const AppWithNavigationState = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(App));
 
 const AppRoot = () => (
-  <Suspense fallback={<View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}><Spinner /></View>}>
+  <Suspense
+    fallback={(
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Spinner theme={defaultTheme} />
+      </View>
+    )}
+  >
     <Provider store={store}>
       <PersistGate
         loading={<Container defaultTheme={defaultTheme}><LoadingSpinner theme={defaultTheme} /></Container>}

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -30,14 +30,10 @@ type Props = {|
   trackWidth?: number,
   color?: ?string,
   style?: StyleSheet.Styles,
+  theme?: Theme,
 |};
 
-type CombinedProps = {
-  ...Props,
-  theme: Theme,
-}
-
-const getSpinnerColor = (props: CombinedProps) => {
+const getSpinnerColor = (props: Props) => {
   const { theme, basic, color } = props;
   if (color) return color;
   const colors = getThemeColors(theme);
@@ -45,7 +41,7 @@ const getSpinnerColor = (props: CombinedProps) => {
   return colors.primaryAccent130;
 };
 
-const Spinner = (props: CombinedProps) => {
+const Spinner = (props: Props) => {
   const {
     size = 40,
     trackWidth = 3,


### PR DESCRIPTION
Fixes app launch crash when `withTheme` middleware is not ready for `Spinner` component.

Crash can be reproduced by disabling "JS Dev Mode" on React Native dev settings.