### PR TITLE
fix/detect 0 rate on 1inch

### DIFF
--- a/src/services/1inch.js
+++ b/src/services/1inch.js
@@ -102,16 +102,19 @@ export const get1inchOffer = async (
   const response = await getResponseData(url, 'Failed to fetch 1inch offer');
   if (!response) return null;
 
+  const toTokenAmount = convertToNominalUnits(
+    new BigNumber(toAssetParsed.decimals),
+    new BigNumber(response.toTokenAmount),
+  );
+
+  // rate from target amount to zero means no pair available
+  if (toTokenAmount.isZero()) return null;
+
   const allowanceSet = await getAllowanceSet(clientAddress, safeFromAddress, fromAssetParsed);
 
   const fromTokenAmount = convertToNominalUnits(
     new BigNumber(fromAssetParsed.decimals),
     new BigNumber(response.fromTokenAmount),
-  );
-
-  const toTokenAmount = convertToNominalUnits(
-    new BigNumber(toAssetParsed.decimals),
-    new BigNumber(response.toTokenAmount),
   );
 
   const askRate = toTokenAmount.dividedBy(fromTokenAmount);


### PR DESCRIPTION
1inch API returns any offer that's quoted, however, unavailable pairs return `toTokenAmount: "0"` and this way we can filter unavailable 1inch pairs.

I.e. try https://api.1inch.exchange/v2.0/swagger/#/Quote%2FSwap/getQuote `/v2.0/quote` from token `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` (ETH) to `0x2fb12bccf6f5dd338b76be784a93ade072425690` (BEAT) on any amount.

