### PR TITLE
Account for exchange fee in Rari deposit flow

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1427,7 +1427,8 @@
     "rariDeposit": "{{amount}} {{token}} deposited to Rari Capital.",
     "rariWithdraw":"{{amount}} {{token}} withdrawn from Rari Capital.",
     "rariTransfer" :"{{amount}} {{token}} transfered to {{recipient}}.",
-    "rariClaimRgt": "{{amount}} RGT rewards claimed from Rari Capital."
+    "rariClaimRgt": "{{amount}} RGT rewards claimed from Rari Capital.",
+    "rariNotEnoughEthForExchange": "Not enough ETH to pay for exchange fee. Please deposit more ETH."
   },
 
   "exchangeContent": {

--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -35,7 +35,7 @@ import Toast from 'components/Toast';
 
 import { getRariDepositTransactionsAndExchangeFee } from 'utils/rari';
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
-import { reportErrorLog } from 'utils/common';
+import { reportErrorLog, formatUnits } from 'utils/common';
 
 import { calculateRariDepositTransactionEstimateAction } from 'actions/rariActions';
 import { resetEstimateTransactionAction, setEstimatingTransactionAction } from 'actions/transactionEstimateActions';
@@ -130,9 +130,18 @@ const RariAddDepositScreen = ({
           message: t('toast.rariServiceFailed'),
           emoji: 'hushed',
         });
+        setEstimatingTransaction(false);
         return;
       }
       const { depositTransactions, exchangeFeeBN: _exchangeFeeBN, slippage: _slippage } = txsAndExchangeFee;
+      if (selectedAsset.symbol === ETH && parseFloat(formatUnits(_exchangeFeeBN, 18)) > parseFloat(assetValue)) {
+        Toast.show({
+          message: t('toast.rariNotEnoughEthForExchange'),
+          emoji: 'hushed',
+        });
+        setEstimatingTransaction(false);
+        return;
+      }
       let _transactionPayload = depositTransactions[0];
 
       // check if there's approve transaction
@@ -152,6 +161,7 @@ const RariAddDepositScreen = ({
         message: t('toast.rariServiceFailed'),
         emoji: 'hushed',
       });
+      setEstimatingTransaction(false);
     });
   }, [assetValue, selectedAsset]);
 

--- a/src/utils/__tests__/rari.test.js
+++ b/src/utils/__tests__/rari.test.js
@@ -241,7 +241,7 @@ describe('Rari utils', () => {
       expect(data).toEqual({
         depositTransactions: [
           {
-            amount: 0.000100000000123456,
+            amount: 0.0001,
             data: 'exchangeAndDeposit(address,uint256,string,(address,address,address,' +
               'address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes,bytes,bytes)[],bytes[],uint256)',
             from: '0x0000',

--- a/src/utils/rari.js
+++ b/src/utils/rari.js
@@ -249,18 +249,18 @@ const getRariDepositTransactionData = async (
 export const getRariDepositTransactionsAndExchangeFee = async (
   rariPool: RariPool, senderAddress: string, amount: number, token: Asset, supportedAssets: Asset[], rates: Rates,
 ) => {
-  let amountBN = parseTokenBigNumberAmount(amount, token.decimals);
+  const amountBN = parseTokenBigNumberAmount(amount, token.decimals);
   let data = await getRariDepositTransactionData(rariPool, amountBN, token, supportedAssets, rates);
   if (!data) return null;
 
   if (token.symbol === ETH) {
     // if we're depositing ETH, subtract 0x protocol fee from deposited amount
     // this will prevent tx revert when depositing max available ETH
-    if (amountBN < data.exchangeFeeBN) {
+    if (amountBN.lt(data.exchangeFeeBN)) {
       return { exchangeFeeBN: data.exchangeFeeBN, depositTransactions: [], slippage: 0 };
     }
-    amountBN = amountBN.sub(data.exchangeFeeBN);
-    data = await getRariDepositTransactionData(rariPool, amountBN, token, supportedAssets, rates);
+    data = await getRariDepositTransactionData(
+      rariPool, amountBN.sub(data.exchangeFeeBN), token, supportedAssets, rates);
     if (!data) return null;
   }
 


### PR DESCRIPTION
Before:
- try to deposit max eth
- the tx will fail to estimate 
After:
- try to deposit max eth
- the transaction will estimate, however it will say something like not enough eth - that's just like in the send asset flow and I'll fix that later, along with the send flow. Probably it was broken with estimating refactor.