### PR TITLE
Fix Rari deposit DAI tx estimation

### DIFF
--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -515,7 +515,7 @@ class SmartWallet {
       estimateMethodParams = [
         ...estimateMethodParams,
         sequentialTransactions[0].recipient,
-        sequentialTransactions[0].value,
+        ethToWei(sequentialTransactions[0].value || 0),
         sequentialTransactions[0].data,
       ];
     }


### PR DESCRIPTION
Rari DAI deposit includes two sub-transactions:
- approve DAI for spending
- deposit DAI to Rari

DAI must be exchanged now via 0x (previously it was via mStable). 0x takes a fee in ETH (mStable doesn't). ETH is sent in transaction value field.
Now, the `estimateAccountTransaction` expects tx values as floats in eth and should convert them for smart wallet sdk to weis. It was converting it just for the first sub-transaction, the second one was missed... resulting in transaction revert, because we haven't sent exchange fee. I've added this conversion and estimating works flawlessly 🎉 
And the rest of services have 0 value in second transaction or don't have an approval tx. So it was working for them  🤷‍♀️ 