### PR TITLE
Fix/Fiat on Exchange screen

### DIFF
--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -169,7 +169,7 @@ export const ValueInputComponent = (props: Props) => {
     if (displayFiatAmount) {
       const split = newValue.split('.');
       // only allow 2 decimals in fiat mode
-      if (split.length <= 2 && split[1] ? split[1].length <= 2 : true) {
+      if (split.length <= 2 && !(split[1] && split[1].length > 2)) {
         setValueInFiat(newValue);
         const convertedValue =
         getAssetBalanceFromFiat(baseFiatCurrency, newValue, ratesWithCustomRates, assetSymbol).toString();

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -169,7 +169,8 @@ export const ValueInputComponent = (props: Props) => {
         onValueChange(convertedValue);
       }
     } else {
-      setValueInFiat(getBalanceInFiat(fiatCurrency, newValue, ratesWithCustomRates, assetSymbol).toString());
+      const fiatValue = getBalanceInFiat(fiatCurrency, newValue, ratesWithCustomRates, assetSymbol);
+      setValueInFiat(String(fiatValue ? fiatValue.toFixed(2) : 0));
       onValueChange(newValue);
     }
   };
@@ -187,7 +188,8 @@ export const ValueInputComponent = (props: Props) => {
     ));
     const maxValueInFiat = getBalanceInFiat(fiatCurrency, newMaxValue, ratesWithCustomRates, assetSymbol);
     onValueChange((parseFloat(newMaxValue) * (percent / 100)).toString());
-    setValueInFiat((maxValueInFiat * (percent / 100)).toString());
+    const fiatValue = maxValueInFiat * (percent / 100);
+    setValueInFiat(String(fiatValue ? fiatValue.toFixed(2) : 0));
   };
 
   const onInputBlur = () => {
@@ -267,6 +269,15 @@ export const ValueInputComponent = (props: Props) => {
 
   const { tokenType = TOKENS } = assetData;
 
+  const toggleDisplayFiat = () => {
+    // when switching at error state, reset value to avoid new errors
+    if (errorMessage) {
+      setValueInFiat('0');
+      handleValueChange('0');
+    }
+    setDisplayFiatAmount(!displayFiatAmount);
+  };
+
   return (
     <>
       {tokenType === TOKENS && (
@@ -282,7 +293,7 @@ export const ValueInputComponent = (props: Props) => {
             ? t('tokenValue', { value: formatAmount(value || '0', 2), token: assetSymbol || '' })
             : formattedValueInFiat
           }
-          onLeftSideTextPress={() => setDisplayFiatAmount(!displayFiatAmount)}
+          onLeftSideTextPress={toggleDisplayFiat}
           rightPlaceholder={displayFiatAmount ? fiatCurrency : assetSymbol}
           leftSideSymbol={leftSideSymbol}
           getInputRef={getInputRef}

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -156,6 +156,13 @@ export const ValueInputComponent = (props: Props) => {
   const formattedMaxValueInFiat = getFormattedBalanceInFiat(fiatCurrency, maxValue, ratesWithCustomRates, assetSymbol);
   const formattedValueInFiat = getFormattedBalanceInFiat(fiatCurrency, value, ratesWithCustomRates, assetSymbol);
 
+  React.useEffect(() => {
+    if (disabled) { // handle fiat updates when disabled, e.g. on Exchange screen
+      const fiatValue = getBalanceInFiat(fiatCurrency, value, ratesWithCustomRates, assetSymbol);
+      setValueInFiat(String(fiatValue ? fiatValue.toFixed(2) : 0));
+    }
+  }, [value]);
+
   const handleValueChange = (newValue: string) => {
     // ethers will crash with commas, TODO: we need a proper localisation
     newValue = newValue.replace(/,/g, '.');
@@ -270,7 +277,7 @@ export const ValueInputComponent = (props: Props) => {
   const { tokenType = TOKENS } = assetData;
 
   const toggleDisplayFiat = () => {
-    // when switching at error state, reset value to avoid new errors
+    // when switching at error state, reset values to avoid new errors
     if (errorMessage) {
       setValueInFiat('0');
       handleValueChange('0');


### PR DESCRIPTION
Fix several issues with "display fiat" option on Exchange screen: add error handling, limit fiat amounts to 2 decimals, add fiat updates for disabled input ("to" field). 