### PR TITLE
Liquidity pools fixes

### DIFF
--- a/src/actions/liquidityPoolsActions.js
+++ b/src/actions/liquidityPoolsActions.js
@@ -85,8 +85,14 @@ const fetchUnipoolUserDataAction = (unipoolAddress: string) => {
 };
 
 const fetchUniswapPoolDataAction = (poolAddress: string) => {
-  return async (dispatch: Dispatch) => {
-    const poolData = await fetchPoolData(poolAddress)
+  return async (dispatch: Dispatch, getState: GetState) => {
+    const {
+      accounts: { data: accounts },
+    } = getState();
+    const smartWalletAccount = findFirstSmartAccount(accounts);
+    if (!smartWalletAccount) return;
+
+    const poolData = await fetchPoolData(poolAddress, getAccountAddress(smartWalletAccount))
       .catch(error => {
         if (error instanceof GraphQueryError) {
           dispatch({

--- a/src/actions/liquidityPoolsActions.js
+++ b/src/actions/liquidityPoolsActions.js
@@ -257,6 +257,7 @@ export const calculateRemoveLiquidityTransactionEstimateAction = (
   tokenAmount: number,
   poolToken: Asset,
   tokensAssets: Asset[],
+  obtainedTokensAmounts: number[],
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const { accounts: { data: accounts } } = getState();
@@ -271,6 +272,7 @@ export const calculateRemoveLiquidityTransactionEstimateAction = (
       tokenAmount,
       poolToken,
       tokensAssets,
+      obtainedTokensAmounts,
     ).catch(error => {
       reportErrorLog("Liquidity pools service failed: can't create remove liquidity transaction", { error });
       return null;

--- a/src/models/LiquidityPools.js
+++ b/src/models/LiquidityPools.js
@@ -65,5 +65,6 @@ export type LiquidityPoolStats = {
   tokensPricesUSD: {[string]: number },
   tokensPerLiquidityToken: {[string]: number },
   totalSupply: number,
-  history: {date: Date, value: number}[]
+  history: {date: Date, value: number}[],
+  userLiquidityTokenBalance: number,
 };

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -94,7 +94,6 @@ import { combinedCollectiblesHistorySelector } from 'selectors/collectibles';
 import { poolTogetherUserStatsSelector } from 'selectors/poolTogether';
 import { isActiveAccountSmartWalletSelector } from 'selectors/smartWallet';
 import { sablierEventsSelector } from 'selectors/sablier';
-import { accountBalancesSelector } from 'selectors/balances';
 
 // utils
 import { spacing, fontSizes } from 'utils/variables';
@@ -103,7 +102,7 @@ import { mapTransactionsHistory, mapOpenSeaAndBCXTransactionsHistory } from 'uti
 import { resetAppNotificationsBadgeNumber } from 'utils/notifications';
 import { formatAmountDisplay, formatFiat } from 'utils/common';
 import { getPoolStats } from 'utils/liquidityPools';
-import { getBalance, convertUSDToFiat } from 'utils/assets';
+import { convertUSDToFiat } from 'utils/assets';
 
 // models, types
 import type { Account, Accounts } from 'models/Account';
@@ -113,7 +112,7 @@ import type { UserEvent } from 'models/userEvent';
 import type { Theme } from 'models/Theme';
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
 import type { User } from 'models/User';
-import type { DepositedAsset, Rates, Balances } from 'models/Asset';
+import type { DepositedAsset, Rates } from 'models/Asset';
 import type { Stream } from 'models/Sablier';
 import type { RariPool, Interests } from 'models/RariPool';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
@@ -185,7 +184,6 @@ type Props = {
   liquidityPoolsReducer: LiquidityPoolsReducerState,
   rates: Rates,
   hideLiquidityPools: boolean,
-  balances: Balances,
 };
 
 const RequestsWrapper = styled.View`
@@ -442,8 +440,8 @@ class HomeScreen extends React.Component<Props> {
   }
 
   renderLiquidityPool = ({ item: { pool, poolStats } }) => {
-    const { balances, rates, baseFiatCurrency } = this.props;
-    const tokenBalance = getBalance(balances, pool.symbol);
+    const { rates, baseFiatCurrency } = this.props;
+    const tokenBalance = poolStats.userLiquidityTokenBalance;
     const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
     return (
       <ListItemWithImage
@@ -501,7 +499,6 @@ class HomeScreen extends React.Component<Props> {
       isFetchingLiquidityPoolsData,
       toggleLiquidityPools,
       liquidityPoolsReducer,
-      balances,
     } = this.props;
 
     const tokenTxHistory = history
@@ -563,8 +560,7 @@ class HomeScreen extends React.Component<Props> {
         pool,
         poolStats: getPoolStats(pool, liquidityPoolsReducer),
       }))
-      .filter(({ pool, poolStats }) =>
-        poolStats && (getBalance(balances, pool.symbol) > 0 || poolStats.stakedAmount > 0));
+      .filter(({ poolStats }) => poolStats && (poolStats.userLiquidityTokenBalance > 0 || poolStats.stakedAmount > 0));
 
     return (
       <React.Fragment>
@@ -838,7 +834,6 @@ const structuredSelector = createStructuredSelector({
   poolTogetherUserStats: poolTogetherUserStatsSelector,
   isSmartWalletActive: isActiveAccountSmartWalletSelector,
   sablierEvents: sablierEventsSelector,
-  balances: accountBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/LiquidityPools/LiquidityPoolDashboard.js
+++ b/src/screens/LiquidityPools/LiquidityPoolDashboard.js
@@ -22,7 +22,6 @@ import { connect } from 'react-redux';
 import { View, RefreshControl } from 'react-native';
 import { CachedImage } from 'react-native-cached-image';
 import styled, { withTheme } from 'styled-components/native';
-import { createStructuredSelector } from 'reselect';
 import type { NavigationScreenProp } from 'react-navigation';
 import { getEnv } from 'configs/envConfig';
 import t from 'translations/translate';
@@ -57,12 +56,9 @@ import { LIQUIDITY_POOLS } from 'constants/liquidityPoolsConstants';
 
 // utils
 import { formatMoney, formatAmount, formatFiat, formatBigFiatAmount, formatBigAmount } from 'utils/common';
-import { getBalance, convertUSDToFiat } from 'utils/assets';
+import { convertUSDToFiat } from 'utils/assets';
 import { getPoolStats } from 'utils/liquidityPools';
 import { getColorByThemeOutsideStyled } from 'utils/themes';
-
-// selectors
-import { accountBalancesSelector } from 'selectors/balances';
 
 // types
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
@@ -150,7 +146,6 @@ const Overlay = styled(AbsolutePositioning)`
 
 const LiquidityPoolDashboard = ({
   navigation,
-  balances,
   baseFiatCurrency,
   isFetchingLiquidityPoolsData,
   poolDataGraphQueryFailed,
@@ -173,9 +168,9 @@ const LiquidityPoolDashboard = ({
 
   useEffect(() => {
     if (
-      getBalance(balances, pool.symbol) > 0 &&
       poolStats &&
       poolStats.stakedAmount === 0 &&
+      poolStats.userLiquidityTokenBalance > 0 &&
       !shownStakingEnabledModal[pool.name] &&
       pool.rewardsEnabled
     ) {
@@ -187,7 +182,7 @@ const LiquidityPoolDashboard = ({
       ));
       setShownStakingEnabledModal(pool.name);
     }
-  }, [balances, poolStats]);
+  }, [poolStats]);
 
   if (!poolStats) return <Loader />;
 
@@ -196,7 +191,7 @@ const LiquidityPoolDashboard = ({
     return null;
   }
 
-  const balance = getBalance(balances, pool.symbol);
+  const balance = poolStats.userLiquidityTokenBalance;
   const formattedBalance = formatMoney(balance, 4);
   const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
   const fiatBalance = formatFiat(convertUSDToFiat(balance * poolStats.currentPrice, rates, fiatCurrency), fiatCurrency);
@@ -470,18 +465,9 @@ const mapStateToProps = ({
   shownStakingEnabledModal,
 });
 
-const structuredSelector = createStructuredSelector({
-  balances: accountBalancesSelector,
-});
-
-const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
-  ...structuredSelector(state),
-  ...mapStateToProps(state),
-});
-
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   fetchLiquidityPoolsData: (pools: LiquidityPool[]) => dispatch(fetchLiquidityPoolsDataAction(pools)),
   setShownStakingEnabledModal: (poolName: string) => dispatch(setShownStakingEnabledModalAction(poolName)),
 });
 
-export default withTheme(connect(combinedMapStateToProps, mapDispatchToProps)(LiquidityPoolDashboard));
+export default withTheme(connect(mapStateToProps, mapDispatchToProps)(LiquidityPoolDashboard));

--- a/src/screens/LiquidityPools/LiquidityPools.js
+++ b/src/screens/LiquidityPools/LiquidityPools.js
@@ -264,7 +264,7 @@ const LiquidityPoolsScreen = ({
       <TouchableOpacity onPress={() => goToPoolDashboard(pool)}>
         <ListItemWithImage
           label={pool.name}
-          subtext={t('tokenValue', { token: poolToken.symbol, value: balance })}
+          subtext={t('tokenValue', { token: poolToken.symbol, value: formatAmount(balance) })}
           itemImageUrl={`${getEnv().SDK_PROVIDER}/${pool.iconUrl}?size=3`}
           customAddon={(
             <View style={{ alignItems: 'flex-end' }}>

--- a/src/screens/LiquidityPools/LiquidityPools.js
+++ b/src/screens/LiquidityPools/LiquidityPools.js
@@ -22,7 +22,6 @@ import { connect } from 'react-redux';
 import { FlatList, View, TouchableOpacity, RefreshControl } from 'react-native';
 import styled, { withTheme } from 'styled-components/native';
 import type { NavigationScreenProp } from 'react-navigation';
-import { createStructuredSelector } from 'reselect';
 import { CachedImage } from 'react-native-cached-image';
 import { getEnv } from 'configs/envConfig';
 import t from 'translations/translate';
@@ -36,7 +35,7 @@ import ListItemWithImage from 'components/ListItem/ListItemWithImage';
 import RetryGraphQueryBox from 'components/RetryGraphQueryBox';
 
 import { formatAmount, formatFiat, formatBigFiatAmount, formatBigAmount } from 'utils/common';
-import { getBalance, convertUSDToFiat } from 'utils/assets';
+import { convertUSDToFiat } from 'utils/assets';
 import { getPoolStats } from 'utils/liquidityPools';
 import { getThemeColors } from 'utils/themes';
 
@@ -44,11 +43,9 @@ import { defaultFiatCurrency } from 'constants/assetsConstants';
 import { LIQUIDITY_POOL_DASHBOARD, LIQUIDITY_POOLS_INFO } from 'constants/navigationConstants';
 import { LIQUIDITY_POOLS } from 'constants/liquidityPoolsConstants';
 
-import { accountBalancesSelector } from 'selectors/balances';
-
 import { fetchLiquidityPoolsDataAction } from 'actions/liquidityPoolsActions';
 
-import type { Rates, Asset, Balances } from 'models/Asset';
+import type { Rates, Asset } from 'models/Asset';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 import type { LiquidityPool } from 'models/LiquidityPools';
@@ -59,7 +56,6 @@ type Props = {
   fetchLiquidityPoolsData: (pools: LiquidityPool[]) => void,
   baseFiatCurrency: ?string,
   supportedAssets: Asset[],
-  balances: Balances,
   isFetchingLiquidityPoolsData: boolean,
   liquidityPoolsReducer: LiquidityPoolsReducerState,
   navigation: NavigationScreenProp<*>,
@@ -128,7 +124,6 @@ const LiquidityPoolsScreen = ({
   fetchLiquidityPoolsData,
   baseFiatCurrency,
   supportedAssets,
-  balances,
   isFetchingLiquidityPoolsData,
   liquidityPoolsReducer,
   navigation,
@@ -260,7 +255,7 @@ const LiquidityPoolsScreen = ({
     const poolStats = poolsStats[index];
     const poolToken = supportedAssets.find(({ symbol }) => symbol === pool.symbol);
     if (!poolToken) return null;
-    const balance = getBalance(balances, poolToken.symbol);
+    const balance = poolStats.userLiquidityTokenBalance;
 
     const { tokenPrice } = poolStats;
     const balanceInFiat = formatFiat(tokenPrice * balance, fiatCurrency);
@@ -301,12 +296,12 @@ const LiquidityPoolsScreen = ({
 
   const isAvailablePool = (pool: LiquidityPool, index: number) => {
     const poolStats = poolsStats[index];
-    return poolStats && getBalance(balances, pool.symbol) === 0 && poolStats.stakedAmount === 0;
+    return poolStats && poolStats.userLiquidityTokenBalance === 0 && poolStats.stakedAmount === 0;
   };
 
   const isPurchasedPool = (pool: LiquidityPool, index: number) => {
     const poolStats = poolsStats[index];
-    return poolStats && getBalance(balances, pool.symbol) > 0 && poolStats.stakedAmount === 0;
+    return poolStats && poolStats.userLiquidityTokenBalance > 0 && poolStats.stakedAmount === 0;
   };
 
   const isStakedPool = (pool: LiquidityPool, index: number) => {
@@ -404,18 +399,8 @@ const mapStateToProps = ({
   rates,
 });
 
-const structuredSelector = createStructuredSelector({
-  balances: accountBalancesSelector,
-});
-
-const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
-  ...structuredSelector(state),
-  ...mapStateToProps(state),
-});
-
-
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   fetchLiquidityPoolsData: (pools: LiquidityPool[]) => dispatch(fetchLiquidityPoolsDataAction(pools)),
 });
 
-export default withTheme(connect(combinedMapStateToProps, mapDispatchToProps)(LiquidityPoolsScreen));
+export default withTheme(connect(mapStateToProps, mapDispatchToProps)(LiquidityPoolsScreen));

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -325,7 +325,10 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
     poolAsset: Asset,
     tokensAssets: Asset[],
     obtainedAssetsValues: number[],
-  ) => dispatch(calculateRemoveLiquidityTransactionEstimateAction(pool, tokenAmount, poolAsset, tokensAssets, obtainedAssetsValues)), 500),
+  ) => dispatch(
+    calculateRemoveLiquidityTransactionEstimateAction(
+      pool, tokenAmount, poolAsset, tokensAssets, obtainedAssetsValues,
+    )), 500),
 });
 
 export default connect(combinedMapStateToProps, mapDispatchToProps)(AddLiquidityScreen);

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -69,7 +69,8 @@ type Props = {
     pool: LiquidityPool,
     tokenAmount: number,
     poolAsset: Asset,
-    erc20Token: Asset,
+    tokensAssets: Asset[],
+    obtainedAssetsValues: number[],
   ) => void,
   balances: Balances,
   liquidityPoolsReducer: LiquidityPoolsReducerState,
@@ -141,6 +142,7 @@ const AddLiquidityScreen = ({
       parseFloat(poolTokenAmount),
       poolTokenData,
       tokensData,
+      obtainedAssetsValues.map(v => parseFloat(v)),
     );
   }, [poolTokenAmount, obtainedTokenFieldsValid, poolTokenFieldValid]);
 
@@ -322,7 +324,8 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
     tokenAmount: number,
     poolAsset: Asset,
     tokensAssets: Asset[],
-  ) => dispatch(calculateRemoveLiquidityTransactionEstimateAction(pool, tokenAmount, poolAsset, tokensAssets)), 500),
+    obtainedAssetsValues: number[],
+  ) => dispatch(calculateRemoveLiquidityTransactionEstimateAction(pool, tokenAmount, poolAsset, tokensAssets, obtainedAssetsValues)), 500),
 });
 
 export default connect(combinedMapStateToProps, mapDispatchToProps)(AddLiquidityScreen);

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -40,7 +40,7 @@ import { LIQUIDITY_POOLS_REMOVE_LIQUIDITY_REVIEW } from 'constants/navigationCon
 
 // utils
 import { formatAmount } from 'utils/common';
-import { isEnoughBalanceForTransactionFee, getBalance } from 'utils/assets';
+import { isEnoughBalanceForTransactionFee } from 'utils/assets';
 import { getPoolStats, calculateProportionalRemoveLiquidityAssetValues } from 'utils/liquidityPools';
 
 // selectors
@@ -173,7 +173,7 @@ const AddLiquidityScreen = ({
   const renderTokenInput = (tokenIndex: number) => {
     const poolTokenSymbol = poolTokenData?.symbol;
     if (!poolTokenSymbol) return null;
-    const maxAmountBurned = getBalance(balances, poolTokenSymbol);
+    const maxAmountBurned = poolStats?.userLiquidityTokenBalance || 0;
     const totalAmount = parseFloat(poolStats?.totalSupply);
     const tokenPool = parseFloat(poolStats?.tokensLiquidity[pool.tokensProportions[tokenIndex].symbol]);
 
@@ -237,6 +237,13 @@ const AddLiquidityScreen = ({
     },
   );
 
+  const poolTokenCustomBalances = poolTokenData && {
+    [poolTokenData.symbol]: {
+      balance: poolStats?.userLiquidityTokenBalance,
+      symbol: poolTokenData.symbol,
+    },
+  };
+
   return (
     <ContainerWithHeader
       headerProps={{ centerItems: [{ title: t('liquidityPoolsContent.title.removeLiquidity') }] }}
@@ -276,6 +283,7 @@ const AddLiquidityScreen = ({
           value={poolTokenAmount}
           onValueChange={onPoolTokenAmountChange}
           onFormValid={setPoolTokenFieldValid}
+          customBalances={poolTokenCustomBalances}
         />
         <StyledIcon name="direct" />
         {renderTokenInput(1)}

--- a/src/screens/LiquidityPools/RemoveLiquidityReview.js
+++ b/src/screens/LiquidityPools/RemoveLiquidityReview.js
@@ -100,6 +100,7 @@ const RemoveLiquidityReviewScreen = ({
       poolTokenValue,
       poolToken,
       obtainedTokensData,
+      obtainedTokensValues,
       feeInfo?.fee,
     );
 

--- a/src/screens/LiquidityPools/StakeTokens.js
+++ b/src/screens/LiquidityPools/StakeTokens.js
@@ -39,11 +39,15 @@ import { LIQUIDITY_POOLS_STAKE_REVIEW } from 'constants/navigationConstants';
 import { resetEstimateTransactionAction } from 'actions/transactionEstimateActions';
 import { calculateStakeTransactionEstimateAction } from 'actions/liquidityPoolsActions';
 
+// utils
+import { getPoolStats } from 'utils/liquidityPools';
+
 // types
 import type { Asset } from 'models/Asset';
 import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { LiquidityPool } from 'models/LiquidityPools';
+import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 
 
 type Props = {
@@ -58,6 +62,7 @@ type Props = {
     tokenAmount: number,
     tokenAsset: Asset,
   ) => void,
+  liquidityPoolsReducer: LiquidityPoolsReducerState,
 };
 
 const MainContainer = styled.View`
@@ -83,12 +88,14 @@ const StakeTokensScreen = ({
   estimateErrorMessage,
   resetEstimateTransaction,
   calculateStakeTransactionEstimate,
+  liquidityPoolsReducer,
 }: Props) => {
   useEffect(() => {
     resetEstimateTransaction();
   }, []);
 
   const { pool } = navigation.state.params;
+  const poolStats = getPoolStats(pool, liquidityPoolsReducer);
   const assetData = supportedAssets.find(asset => asset.symbol === pool.symbol);
   const [assetValue, setAssetValue] = useState('');
   const [isValid, setIsValid] = useState(false);
@@ -113,6 +120,13 @@ const StakeTokensScreen = ({
     LIQUIDITY_POOLS_STAKE_REVIEW,
     { amount: assetValue, poolToken: assetData, pool },
   );
+
+  const poolTokenCustomBalances = {
+    [pool.symbol]: {
+      balance: poolStats?.userLiquidityTokenBalance,
+      symbol: pool?.symbol,
+    },
+  };
 
   return (
     <ContainerWithHeader
@@ -152,6 +166,7 @@ const StakeTokensScreen = ({
           value={assetValue}
           onValueChange={setAssetValue}
           onFormValid={setIsValid}
+          customBalances={poolTokenCustomBalances}
         />
       </MainContainer>
     </ContainerWithHeader>
@@ -161,11 +176,13 @@ const StakeTokensScreen = ({
 const mapStateToProps = ({
   assets: { supportedAssets },
   transactionEstimate: { feeInfo, isEstimating, errorMessage: estimateErrorMessage },
+  liquidityPools: liquidityPoolsReducer,
 }: RootReducerState): $Shape<Props> => ({
   supportedAssets,
   isEstimating,
   feeInfo,
   estimateErrorMessage,
+  liquidityPoolsReducer,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({

--- a/src/utils/__tests__/liquidityPools.test.js
+++ b/src/utils/__tests__/liquidityPools.test.js
@@ -81,6 +81,9 @@ const liquidityPoolsReducerMock = {
           hourlyVolumeUSD: '5',
         },
       ],
+      liquidityPosition: {
+        liquidityTokenBalance: '0.123',
+      },
     },
   },
   isFetchingLiquidityPoolsData: false,
@@ -145,6 +148,7 @@ describe('Liquidity pools utils', () => {
             value: 4,
           },
         ],
+        userLiquidityTokenBalance: 0.123,
       });
     });
   });

--- a/src/utils/liquidityPools.js
+++ b/src/utils/liquidityPools.js
@@ -192,6 +192,7 @@ export const getAddLiquidityTransactions = async (
     extra: {
       amount: poolTokenAmount,
       pool,
+      tokenAmounts,
     },
     txFeeInWei,
   };
@@ -205,6 +206,7 @@ export const getRemoveLiquidityTransactions = async (
   poolTokenAmount: number,
   poolToken: Asset,
   tokensAssets: Asset[],
+  obtainedTokensAmounts: number[],
   txFeeInWei?: BigNumber,
 ): Promise<Object[]> => {
   const tokenAmountBN = parseTokenBigNumberAmount(poolTokenAmount, poolToken.decimals);
@@ -266,8 +268,9 @@ export const getRemoveLiquidityTransactions = async (
     ...removeLiquidityTransactions[0],
     tag: LIQUIDITY_POOLS_REMOVE_LIQUIDITY_TRANSACTION,
     extra: {
-      amoun: poolTokenAmount,
+      amount: poolTokenAmount,
       pool,
+      tokenAmounts: obtainedTokensAmounts,
     },
     txFeeInWei,
   };

--- a/src/utils/liquidityPools.js
+++ b/src/utils/liquidityPools.js
@@ -49,7 +49,7 @@ import type { LiquidityPool, LiquidityPoolStats } from 'models/LiquidityPools';
 import type { Transaction } from 'models/Transaction';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 
-export const fetchPoolData = async (poolAddress: string): Promise<Object> => {
+export const fetchPoolData = async (poolAddress: string, userAddress: string): Promise<Object> => {
   /* eslint-disable i18next/no-literal-string */
   const query = `
     {
@@ -95,6 +95,9 @@ export const fetchPoolData = async (poolAddress: string): Promise<Object> => {
         }
       ) {
         hourlyVolumeUSD
+      }
+      liquidityPosition(id: "${poolAddress.toLowerCase()}-${userAddress.toLowerCase()}") {
+        liquidityTokenBalance
       }
     }
   `;
@@ -403,6 +406,7 @@ export const getPoolStats = (
     tokensPerLiquidityToken,
     totalSupply: parseFloat(pairData.totalSupply),
     history,
+    userLiquidityTokenBalance: parseFloat(poolData.liquidityPosition?.liquidityTokenBalance) || 0,
   };
 };
 


### PR DESCRIPTION
1. try to add liquidity without uni-v2 asset added - you won't see updated balance and you can't stake tokens. Fixed by fetching balance from the uniswap subgraph.
2. Add liquidity and immediately check event details modal. Crash.