### PR TITLE
Chore/git tag bump changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,15 @@ executors:
       NODE_OPTIONS: "--max-old-space-size=4096"
     shell: /bin/bash --login -o pipefail
 
+    python3-alpine-executor:
+      working_directory: ~/pillarwallet
+      docker:
+      - image: python:3.7-alpine
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+      resource_class: small
+
 aliases:
   - &restore_pod_cache
     restore_cache:
@@ -218,6 +227,7 @@ aliases:
         - homebrew-packages-v1
 
 jobs:
+
   build-and-test:
     executor: node10-executor
     steps:
@@ -421,12 +431,32 @@ jobs:
           failure_message: '$(shuf -n 1 android_appcenter.txt) :circleci-fail:'
           webhook: "${SLACK_WEBHOOK_URL}"
 
+  bump-push-git-tag:
+    executor: python3-alpine-executor
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --update curl git
+      - run:
+          name: Fetch semget and bump tag
+          command: |
+            curl -o semtag https://raw.githubusercontent.com/pnikosis/semtag/v0.0.9/semtag
+            chmod +x semtag
+            SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
+            semtag final -s $SEMVER_TAG
+
   get-latest-tag:
-    executor: node10-executor
+    executor: python3-alpine-executor
     steps:
       - checkout
       - attach_workspace: &attach_workspace
           at: /tmp/workspace
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --update git
       - run:
           name: Fetch and set the latest GitHub tag
           command: |
@@ -741,10 +771,20 @@ jobs:
 
 workflows:
   version: 2.1
-  build_and_deploy:
+
+  build_and_test:
     jobs:
       - build-and-test:
           context: docker-hub-creds
+
+  build_and_deploy_appcenter:
+    jobs:
+      - build-and-test:
+          context: docker-hub-creds
+          filters:
+            branches:
+              only:
+                - develop
       - appcenter_ios:
           requires:
             - build-and-test
@@ -760,6 +800,23 @@ workflows:
             branches:
               only:
                 - develop
+
+  build_and_deploy_production:
+    jobs:
+      - bump-push-git-tag:
+          context: docker-hub-creds
+          filters:
+            branches:
+              only:
+                - master
+      - build-and-test:
+          requires:
+            - bump-push-git-tag
+          context: docker-hub-creds
+          filters:
+            branches:
+              only:
+                - master
       - get-latest-tag:
           context: docker-hub-creds
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,14 @@ executors:
       NODE_OPTIONS: "--max-old-space-size=4096"
     shell: /bin/bash --login -o pipefail
 
-    python3-alpine-executor:
-      working_directory: ~/pillarwallet
-      docker:
-      - image: python:3.7-alpine
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_PASSWORD
-      resource_class: small
+  python3-alpine-executor:
+    working_directory: ~/pillarwallet
+    docker:
+    - image: python:3.7-alpine
+      auth:
+        username: $DOCKERHUB_USER
+        password: $DOCKERHUB_PASSWORD
+    resource_class: small
 
 aliases:
   - &restore_pod_cache
@@ -784,7 +784,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - develop 
       - appcenter_ios:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,7 +776,12 @@ workflows:
     jobs:
       - build-and-test:
           context: docker-hub-creds
-
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+                
   build_and_deploy_appcenter:
     jobs:
       - build-and-test:

--- a/.github/workflows/bump-tag-prod.yml
+++ b/.github/workflows/bump-tag-prod.yml
@@ -1,17 +1,17 @@
-name: Bump version Prod
-on:
-  push:
-    branches:
-      - master
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.13.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
-        RELEASE_BRANCHES: master
-        DEFAULT_BUMP: minor
+# name: Bump version Prod
+# on:
+#   push:
+#     branches:
+#       - master
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@master
+#     - name: Bump version and push tag
+#       uses: anothrNick/github-tag-action@1.13.0
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         WITH_V: true
+#         RELEASE_BRANCHES: master
+#         DEFAULT_BUMP: minor


### PR DESCRIPTION
This commit intends to:

1. Move the git tag bump and push action from gh actions to CircleCI
2. Separates the workflows in CircleCI
 - test only for all branches
 - appcenter builds workflow for develop branch
 - prod stores builds workflow and git tag bump and push for master branch