### PR TITLE
Chore/git tag fail safe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,7 +753,6 @@ workflows:
               ignore:
                 - develop
                 - master
-                - chore/git-tag-fail-safe
                 
   build_and_deploy_appcenter:
     jobs:
@@ -786,7 +785,7 @@ workflows:
           filters:
             branches:
               only:
-                - chore/git-tag-fail-safe
+                - master
       - build-and-test:
           requires:
             - bump-push-git-tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
           name: Fetch semtag and bump tag
           command: |
             chmod +x .circleci/semtag.sh
-            ./circleci/semtag.sh
+            bash .circleci/semtag.sh
 
   get-latest-tag:
     executor: python3-alpine-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,10 +426,8 @@ jobs:
       - run:
           name: Fetch semtag and bump tag
           command: |
-            curl -o semtag https://raw.githubusercontent.com/pnikosis/semtag/v0.0.9/semtag
-            chmod +x semtag
-            SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
-            bash semtag final -s $SEMVER_TAG
+            chmod +x .circleci/semtag.sh
+            ./circleci/semtag.sh
 
   get-latest-tag:
     executor: python3-alpine-executor
@@ -755,6 +753,7 @@ workflows:
               ignore:
                 - develop
                 - master
+                - chore/git-tag-fail-safe
                 
   build_and_deploy_appcenter:
     jobs:
@@ -787,7 +786,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - chore/git-tag-fail-safe
       - build-and-test:
           requires:
             - bump-push-git-tag

--- a/.circleci/semtag.sh
+++ b/.circleci/semtag.sh
@@ -6,13 +6,7 @@ chmod +x semtag
 SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
 
 case "$SEMVER_TAG" in
-	patch)
-		bash semtag final -s $SEMVER_TAG
-		;;
-	minor)
-		bash semtag final -s $SEMVER_TAG
-		;;
-	major)
+	patch | minor | major)
 		bash semtag final -s $SEMVER_TAG
 		;;
 	*)

--- a/.circleci/semtag.sh
+++ b/.circleci/semtag.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 curl -o semtag https://raw.githubusercontent.com/pnikosis/semtag/v0.0.9/semtag
 chmod +x semtag
-SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
+SEMVER_TAG='pillarwallet/develop'
 
 case "$SEMVER_TAG" in
 	patch)

--- a/.circleci/semtag.sh
+++ b/.circleci/semtag.sh
@@ -3,20 +3,17 @@ set -euo pipefail
 
 curl -o semtag https://raw.githubusercontent.com/pnikosis/semtag/v0.0.9/semtag
 chmod +x semtag
-SEMVER_TAG='pillarwallet/develop'
+SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
 
 case "$SEMVER_TAG" in
 	patch)
-		#bash semtag final -s $SEMVER_TAG
-        echo "All good - patch"
+		bash semtag final -s $SEMVER_TAG
 		;;
 	minor)
-		#bash semtag final -s $SEMVER_TAG
-        echo "All good - minor"
+		bash semtag final -s $SEMVER_TAG
 		;;
 	major)
-		#bash semtag final -s $SEMVER_TAG
-        echo "All good - major"
+		bash semtag final -s $SEMVER_TAG
 		;;
 	*)
 		exit 1

--- a/.circleci/semtag.sh
+++ b/.circleci/semtag.sh
@@ -18,4 +18,4 @@ case "$SEMVER_TAG" in
 	*)
 		exit 1
 		;;
-	esac
+esac

--- a/.circleci/semtag.sh
+++ b/.circleci/semtag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+curl -o semtag https://raw.githubusercontent.com/pnikosis/semtag/v0.0.9/semtag
+chmod +x semtag
+SEMVER_TAG=$(git log -1  --pretty='%s' | awk 'NF>1{print $NF}' | cut -d'#' -f2 | tr '[:upper:]' '[:lower:]')
+
+case "$SEMVER_TAG" in
+	patch)
+		#bash semtag final -s $SEMVER_TAG
+        echo "All good - patch"
+		;;
+	minor)
+		#bash semtag final -s $SEMVER_TAG
+        echo "All good - minor"
+		;;
+	major)
+		#bash semtag final -s $SEMVER_TAG
+        echo "All good - major"
+		;;
+	*)
+		exit 1
+		;;
+	esac


### PR DESCRIPTION
Run the `semtag` tool in a script in order to wrap it and exit failure if SEMVER_TAG is not properly set.