### PR TITLE
Fix rari errors waterfall

### DIFF
--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -117,7 +117,7 @@ const RariAddDepositScreen = ({
     : estimateErrorMessage;
 
   useEffect(() => {
-    if (!assetValue || !parseFloat(assetValue) || !selectedAsset) return;
+    if (!assetValue || !parseFloat(assetValue) || !selectedAsset || isEstimating) return;
     setEstimatingTransaction(true);
     getRariDepositTransactionsAndExchangeFee(
       rariPool,

--- a/src/screens/Rari/RariWithdraw.js
+++ b/src/screens/Rari/RariWithdraw.js
@@ -117,7 +117,7 @@ const RariWithdrawScreen = ({
     : estimateErrorMessage;
 
   useEffect(() => {
-    if (!assetValue || !parseFloat(assetValue) || !selectedAsset) return;
+    if (!assetValue || !parseFloat(assetValue) || !selectedAsset || isEstimating) return;
     setEstimatingTransaction(true);
     getRariWithdrawTransaction(rariPool, activeAccountAddress, assetValue, selectedAsset)
       .then(txsAndExchangeFee => {


### PR DESCRIPTION
The errors can be reproduced by quickly entering many digits/deleting many digits in value input. The app would make many requests to 0x and 0x would respond with http 429. The PR prevents making many requests in short amount of time