### PR TITLE
[PIL- 939] Fix Rari estimation request throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "tcomb-form-native": "^0.6.11",
     "timers-browserify": "^1.0.1",
     "url": "~0.10.1",
+    "use-debounce": "^5.2.0",
     "util": "~0.10.3",
     "uuid": "^3.3.2",
     "vm-browserify": "0.0.4",

--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -23,6 +23,7 @@ import styled from 'styled-components/native';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import debounce from 'lodash.debounce';
+import { useDebounce } from 'use-debounce';
 import t from 'translations/translate';
 
 import ContainerWithHeader from 'components/Layout/ContainerWithHeader';
@@ -99,6 +100,8 @@ const RariAddDepositScreen = ({
   const [slippage, setSlippage] = useState(null);
   const [inputValid, setInputValid] = useState(false);
 
+  const [debouncedAssetValue] = useDebounce(assetValue, 500);
+
   const rariPool = navigation.getParam('rariPool');
 
   let notEnoughForFee = false;
@@ -172,7 +175,7 @@ const RariAddDepositScreen = ({
       }
       setEstimatingTransaction(false);
     });
-  }, [assetValue, selectedAsset]);
+  }, [debouncedAssetValue, selectedAsset]);
 
   const onNextButtonPress = () => {
     navigation.navigate(RARI_ADD_DEPOSIT_REVIEW, {

--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -120,7 +120,7 @@ const RariAddDepositScreen = ({
     : estimateErrorMessage;
 
   useEffect(() => {
-    if (!assetValue || !parseFloat(assetValue) || !selectedAsset || isEstimating) return;
+    if (!assetValue || !parseFloat(assetValue) || !selectedAsset) return;
     setEstimatingTransaction(true);
     getRariDepositTransactionsAndExchangeFee(
       rariPool,

--- a/src/screens/Rari/RariWithdraw.js
+++ b/src/screens/Rari/RariWithdraw.js
@@ -23,6 +23,7 @@ import styled from 'styled-components/native';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import debounce from 'lodash.debounce';
+import { useDebounce } from 'use-debounce';
 import isEmpty from 'lodash.isempty';
 import t from 'translations/translate';
 import { getEnv } from 'configs/envConfig';
@@ -98,6 +99,7 @@ const RariWithdrawScreen = ({
   const [isCalculatingMaxAmount, setIsCalculatingMaxAmount] = useState(false);
   const [customBalances, setCustomBalances] = useState({});
 
+  const [debouncedAssetValue] = useDebounce(assetValue, 500);
 
   const rariPool = navigation.getParam('rariPool');
 
@@ -150,7 +152,7 @@ const RariWithdrawScreen = ({
           });
         }
       });
-  }, [assetValue, selectedAsset]);
+  }, [debouncedAssetValue, selectedAsset]);
 
   useEffect(() => {
     if (!selectedAsset) return;

--- a/src/screens/Rari/RariWithdraw.js
+++ b/src/screens/Rari/RariWithdraw.js
@@ -119,7 +119,7 @@ const RariWithdrawScreen = ({
     : estimateErrorMessage;
 
   useEffect(() => {
-    if (!assetValue || !parseFloat(assetValue) || !selectedAsset || isEstimating) return;
+    if (!assetValue || !parseFloat(assetValue) || !selectedAsset) return;
     setEstimatingTransaction(true);
     getRariWithdrawTransaction(rariPool, activeAccountAddress, assetValue, selectedAsset)
       .then(txsAndExchangeFee => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17111,6 +17111,11 @@ use-callback-ref@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.3.tgz#9f939dfb5740807bbf9dd79cdd4e99d27e827756"
 
+use-debounce@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.2.0.tgz#3cb63f5c46f40092c570356e441dbc016ffb2f8b"
+  integrity sha512-lW4tbPsTnvPKYqOYXp5xZ7SP7No/ARLqqQqoyRKuSzP0HxR9arhSAhznXUZFoNPWDRij8fog+N6sYbjb8c3kzw==
+
 use-sidecar@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"


### PR DESCRIPTION
Scope:
- [x] Apply debounce to input value.
- [x] Rollback previous workaround
- [x] Test

Currently I am not able to test it with actual Rari input, however it works for input debouncing alone. 