### PR TITLE
Chore/remove homebrew cache step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ aliases:
   - &homebrew_save_cache
     save_cache:
       name: Save homebrew cache
-      key: homebrew-packages-v1
+      key: homebrew-packages-v2
       paths:
         - /usr/local/Homebrew
   - &homebrew_install
@@ -214,7 +214,7 @@ aliases:
     restore_cache:
       name: Restore homebrew cache
       keys:
-        - homebrew-packages-v1
+        - homebrew-packages-v2
 
 jobs:
 
@@ -264,7 +264,7 @@ jobs:
           command: |
             aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/ios_appcenter.txt .
 
-      - *homebrew_restore_cache
+      #- *homebrew_restore_cache
       - *homebrew_install
       - *homebrew_save_cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ executors:
       FL_OUTPUT_DIR: output
       _JAVA_OPTIONS: "-Xms128m -Xmx3024m"
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1248m -XX:+HeapDumpOnOutOfMemoryError"'
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
     shell: /bin/bash --login -o pipefail
 
@@ -199,22 +200,11 @@ aliases:
       paths:
         - ~/android/.gradle
         - ~/android/.m2
-  - &homebrew_save_cache
-    save_cache:
-      name: Save homebrew cache
-      key: homebrew-packages-v2
-      paths:
-        - /usr/local/Homebrew
   - &homebrew_install
     run:
       name: Install coureutils
       command: |
         brew install coreutils
-  - &homebrew_restore_cache
-    restore_cache:
-      name: Restore homebrew cache
-      keys:
-        - homebrew-packages-v2
 
 jobs:
 
@@ -264,9 +254,7 @@ jobs:
           command: |
             aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/ios_appcenter.txt .
 
-      - *homebrew_restore_cache
       - *homebrew_install
-      - *homebrew_save_cache
 
       - *node_restore_cache
 
@@ -470,9 +458,7 @@ jobs:
           command: |
             aws --region $AWS_DEFAULT_REGION s3 cp $PROD_KEYSTORE_S3_BUCKET/ios_prod.txt .
 
-      - *homebrew_restore_cache
       - *homebrew_install
-      - *homebrew_save_cache
 
       - run:
           name: Set production environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,7 +739,6 @@ workflows:
               ignore:
                 - develop
                 - master
-                - chore/remove-homebrew-cache-step
                 
   build_and_deploy_appcenter:
     jobs:
@@ -748,14 +747,14 @@ workflows:
           filters:
             branches:
               only:
-                - chore/remove-homebrew-cache-step 
+                - develop
       - appcenter_ios:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                - chore/remove-homebrew-cache-step
+                - develop
       - appcenter_android:
           context: docker-hub-creds
           requires:
@@ -763,7 +762,7 @@ workflows:
           filters:
             branches:
               only:
-                - chore/remove-homebrew-cache-step
+                - develop
 
   build_and_deploy_production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,7 +264,7 @@ jobs:
           command: |
             aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/ios_appcenter.txt .
 
-      #- *homebrew_restore_cache
+      - *homebrew_restore_cache
       - *homebrew_install
       - *homebrew_save_cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,7 +264,7 @@ jobs:
           command: |
             aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/ios_appcenter.txt .
 
-      - *homebrew_restore_cache
+      #- *homebrew_restore_cache
       - *homebrew_install
       - *homebrew_save_cache
 
@@ -753,6 +753,7 @@ workflows:
               ignore:
                 - develop
                 - master
+                - chore/remove-homebrew-cache-step
                 
   build_and_deploy_appcenter:
     jobs:
@@ -761,14 +762,14 @@ workflows:
           filters:
             branches:
               only:
-                - develop 
+                - chore/remove-homebrew-cache-step 
       - appcenter_ios:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                - develop
+                - chore/remove-homebrew-cache-step
       - appcenter_android:
           context: docker-hub-creds
           requires:
@@ -776,7 +777,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - chore/remove-homebrew-cache-step
 
   build_and_deploy_production:
     jobs:


### PR DESCRIPTION
- Add `HOMEBREW_NO_AUTO_UPDATE: 1` that significantly reduces the time for any `brew install` command.
- Removed caching, no longer needed.