### PR TITLE
PIL-946: fix liquidity pools find supported assets by address

### DIFF
--- a/src/screens/LiquidityPools/AddLiquidity.js
+++ b/src/screens/LiquidityPools/AddLiquidity.js
@@ -41,7 +41,7 @@ import { LIQUIDITY_POOLS_ADD_LIQUIDITY_REVIEW } from 'constants/navigationConsta
 
 // utils
 import { formatAmount } from 'utils/common';
-import { isEnoughBalanceForTransactionFee } from 'utils/assets';
+import { findSupportedAsset, isEnoughBalanceForTransactionFee } from 'utils/assets';
 import { getPoolStats, calculateProportionalAssetValues, getShareOfPool } from 'utils/liquidityPools';
 
 // selectors
@@ -130,7 +130,7 @@ const AddLiquidityScreen = ({
   const poolStats = getPoolStats(pool, liquidityPoolsReducer);
 
   const tokensData = pool.tokensProportions.map(({ symbol }) => supportedAssets.find(asset => asset.symbol === symbol));
-  const poolTokenData = supportedAssets.find(asset => asset.symbol === pool.symbol);
+  const poolTokenData = findSupportedAsset(supportedAssets, pool.uniswapPairAddress);
 
   useEffect(() => {
     if (!assetsValues.every(f => !!parseFloat(f)) || !fieldsValid.every(f => f)) return;

--- a/src/screens/LiquidityPools/LiquidityPoolDashboard.js
+++ b/src/screens/LiquidityPools/LiquidityPoolDashboard.js
@@ -448,6 +448,7 @@ const LiquidityPoolDashboard = ({
 };
 
 const mapStateToProps = ({
+  appSettings: { data: { baseFiatCurrency } },
   liquidityPools: {
     isFetchingLiquidityPoolsData,
     poolDataGraphQueryFailed,
@@ -457,6 +458,7 @@ const mapStateToProps = ({
   liquidityPools: liquidityPoolsReducer,
   rates: { data: rates },
 }: RootReducerState): $Shape<Props> => ({
+  baseFiatCurrency,
   isFetchingLiquidityPoolsData,
   poolDataGraphQueryFailed,
   supportedAssets,

--- a/src/screens/LiquidityPools/LiquidityPools.js
+++ b/src/screens/LiquidityPools/LiquidityPools.js
@@ -35,7 +35,7 @@ import ListItemWithImage from 'components/ListItem/ListItemWithImage';
 import RetryGraphQueryBox from 'components/RetryGraphQueryBox';
 
 import { formatAmount, formatFiat, formatBigFiatAmount, formatBigAmount } from 'utils/common';
-import { convertUSDToFiat } from 'utils/assets';
+import { findSupportedAsset, convertUSDToFiat } from 'utils/assets';
 import { getPoolStats } from 'utils/liquidityPools';
 import { getThemeColors } from 'utils/themes';
 
@@ -271,7 +271,7 @@ const LiquidityPoolsScreen = ({
 
   const renderPurchasedPool = ({ item: pool, index }) => {
     const poolStats = poolsStats[index];
-    const poolToken = supportedAssets.find(({ symbol }) => symbol === pool.symbol);
+    const poolToken = findSupportedAsset(supportedAssets, pool.uniswapPairAddress);
     if (!poolToken) return null;
     const balance = poolStats.userLiquidityTokenBalance;
 

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -40,7 +40,7 @@ import { LIQUIDITY_POOLS_REMOVE_LIQUIDITY_REVIEW } from 'constants/navigationCon
 
 // utils
 import { formatAmount } from 'utils/common';
-import { isEnoughBalanceForTransactionFee } from 'utils/assets';
+import { findSupportedAsset, isEnoughBalanceForTransactionFee } from 'utils/assets';
 import { getPoolStats, calculateProportionalRemoveLiquidityAssetValues } from 'utils/liquidityPools';
 
 // selectors
@@ -123,7 +123,7 @@ const AddLiquidityScreen = ({
   const tokensData = pool.tokensProportions
     .map(({ symbol: tokenSymbol }) => supportedAssets.find(({ symbol }) => symbol === tokenSymbol));
 
-  const poolTokenData = supportedAssets.find(asset => asset.symbol === pool.symbol);
+  const poolTokenData = findSupportedAsset(supportedAssets, pool.uniswapPairAddress);
 
   useEffect(() => {
     if (

--- a/src/screens/LiquidityPools/StakeTokens.js
+++ b/src/screens/LiquidityPools/StakeTokens.js
@@ -40,6 +40,7 @@ import { resetEstimateTransactionAction } from 'actions/transactionEstimateActio
 import { calculateStakeTransactionEstimateAction } from 'actions/liquidityPoolsActions';
 
 // utils
+import { findSupportedAsset } from 'utils/assets';
 import { getPoolStats } from 'utils/liquidityPools';
 
 // types
@@ -96,7 +97,7 @@ const StakeTokensScreen = ({
 
   const { pool } = navigation.state.params;
   const poolStats = getPoolStats(pool, liquidityPoolsReducer);
-  const assetData = supportedAssets.find(asset => asset.symbol === pool.symbol);
+  const assetData = findSupportedAsset(supportedAssets, pool.uniswapPairAddress);
   const [assetValue, setAssetValue] = useState('');
   const [isValid, setIsValid] = useState(false);
 
@@ -121,12 +122,12 @@ const StakeTokensScreen = ({
     { amount: assetValue, poolToken: assetData, pool },
   );
 
-  const poolTokenCustomBalances = {
-    [pool.symbol]: {
+  const poolTokenCustomBalances = assetData != null ? {
+    [assetData.symbol]: {
       balance: poolStats?.userLiquidityTokenBalance,
-      symbol: pool?.symbol,
+      symbol: assetData?.symbol,
     },
-  };
+  } : {};
 
   return (
     <ContainerWithHeader

--- a/src/screens/LiquidityPools/UnstakeTokens.js
+++ b/src/screens/LiquidityPools/UnstakeTokens.js
@@ -36,6 +36,7 @@ import FeeLabelToggle from 'components/FeeLabelToggle';
 import { LIQUIDITY_POOLS_UNSTAKE_REVIEW } from 'constants/navigationConstants';
 
 // utils
+import { findSupportedAsset } from 'utils/assets';
 import { getPoolStats } from 'utils/liquidityPools';
 
 // actions
@@ -92,7 +93,7 @@ const UnstakeTokensScreen = ({
 
   const { pool } = navigation.state.params;
   const poolStats = getPoolStats(pool, liquidityPoolsReducer);
-  const assetData = supportedAssets.find(asset => asset.symbol === pool.symbol);
+  const assetData = findSupportedAsset(supportedAssets, pool.uniswapPairAddress);
   const [assetValue, setAssetValue] = useState('');
   const [isValid, setIsValid] = useState(false);
 
@@ -113,12 +114,12 @@ const UnstakeTokensScreen = ({
     { amount: assetValue, poolToken: assetData, pool },
   );
 
-  const customBalances = assetData && {
+  const customBalances = assetData != null ? {
     [assetData.symbol]: {
       balance: poolStats?.stakedAmount,
       symbol: assetData.symbol,
     },
-  };
+  } : 0;
 
   return (
     <ContainerWithHeader

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -254,6 +254,10 @@ export const addressesInclude = (addresses: string[], addressToFind: ?string): b
   return addresses.some(item => isCaseInsensitiveMatch(item, addressToFind));
 };
 
+export const findSupportedAsset = (supportedAssets: Asset[], addressToFind: ?string): Asset | void => {
+  return supportedAssets.find(asset => addressesEqual(asset.address, addressToFind));
+};
+
 export const getAssetData = (
   userAssets: Asset[],
   supportedAssetsData: Asset[],


### PR DESCRIPTION
In a recent case LP token symbol change for ETH/PLR & DAI/PLR pools caused them crash as hardcoded symbol did not match supported assets symbol from backend. LP token symbols are not really standardized and can change.

This PR tries to mitigate that issue for the future, by finding LP token supported assets by address and not by LP token symbol.