### PR TITLE
Fix/2fa pipeline apple issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,10 @@ jobs:
             sed -i.bak "s/_staging_rampnetwork_api_key_/$STAGING_RAMPNETWORK_API_KEY/g" ./src/configs/buildConfig.js
             echo "$buildNumber" >> ~/pillarwallet/buildNumber.txt
       - run:
+          name: Fetch App Store Connect API key
+          command: |
+            aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/AuthKey.p8 ./ios
+      - run:
           no_output_timeout: 20m
           name: Upload to App Center
           command: |
@@ -739,6 +743,7 @@ workflows:
               ignore:
                 - develop
                 - master
+                - fix/2fa-pipeline-apple-issue
                 
   build_and_deploy_appcenter:
     jobs:
@@ -747,14 +752,14 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - fix/2fa-pipeline-apple-issue
       - appcenter_ios:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                - develop
+                - fix/2fa-pipeline-apple-issue
       - appcenter_android:
           context: docker-hub-creds
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,6 +510,10 @@ jobs:
       - *save_pod_cache
 
       - run:
+          name: Fetch App Store Connect API key
+          command: |
+            aws --region $AWS_DEFAULT_REGION s3 cp $PROD_KEYSTORE_S3_BUCKET/AuthKey.p8 ./ios
+      - run:
           no_output_timeout: 20m
           name: Upload to TestFlight
           command: |
@@ -743,7 +747,6 @@ workflows:
               ignore:
                 - develop
                 - master
-                - fix/2fa-pipeline-apple-issue
                 
   build_and_deploy_appcenter:
     jobs:
@@ -752,14 +755,14 @@ workflows:
           filters:
             branches:
               only:
-                - fix/2fa-pipeline-apple-issue
+                - develop
       - appcenter_ios:
           requires:
             - build-and-test
           filters:
             branches:
               only:
-                - fix/2fa-pipeline-apple-issue
+                - develop
       - appcenter_android:
           context: docker-hub-creds
           requires:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -23,9 +23,6 @@ platform :ios do
           team_id: "J9DEY3FGPD"
         )
 
-    #sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration release -scheme pillarwallet -derivedDataPath ../build"
-    #sh "mkdir -p ../build/pillarwallet/Payload && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet.ipa *"
-
     gym(
       workspace: "pillarwallet.xcworkspace",
       configuration: "Release",
@@ -45,10 +42,6 @@ platform :ios do
     # 1. Delete the expired prov. profile.
     # 2. Run match with readonly set to false in order for match to create a new Distribution certificate and a new provisioning profile.
     # When the new one is created, using match, it should be created with the same name, so we should expect no changes/problems to occure in the gym stage.
-
-    #sigh(force: true)
-
-    #sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.mobileprovision'"
 
     commit = last_git_commit
     upload_to_testflight(
@@ -101,21 +94,6 @@ platform :ios do
       derived_data_path: "build"
     )
 
-    # trigger the build
-    #sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration Staging.Release -scheme Staging -derivedDataPath ../build -verbose "
-
-    # manually zip the results into an ipa
-    #sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
-
-    # download the signing cert
-    #sigh(
-      #app_identifier: "com.pillarproject.wallet.staging",
-      #force: true
-    #)
-
-    # apply the signing certs to the build
-    #sh "cd /Users/distiller/pillarwallet/ios/output/gym/ && fastlane sigh resign pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '../../AppStore_com.pillarproject.wallet.staging.mobileprovision'"
-
     # questions remaining:
     # 1. do we need to download certs, then build, then download more certs and re-sign? sounds like at least one step doesnt' need doing
     # 2. given that we have the process working now, should we try to shuffle the sh "xcodebuild" blocks into fast-lane speak? we shouldn't need to run anything direct from commandline
@@ -155,6 +133,13 @@ platform :ios do
     # ensure we don't have automatic code signing set up
     #disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
 
+    app_store_connect_api_key(
+      key_id: ENV["APPLE_API_KEY_ID"],
+      issuer_id: ENV["APPLE_API_KEY_ISSUER_ID"],
+      key_filepath: "./AuthKey.p8",
+      in_house: false,
+    )
+
     #register_devices(devices_file: "./devices.txt")
     register_devices(
       devices_file: "./devices.txt"
@@ -168,14 +153,6 @@ platform :ios do
           team_id: "J9DEY3FGPD",
           force_for_new_devices: false
           )
-
-    # get our appstore provisioning profile
-    #match(type: "appstore",
-      #readonly: true,
-      #git_branch: "develop",
-      #app_identifier: "com.pillarproject.wallet.staging",
-      #team_id: "J9DEY3FGPD",
-    #)
 
     gym(
       workspace: "pillarwallet.xcworkspace",
@@ -195,19 +172,6 @@ platform :ios do
     # Gym command xcargs will have to be reviewed and changed at the point when the current Distribution cert. and prov. profile expire.
     # Especially the PROVISIONING_PROFILE_SPECIFIER set in there since it is hardcoded to a prov. profile that is specific, we need to change it to a standard match AdHoc com.pillarproject.wallet.staging
     # withouth the numbers created at the end, which have been added by match command back when the profile was created.
-
-    # get our push-notification cert
-    #get_push_certificate(
-      #force: false,
-      #app_identifier: "com.pillarproject.wallet.staging",
-      #team_id: "J9DEY3FGPD",
-    #)
-
-    # trigger the build
-    #sh "xcodebuild -workspace ../pillarwallet.xcworkspace -configuration Staging.Release -scheme Staging -derivedDataPath ../build -verbose "
-
-    # manually zip the results into an ipa
-    #sh "mkdir -p ../build/pillarwallet/Payload && rm -rf ../build/pillarwallet/Payload/* && cp -R ../build/Build/Products/Release-iphoneos/pillarwallet-staging.app ../build/pillarwallet/Payload && cp -R ../pillarwallet/SwiftSupport ../build/pillarwallet && rm -rf ../build/pillarwallet/Payload/pillarwallet-staging.app/libswiftRemoteMirror.dylib && cd ../build/pillarwallet && /usr/bin/zip -r -X ../../pillarwallet-staging.ipa *"
 
     #sh "fastlane sigh resign ../pillarwallet-staging.ipa --signing_identity 'iPhone Distribution: PILLAR PROJECT WORLDWIDE LIMITED (J9DEY3FGPD)' --provisioning_profile '" + ENV["sigh_com.pillarproject.wallet.staging_adhoc_profile-path"] + "'"
     changelog = build_custom_changelog

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,6 +16,13 @@ platform :ios do
     MY_APP_ID = "com.pillarproject.wallet"
     MY_PROFILE = "match AppStore com.pillarproject.wallet"
 
+    app_store_connect_api_key(
+      key_id: ENV["APPLE_API_KEY_ID"],
+      issuer_id: ENV["APPLE_API_KEY_ISSUER_ID"],
+      key_filepath: "./AuthKey.p8",
+      in_house: false,
+    )
+
     match(type: "appstore",
           readonly: true,
           git_branch: "master",
@@ -48,75 +55,7 @@ platform :ios do
       changelog: commit[:message],
       skip_waiting_for_build_processing: true,
     )
-  end
 
-  desc "Release to staging TestFlight"
-  lane :deploy_staging do |options|
-
-    # insert circleCI's build number as our build number
-    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
-    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
-    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
-
-    # ensure we don't have automatic code signing set up
-    #disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
-
-    MY_APP_ID = "com.pillarproject.wallet.staging"
-    MY_PROFILE = "match AppStore com.pillarproject.wallet.staging"
-
-    # get our provisioning profile
-    match(type: "appstore",
-      readonly: true,
-      git_branch: "develop",
-      app_identifier: "com.pillarproject.wallet.staging",
-      team_id: "J9DEY3FGPD",
-    )
-
-    # get our push-notification cert
-    pem(
-      force: false,
-      app_identifier: "com.pillarproject.wallet.staging",
-      team_id: "J9DEY3FGPD",
-    )
-
-    gym(
-      workspace: "pillarwallet.xcworkspace",
-      configuration: "Staging.Release",
-      scheme: "Staging",
-      xcargs: "xBUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.pillarproject.wallet.staging' DEVELOPMENT_TEAM='J9DEY3FGPD'",
-      export_method: "app-store",
-      export_options: {
-        provisioningProfiles: {
-            MY_APP_ID => MY_PROFILE
-        }
-      },
-      clean: true,
-      derived_data_path: "build"
-    )
-
-    # questions remaining:
-    # 1. do we need to download certs, then build, then download more certs and re-sign? sounds like at least one step doesnt' need doing
-    # 2. given that we have the process working now, should we try to shuffle the sh "xcodebuild" blocks into fast-lane speak? we shouldn't need to run anything direct from commandline
-    # 3. should we not be breaking things up a bit more? having a standard 'build' method that all the other methods call?
-    # 4. should we be trying to store the IPA in artifactory at some stage?
-    # 5. do we care that the build that goes into staging will not have the same number as the equivalent build going into production? (because circleCI build number..)
-
-    commit = last_git_commit
-    upload_to_testflight(changelog: commit[:message],
-     skip_waiting_for_build_processing: true,
-    )
-
-  end
-
-  lane :build_custom_changelog do
-    changelog_notes = changelog_from_git_commits(
-      merge_commit_filtering: "include_merges",
-      commits_count: "25"
-    )
-
-    UI.message "Changelog: #{changelog_notes}"
-    
-    changelog_notes
   end
 
   desc "Release to adhoc TestFlight"
@@ -187,6 +126,76 @@ platform :ios do
       release_notes: changelog
     )
 
+  end
+
+  desc "Release to staging TestFlight"
+  lane :deploy_staging do |options|
+
+    # insert circleCI's build number as our build number
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+    sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
+
+    # ensure we don't have automatic code signing set up
+    #disable_automatic_code_signing(path: "pillarwallet.xcodeproj")
+
+    MY_APP_ID = "com.pillarproject.wallet.staging"
+    MY_PROFILE = "match AppStore com.pillarproject.wallet.staging"
+
+    # get our provisioning profile
+    match(type: "appstore",
+      readonly: true,
+      git_branch: "develop",
+      app_identifier: "com.pillarproject.wallet.staging",
+      team_id: "J9DEY3FGPD",
+    )
+
+    # get our push-notification cert
+    pem(
+      force: false,
+      app_identifier: "com.pillarproject.wallet.staging",
+      team_id: "J9DEY3FGPD",
+    )
+
+    gym(
+      workspace: "pillarwallet.xcworkspace",
+      configuration: "Staging.Release",
+      scheme: "Staging",
+      xcargs: "xBUNDLE_IDENTIFIER='com.pillarproject.wallet.staging' PROVISIONING_PROFILE_SPECIFIER='match AppStore com.pillarproject.wallet.staging' DEVELOPMENT_TEAM='J9DEY3FGPD'",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+            MY_APP_ID => MY_PROFILE
+        }
+      },
+      clean: true,
+      derived_data_path: "build"
+    )
+
+    # questions remaining:
+    # 1. do we need to download certs, then build, then download more certs and re-sign? sounds like at least one step doesnt' need doing
+    # 2. given that we have the process working now, should we try to shuffle the sh "xcodebuild" blocks into fast-lane speak? we shouldn't need to run anything direct from commandline
+    # 3. should we not be breaking things up a bit more? having a standard 'build' method that all the other methods call?
+    # 4. should we be trying to store the IPA in artifactory at some stage?
+    # 5. do we care that the build that goes into staging will not have the same number as the equivalent build going into production? (because circleCI build number..)
+
+    commit = last_git_commit
+    upload_to_testflight(changelog: commit[:message],
+     skip_waiting_for_build_processing: true,
+    )
+
+  end
+
+  lane :build_custom_changelog do
+    changelog_notes = changelog_from_git_commits(
+      merge_commit_filtering: "include_merges",
+      commits_count: "25"
+    )
+
+    UI.message "Changelog: #{changelog_notes}"
+    
+    changelog_notes
+    
   end
 
 end


### PR DESCRIPTION
Fixes the 2FA issue we had in our ios build pipeline. I have removed the USER/PASSWORD combination and we will now use an App Store Connect API key to authenticate.

The key is stored in  private s3 buckets in our AWS accounts and fetched in our pipeline.