### PR TITLE
PIL-954 fix Rari ETH pool crash

### DIFF
--- a/src/services/rari.js
+++ b/src/services/rari.js
@@ -337,7 +337,7 @@ const getEthPoolAPY = async (servicesApys: Object[]) => {
         maxApyBN = apyBN;
       }
     });
-    return maxApyBN;
+    return parseFloat(maxApyBN.toString()) / 1e16;
   }
   // If balance > 0, calculate the APY using the factors
   let apyBN = EthersBigNumber.from(0);


### PR DESCRIPTION
One of `getEthPoolAPY` return branches returned Ethers BigNumber instead of number as expected. 