### PR TITLE
Change the etherspot appcenter naming and add 2 separate ios and android jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,9 @@ jobs:
             mkdir -p /tmp/workspace/build-num
             mkdir -p /tmp/workspace/releases
             cd /tmp/workspace/build-num
-            echo ${APP_BUILD_NUMBER}-etherspot > app_build_number.txt
+            echo ${APP_BUILD_NUMBER} > app_build_number.txt
+            export buildNumber=$(node -e "console.log(require('./package.json').version);")
+            echo $buildNumber-etherspot > build_number.txt
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -270,6 +272,174 @@ jobs:
       - slack/status:
           fail_only: true
           failure_message: "Triggered by: *${CIRCLE_USERNAME}* \n\n Hi *${CIRCLE_USERNAME}*, the *$CIRCLE_JOB* job has failed. :circleci-fail:"
+          webhook: "${SLACK_WEBHOOK_URL}"
+
+  # Build temporary appcenter etherspot ios
+  appcenter_ios_etherspot:
+    executor: ios-executor
+    steps:
+      - checkout
+      - attach_workspace: &attach_workspace
+          at: /tmp/workspace
+      - aws-cli/setup:
+          aws-access-key-id: NONPROD_APP_STORE_ACCESS_KEY
+          aws-secret-access-key: NONPROD_APP_STORE_SECRET_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+      - run:
+          name: Set slack message
+          command: |
+            aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/ios_appcenter.txt .
+
+      - *homebrew_install
+
+      - *node_restore_cache
+
+      - *yarn_install_ios
+
+      - *node_save_cache
+
+      - *restore_gems_cache_ios
+      - *install_gems_ios
+      - *save_gems_cache_ios
+
+      - *restore_pod_cache
+      - run:
+          name: Install CocoaPods
+          command: |
+            cd ios
+            bundle exec pod install --verbose
+      - *save_pod_cache
+
+      - run:
+          name: Set staging environment
+          command: |
+            cd ~/pillarwallet
+            git config user.email "devops@pillar.io"
+            git config user.name "Issabot"
+            export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
+            export buildNumber="$(cat /tmp/workspace/build-num/build_number.txt)"
+            npm --no-git-tag-version version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$APP_BUILD_NUMBER
+            sed -i.bak "s/_build_type_/staging/g" .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
+            sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_infura_project_id_/$STAGING_INFURA_PROJECT_ID/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_sentry_auth_token_/$SENTRY_AUTH_TOKEN/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_sentry_auth_token_/$SENTRY_AUTH_TOKEN/g" .env
+            sed -i.bak "s/_ethplorer_api_key_/$ETHPLORER_API_KEY/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_widget_signature_/$WIDGET_SIGNATURE/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_staging_rampnetwork_api_key_/$STAGING_RAMPNETWORK_API_KEY/g" ./src/configs/buildConfig.js
+      - run:
+          name: Fetch App Store Connect API key
+          command: |
+            aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/AuthKey.p8 ./ios
+      - run:
+          no_output_timeout: 20m
+          name: Upload to App Center
+          command: |
+            export buildNumber="$(cat /tmp/workspace/build-num/build_number.txt)"
+            export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
+            cd ios && bundle exec fastlane deploy_ios_appcenter APP_BUILD_NUMBER:$APP_BUILD_NUMBER build_number:$buildNumber APP_NAME:"Pillar Staging"
+      - run:
+          name: prepare to archive ipa file
+          command: |
+            mkdir -p ./toArchive
+            cp ./ios/output/gym/pillarwallet-staging.ipa ./toArchive
+      - store_artifacts:
+          path: ./toArchive
+          destination: app_build
+      - slack/status:
+          fail_only: true
+          only_for_branches: develop
+          failure_message: "$(gshuf -n 1 ios_appcenter.txt) :circleci-fail:"
+          webhook: "${SLACK_WEBHOOK_URL}"
+
+  # Build temprorary appcenter etherspot android
+  appcenter_android_etherspot:
+    executor: android-executor
+    steps:
+      - checkout
+      - attach_workspace: &attach_workspace
+          at: /tmp/workspace
+      - aws-cli/setup:
+          aws-access-key-id: NONPROD_APP_STORE_ACCESS_KEY
+          aws-secret-access-key: NONPROD_APP_STORE_SECRET_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+      - run:
+          name: Set slack message
+          command: |
+            aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/android_appcenter.txt .
+
+      - *node_restore_cache
+      - *android_latest_npm
+      - *yarn_restore_cache
+      - *yarn_install
+      - *yarn_save_cache
+      - *node_save_cache
+
+      - *restore_gems_cache_android
+      - *install_gems_android
+      - *save_gems_cache_android
+
+      - run:
+          name: Get keystore file
+          command: |
+            cd /home/circleci/pillarwallet/android/keystores/
+            aws --region $AWS_DEFAULT_REGION s3 cp $NONPROD_KEYSTORE_S3_BUCKET/staging-key.keystore .
+      - run:
+          name: Accept Android SDK licenses
+          command: |
+            yes | sdkmanager --licenses || exit 0
+      - run:
+          name: Accept Android SDK licenses 2
+          command: |
+            yes | sdkmanager --update || exit 0
+
+      - *gradle_restore_cache
+      - *gradle_dependencies
+
+      - run:
+          name: Set staging environment
+          command: |
+            cd ~/pillarwallet
+            git config user.email "devops@pillar.io"
+            git config user.name "Issabot"
+            export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
+            export buildNumber="$(cat /tmp/workspace/build-num/build_number.txt)"
+            npm --no-git-tag-version version $(node -e "const currentVersion=require('./package.json').version; const firstTwoDots=currentVersion.substring(0, currentVersion.lastIndexOf('.')+1); console.log(firstTwoDots);")$APP_BUILD_NUMBER
+            sed -i.bak "s/_build_type_/staging/g" .env
+            sed -i.bak "s/_build_number_/$buildNumber/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_build_number_/$buildNumber/g" .env
+            sed -i.bak "s/_open_sea_api_key_/$OPEN_SEA_API_KEY/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_infura_project_id_/$STAGING_INFURA_PROJECT_ID/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_sentry_auth_token_/$SENTRY_AUTH_TOKEN/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_sentry_auth_token_/$SENTRY_AUTH_TOKEN/g" .env
+            sed -i.bak "s/_ethplorer_api_key_/$ETHPLORER_API_KEY/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_widget_signature_/$WIDGET_SIGNATURE/g" ./src/configs/buildConfig.js
+            sed -i.bak "s/_staging_rampnetwork_api_key_/$STAGING_RAMPNETWORK_API_KEY/g" ./src/configs/buildConfig.js
+      - run:
+          name: Initial build
+          command: |
+            export buildNumber="$(cat /tmp/workspace/build-num/build_number.txt)"
+            export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
+            cd android && ./gradlew clean app:assembleStaging --no-daemon --stacktrace --max-workers=2 -PBUILD_NUMBER=$APP_BUILD_NUMBER
+
+      - *gradle_save_cache
+
+      - run:
+          name: Upload to App Center
+          command: |
+            export buildNumber="$(cat /tmp/workspace/build-num/build_number.txt)"
+            export APP_BUILD_NUMBER="$(cat /tmp/workspace/build-num/app_build_number.txt)"
+            export ENVFILE=$(echo ~/pillarwallet/.env)
+            cd android && bundle exec fastlane deploy_android_appcenter
+      - store_artifacts:
+          path: android/app/build/outputs/apk
+          destination: apks
+      - slack/status:
+          fail_only: true
+          only_for_branches: develop
+          failure_message: '$(shuf -n 1 android_appcenter.txt) :circleci-fail:'
           webhook: "${SLACK_WEBHOOK_URL}"
 
   # Build appcenter ios
@@ -796,14 +966,14 @@ workflows:
             branches:
               only:
                 - feature/etherspot
-      - appcenter_ios:
+      - appcenter_ios_appcenter:
           requires:
             - build-and-test-etherspot
           filters:
             branches:
               only:
                 - feature/etherspot
-      - appcenter_android:
+      - appcenter_android_appcenter:
           context: docker-hub-creds
           requires:
             - build-and-test-etherspot


### PR DESCRIPTION
Since gradle doesn't like string in the `versionCode` we are changing the naming to contain `-etherspot` in the `versionName`.

For this I had to add 2 additional appcenter ios and android jobs since it will be a lot easier for us to clean them up when all this is tested and complete.