### PR TITLE
PIL-967: coingecko and rari eth-usd rate fixes

### DIFF
--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -396,7 +396,11 @@ export async function getExchangeRates(assets: Assets): Promise<?Object> {
        * because ether price doesn't fit into CoinGecko token price endpoint
        */
       const etherPrice = await getCoinGeckoEtherPrice();
-      rates = { ...rates, [ETH]: etherPrice };
+
+      // append fetched ETH price only if it didn't fail
+      if (!isEmpty(etherPrice)) {
+        rates = { ...rates, [ETH]: etherPrice };
+      }
     }
   }
 

--- a/src/services/coinGecko.js
+++ b/src/services/coinGecko.js
@@ -44,7 +44,7 @@ const BTC_ID = 'bitcoin';
 const WBTC_ID = 'wrapped-bitcoin';
 
 const requestConfig = {
-  timeout: 5000,
+  timeout: 10000,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',

--- a/src/services/rari.js
+++ b/src/services/rari.js
@@ -33,6 +33,8 @@ import RARI_RGT_DISTRIBUTOR_CONTRACT_ABI from 'abi/rariGovernanceTokenDistributo
 import type { RariPool } from 'models/RariPool';
 import type { Rates } from 'models/Asset';
 
+const hasEthUsdPrice = (rates: Rates) => !!rates?.[ETH]?.USD;
+
 const mapPools = (resultsArray: Object[]) => {
   return RARI_POOLS_ARRAY.reduce((result, pool, i) => {
     result[pool] = resultsArray[i];
@@ -53,6 +55,9 @@ export const getRariFundBalanceInUSD = async (rates: Rates) => {
         return EthersBigNumber.from(0);
       });
     if (rariPool === RARI_POOLS.ETH_POOL) {
+      // if ETH USD price is not within rates we cannot do anything – return 0
+      if (!hasEthUsdPrice(rates)) return EthersBigNumber.from(0);
+
       balance = EthersBigNumber.from(balance).mul(Math.floor(rates[ETH].USD * 1e9)).div(1e9);
     }
     return parseFloat(utils.formatUnits(balance, 18));
@@ -111,6 +116,9 @@ export const getAccountDepositInUSDBN = async (rariPool: RariPool, accountAddres
       return EthersBigNumber.from(0);
     });
   if (rariPool === RARI_POOLS.ETH_POOL) {
+    // if ETH USD price is not within rates we cannot do anything – return 0
+    if (!hasEthUsdPrice(rates)) return EthersBigNumber.from(0);
+
     balanceBN = balanceBN.mul(Math.floor(rates[ETH].USD * 1e9)).div(1e9);
   }
   return balanceBN;
@@ -186,6 +194,9 @@ export const getUserInterests = async (accountAddress: string, rates: Rates) => 
     let interests = userBalanceUSD[rariPool] - initialBalance;
     const interestsPercentage = (interests / initialBalance) * 100;
     if (rariPool === RARI_POOLS.ETH_POOL) {
+      // if ETH USD price is not within rates we cannot do anything – return 0
+      if (!hasEthUsdPrice(rates)) return EthersBigNumber.from(0);
+
       // interests in ETH pool are in ETH - convert them to
       const interestsBN = EthersBigNumber.from(Math.floor(interests * 1e9)).mul(Math.floor(rates[ETH].USD * 1e9));
       interests = parseFloat(utils.formatUnits(interestsBN));


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-967/rari-data-failed

Includes:
1. Added check for failed Coingecko ETH price to not include it in updated rates if it failed.
2. Increased Coingecko timeout as it seems this has been common report on Sentry.
3. Added check to Rari ETH pool balance calculation for ETH/USD rate if it's present, however, it should occur anymore based on this PR 1st fix. I didn't add extra logging over ETH/USD rate missing because this would be extra noise and this should never repeat based on 1st fix.