### PR TITLE
init smart wallet sdk on login regardless of instance state

### DIFF
--- a/src/actions/accountsActions.js
+++ b/src/actions/accountsActions.js
@@ -194,7 +194,7 @@ export const initOnLoginSmartWalletAccountAction = (privateKey: string) => {
     if (!smartWalletAccount) return;
 
     const smartWalletAccountId = getAccountId(smartWalletAccount);
-    await dispatch(initSmartWalletSdkAction(privateKey));
+    await dispatch(initSmartWalletSdkAction(privateKey, true));
 
     const activeAccountType = getActiveAccountType(accounts);
     const setAccountActive = activeAccountType !== ACCOUNT_TYPES.SMART_WALLET; // set to active routine

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -861,9 +861,13 @@ export const onSmartWalletSdkEventAction = (event: Object) => {
   };
 };
 
-export const initSmartWalletSdkAction = (walletPrivateKey: string) => {
+export const initSmartWalletSdkAction = (walletPrivateKey: string, forceInit: boolean = false) => {
   return async (dispatch: Dispatch) => {
-    await smartWalletService.init(walletPrivateKey, (event) => dispatch(onSmartWalletSdkEventAction(event)));
+    await smartWalletService.init(
+      walletPrivateKey,
+      (event) => dispatch(onSmartWalletSdkEventAction(event)),
+      forceInit,
+    );
     const initialized: boolean = smartWalletService.sdkInitialized;
     dispatch({
       type: SET_SMART_WALLET_SDK_INIT,

--- a/src/services/smartWallet.js
+++ b/src/services/smartWallet.js
@@ -174,8 +174,8 @@ class SmartWallet {
     }
   }
 
-  async init(privateKey: string, onEvent?: Function) {
-    if (this.sdkInitialized) return;
+  async init(privateKey: string, onEvent?: Function, forceInit: boolean = false) {
+    if (this.sdkInitialized && !forceInit) return;
 
     await this.getSdk()
       .initialize({ device: { privateKey } })


### PR DESCRIPTION
Small improvement for Smart Wallet login initialization call.

I noticed that upon login (or expired Smart Wallet session) we call Smart Wallet instance to be reinitialized, however, there's internal `sdkInitialized` of Smart Wallet instance that is checked before init and this way it's never actually reinitialized.

Added forced Smart Wallet service reinitialization on session expired or upon each login (PIN unlock).