### PR TITLE
PIL-969 Fix/home performance

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -149,38 +149,36 @@ class ActivityFeed extends React.Component<Props> {
     initialNumToRender: 7,
   };
 
-  generateFeedSections = memoize(
-    (tabs, activeTab, feedData, headerComponent, tabsComponent, card) => {
-      let feedList = feedData || [];
+  generateFeedSections = (tabs, activeTab, feedData, headerComponent, tabsComponent, card) => {
+    let feedList = feedData || [];
 
-      if (tabs.length) {
-        const activeTabInfo = tabs.find(({ id }) => id === activeTab);
-        if (activeTabInfo) ({ data: feedList } = activeTabInfo);
-      }
+    if (tabs.length) {
+      const activeTabInfo = tabs.find(({ id }) => id === activeTab);
+      if (activeTabInfo) ({ data: feedList } = activeTabInfo);
+    }
 
-      const filteredFeedList = feedList.filter(this.shouldRenderActivityItem);
+    const filteredFeedList = feedList.filter(this.shouldRenderActivityItem);
+    if (!filteredFeedList.length) {
+      return [{ type: ITEM_TYPE.EMPTY_STATE }];
+    }
 
-      const dataSections = groupAndSortByDate(filteredFeedList);
+    const items = [
+      { type: ITEM_TYPE.HEADER, component: headerComponent },
+      { type: ITEM_TYPE.TABS, component: tabsComponent },
+    ];
 
-      const items = [];
-      items.push({ type: ITEM_TYPE.HEADER, component: headerComponent });
-      items.push({ type: ITEM_TYPE.TABS, component: tabsComponent });
-      if (!filteredFeedList.length) {
-        items.push({ type: ITEM_TYPE.EMPTY_STATE });
-      } else {
-        if (card) {
-          items.push({ type: ITEM_TYPE.CARD_HEADER });
-        }
-        dataSections.forEach(({ data, ...section }) => {
-          items.push({ type: ITEM_TYPE.SECTION, section });
-          data.forEach(item => items.push({ type: ITEM_TYPE.ITEM, item }));
-        });
-      }
+    if (card) {
+      items.push({ type: ITEM_TYPE.CARD_HEADER });
+    }
 
-      return items;
-    },
-    isEqual,
-  );
+    const sections = groupAndSortByDate(filteredFeedList);
+    sections.forEach(({ data, ...section }) => {
+      items.push({ type: ITEM_TYPE.SECTION, section });
+      items.push(...data.map((item) => ({ type: ITEM_TYPE.ITEM, item })));
+    });
+
+    return items;
+  };
 
   getEmptyStateData = () => {
     const {

--- a/src/components/ActivityFeed/ActivityFeed.js
+++ b/src/components/ActivityFeed/ActivityFeed.js
@@ -22,7 +22,6 @@ import { FlatList } from 'react-native';
 import isEqual from 'lodash.isequal';
 import type { NavigationScreenProp } from 'react-navigation';
 import styled, { withTheme } from 'styled-components/native';
-import memoize from 'memoize-one';
 
 // types
 import type { EnsRegistry } from 'reducers/ensRegistryReducer';
@@ -37,7 +36,7 @@ import EventDetails, { shouldShowEventDetails } from 'components/EventDetails';
 import Modal from 'components/Modal';
 
 // utils
-import { groupAndSortByDate } from 'utils/common';
+import { groupSectionsByDate } from 'utils/common';
 import { fontStyles, spacing } from 'utils/variables';
 
 // constants
@@ -171,8 +170,7 @@ class ActivityFeed extends React.Component<Props> {
       items.push({ type: ITEM_TYPE.CARD_HEADER });
     }
 
-    const sections = groupAndSortByDate(filteredFeedList);
-    sections.forEach(({ data, ...section }) => {
+    groupSectionsByDate(filteredFeedList).forEach(({ data, ...section }) => {
       items.push({ type: ITEM_TYPE.SECTION, section });
       items.push(...data.map((item) => ({ type: ITEM_TYPE.ITEM, item })));
     });

--- a/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
+++ b/src/components/ActivityFeed/__tests__/__snapshots__/ActivityFeed.test.js.snap
@@ -31,7 +31,6 @@ exports[`ActivityFeed does not fail for invalid values 1`] = `
         },
         Object {
           "section": Object {
-            "date": "Invalid Date",
             "title": "Invalid Date",
           },
           "type": "SECTION",
@@ -406,7 +405,6 @@ exports[`ActivityFeed renders the Asset correctly 1`] = `
         },
         Object {
           "section": Object {
-            "date": "Invalid Date",
             "title": "Invalid Date",
           },
           "type": "SECTION",

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -1633,7 +1633,7 @@ export class EventDetail extends React.Component<Props> {
         {!!title && (
           <DetailRow color={titleColor}>
             {title}
-            {!!actionIcon && <ActionIcon name={actionIcon} iconColor={statusIconColor} />}
+            {!!actionIcon && <ActionIcon name={actionIcon} iconColor={this.getColor(statusIconColor)} />}
           </DetailRow>
         )}
         {customActionTitle}

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -19,7 +19,7 @@
 */
 
 import * as React from 'react';
-import { View, Linking } from 'react-native';
+import { View, Linking, InteractionManager } from 'react-native';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import styled, { withTheme } from 'styled-components/native';
@@ -361,13 +361,15 @@ export class EventDetail extends React.Component<Props> {
   timeout: ?TimeoutID;
 
   componentDidMount() {
-    const { event } = this.props;
-    const { type } = event;
-    if (!(type === TRANSACTION_EVENT || type === COLLECTIBLE_TRANSACTION)) return;
-    const txInfo = this.findTxInfo(event.type === COLLECTIBLE_TRANSACTION);
-    if (!txInfo) return;
-    this.syncEnsRegistry(txInfo);
-    this.syncTxStatus(txInfo);
+    InteractionManager.runAfterInteractions(() => {
+      const { event } = this.props;
+      const { type } = event;
+      if (!(type === TRANSACTION_EVENT || type === COLLECTIBLE_TRANSACTION)) return;
+      const txInfo = this.findTxInfo(event.type === COLLECTIBLE_TRANSACTION);
+      if (!txInfo) return;
+      this.syncEnsRegistry(txInfo);
+      this.syncTxStatus(txInfo);
+    });
   }
 
   componentDidUpdate() {

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -362,11 +362,12 @@ export class EventDetail extends React.Component<Props> {
 
   componentDidMount() {
     InteractionManager.runAfterInteractions(() => {
-      const { event } = this.props;
-      const { type } = event;
+      const { type } = this.props.event;
       if (!(type === TRANSACTION_EVENT || type === COLLECTIBLE_TRANSACTION)) return;
-      const txInfo = this.findTxInfo(event.type === COLLECTIBLE_TRANSACTION);
+
+      const txInfo = this.findTxInfo(type === COLLECTIBLE_TRANSACTION);
       if (!txInfo) return;
+
       this.syncEnsRegistry(txInfo);
       this.syncTxStatus(txInfo);
     });

--- a/src/components/KeyPad/KeyPad.js
+++ b/src/components/KeyPad/KeyPad.js
@@ -64,7 +64,7 @@ const ButtonText = styled(BaseText)`
 `;
 
 const RippleSizer = styled.View`
-   height: 55;
+   height: 55px;
    width: 100%;
    align-self: center;
 `;

--- a/src/screens/ConnectedDevices/ManageConnectedDevices.js
+++ b/src/screens/ConnectedDevices/ManageConnectedDevices.js
@@ -36,7 +36,8 @@ import { ScrollWrapper } from 'components/Layout';
 
 // utils
 import { themedColors } from 'utils/themes';
-import { humanizeDateString, humanizeHexString } from 'utils/common';
+import { humanizeHexString } from 'utils/common';
+import { humanizeDateString } from 'utils/date';
 import { fontSizes, fontTrackings } from 'utils/variables';
 import { addressesEqual } from 'utils/assets';
 import { images } from 'utils/images';

--- a/src/screens/Home/RariPoolItem.js
+++ b/src/screens/Home/RariPoolItem.js
@@ -48,7 +48,7 @@ const rariLogo = require('assets/images/rari_logo.png');
 
 const DepositedAssetGain = styled(BaseText)`
   margin-bottom: 5px;
-  font-size: ${fontSizes.big};
+  font-size: ${fontSizes.big}px;
 `;
 
 type Props = {|

--- a/src/screens/Tank/SettleBalance/SettleBalance.js
+++ b/src/screens/Tank/SettleBalance/SettleBalance.js
@@ -245,7 +245,7 @@ class SettleBalance extends React.Component<Props, State> {
     } = this.props;
     const { txToSettle } = this.state;
     const showSpinner = !isFetched;
-    const formattedFeedData = groupAndSortByDate(availableToSettleTx, 0);
+    const formattedFeedData = groupAndSortByDate(availableToSettleTx, 1);
     return (
       <ContainerWithHeader
         headerProps={{ centerItems: [{ title: t('ppnContent.title.settleTransactionsScreen') }] }}

--- a/src/screens/Tank/SettleBalance/SettleBalance.js
+++ b/src/screens/Tank/SettleBalance/SettleBalance.js
@@ -55,11 +55,7 @@ import {
   spacing,
   fontSizes,
 } from 'utils/variables';
-import {
-  formatFiat,
-  formatAmount,
-  groupAndSortByDate,
-} from 'utils/common';
+import { formatFiat, formatAmount, groupSectionsByDate } from 'utils/common';
 import { getRate } from 'utils/assets';
 import { getThemeColors } from 'utils/themes';
 
@@ -245,7 +241,7 @@ class SettleBalance extends React.Component<Props, State> {
     } = this.props;
     const { txToSettle } = this.state;
     const showSpinner = !isFetched;
-    const formattedFeedData = groupAndSortByDate(availableToSettleTx, 1);
+    const formattedFeedData = groupSectionsByDate(availableToSettleTx, 1);
     return (
       <ContainerWithHeader
         headerProps={{ centerItems: [{ title: t('ppnContent.title.settleTransactionsScreen') }] }}

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -473,7 +473,7 @@ type SectionData = {|
 
 
 // all default values makes common sense and usage
-export const groupAndSortByDate = (
+export const groupSectionsByDate = (
   data: any[],
   timestampMultiplier: number = 1000,
   dateField: string = 'createdAt',
@@ -483,7 +483,7 @@ export const groupAndSortByDate = (
 
   orderBy(data, [dateField], [sortDirection]).forEach((item) => {
     const date = new Date(item[dateField] * timestampMultiplier);
-    const key = formatDate(date, 'MMM D YYYY');
+    const key = formatDate(date, 'YYYY-MM-DD');
 
     const existingSection = sections[key];
     if (!existingSection) {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -33,7 +33,7 @@ import t from 'translations/translate';
 
 export * from 'date-fns';
 
-const USER_DATE_FORMAT = 'MMM D YYYY';
+const USER_FULL_DATE_FORMAT = 'MMM D YYYY';
 const USER_MONTH_DAY_FORMAT = 'MMM D';
 
 export const isSameDay = (first: Date | number, second: Date | number): boolean => {
@@ -49,14 +49,23 @@ export const isYesterday = (date: Date | number): boolean => {
   return isSameDay(date, DateFns.subDays(new Date(), 1));
 };
 
+export const formatDate = (
+  date: ?(Date | string | number),
+  format?: string,
+): string => {
+  if (!date) return '';
+
+  return DateFns.format(date, format);
+};
+
 export const humanizeDateString = (date: Date): string => {
+  if (!date) return '';
+
   // by default don't show the year if the event happened this year
   if (isToday(date)) return t('label.today');
   if (isYesterday(date)) return t('label.yesterday');
 
   // TODO: localize dates
-  const dateFormat = DateFns.isThisYear(date) ? USER_MONTH_DAY_FORMAT : USER_DATE_FORMAT;
+  const dateFormat = DateFns.isThisYear(date) ? USER_MONTH_DAY_FORMAT : USER_FULL_DATE_FORMAT;
   return DateFns.format(date, dateFormat);
 };
-
-export const formatDate = DateFns.format;

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,62 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+import * as DateFns from 'date-fns';
+import t from 'translations/translate';
+
+/**
+ * This files encapsulates Date FNS library as well as provides custom implementations for some
+ * of the functions that are problematically slow on iOS.
+ *
+ * Experimentally I discovered that `Date` mutation functions (like `setHours`) are really slow, while `format`
+ * is nearly instant. This manifests itself when using functions like `isSameDay`, `isToday`, etc.
+ *
+ * These optimization are need only when running under JavaScriptCore and are not needed under V8 (debugger).
+ */
+
+export * from 'date-fns';
+
+const USER_DATE_FORMAT = 'MMM D YYYY';
+const USER_MONTH_DAY_FORMAT = 'MMM D';
+
+export const isSameDay = (first: Date | number, second: Date | number): boolean => {
+  const dateFormat = 'YYYY-MM-DD';
+  return DateFns.format(first, dateFormat) === DateFns.format(second, dateFormat);
+};
+
+export const isToday = (date: Date | number): boolean => {
+  return isSameDay(date, new Date());
+};
+
+export const isYesterday = (date: Date | number): boolean => {
+  return isSameDay(date, DateFns.subDays(new Date(), 1));
+};
+
+export const humanizeDateString = (date: Date): string => {
+  // by default don't show the year if the event happened this year
+  if (isToday(date)) return t('label.today');
+  if (isYesterday(date)) return t('label.yesterday');
+
+  // TODO: localize dates
+  const dateFormat = DateFns.isThisYear(date) ? USER_MONTH_DAY_FORMAT : USER_DATE_FORMAT;
+  return DateFns.format(date, dateFormat);
+};
+
+export const formatDate = DateFns.format;


### PR DESCRIPTION
Summary:
Improve home screen performance when user has a long list of past activities. This change reduces activity feed processing from ~2500ms to just ~20ms for ~500 activity item entries.

Scope:
* optimise used data structure in `groupSectionsByDate`
* optimise `Date` operations to take into account observed issues with `Date` operations on iOS/JavaScriptCore
  * very fast `Date.format`
  * very slow `Date` mutation ops like `setHours` and hence `startOfDay`, `isSameDay`, `isToday`, `isYesterday`, etc
* remove unnecessary memoization in ActivityFeed (I did measure timing in actual app and noticed no improvements)
* delay component did mount optimisations in EventDetails to allow smooth animation
* fix css/color-related crash & warnings
