### PR TITLE
Fix/send asset precision issues

### DIFF
--- a/src/actions/transactionEstimateActions.js
+++ b/src/actions/transactionEstimateActions.js
@@ -28,7 +28,7 @@ import { buildERC721TransactionData } from 'services/assets';
 
 // utils
 import { buildTxFeeInfo } from 'utils/smartWallet';
-import { getEthereumProvider } from 'utils/common';
+import { getEthereumProvider, truncateAmount } from 'utils/common';
 
 // config
 import { getEnv } from 'configs/envConfig';
@@ -48,6 +48,7 @@ import { COLLECTIBLES } from 'constants/assetsConstants';
 // types
 import type { Dispatch, GetState } from 'reducers/rootReducer';
 import type { AccountTransaction } from 'services/smartWallet';
+import type { Value } from 'utils/common';
 import type { AssetData } from 'models/Asset';
 
 
@@ -71,7 +72,7 @@ export const setEstimatingErrorAction = (errorMessage: string) => ({
 
 export const estimateTransactionAction = (
   recipientAddress: string,
-  value: string | number,
+  value: Value,
   data: ?string,
   assetData: ?AssetData,
   sequential: ?AccountTransaction[],
@@ -83,7 +84,7 @@ export const estimateTransactionAction = (
 
     let transaction: AccountTransaction = {
       recipient: recipientAddress,
-      value,
+      value: truncateAmount(value, assetData?.decimals),
     };
 
     if (sequential) {

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -36,7 +36,7 @@ import Input from 'components/Input';
 import { Spacing } from 'components/Layout';
 import Modal from 'components/Modal';
 
-import { formatAmount, isValidNumber, wrapBigNumber, noop, toFixedString } from 'utils/common';
+import { formatAmount, isValidNumber, wrapBigNumber, noop } from 'utils/common';
 import { getThemeColors } from 'utils/themes';
 import { images } from 'utils/images';
 import { calculateMaxAmount, getFormattedBalanceInFiat, getBalanceInFiat } from 'utils/assets';

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -192,20 +192,19 @@ export const ValueInputComponent = ({
     if (updateTxFee) {
       newTxFeeInfo = await updateTxFee(assetSymbol, percent / 100);
     }
-    const newMaxValue = calculateMaxAmount(
+
+    const maxValueNetFee = wrapBigNumber(calculateMaxAmount(
       assetSymbol,
       assetBalance,
       newTxFeeInfo?.fee,
       newTxFeeInfo?.gasToken,
-    );
-    const maxValueInFiat = getBalanceInFiat(fiatCurrency, newMaxValue, ratesWithCustomRates, assetSymbol);
-    if (percent === 100) {
-      onValueChange(newMaxValue, percent);
-    } else {
-      onValueChange(toFixedString(parseFloat(newMaxValue) * (percent / 100)), percent);
-    }
-    const fiatValue = maxValueInFiat * (percent / 100);
-    setValueInFiat(String(fiatValue ? fiatValue.toFixed(2) : 0));
+    ));
+
+    const newValue = formatAmount(maxValueNetFee.multipliedBy(percent).dividedBy(100), assetData.decimals);
+    onValueChange(newValue, percent);
+
+    const newValueInFiat = getBalanceInFiat(fiatCurrency, newValue.toString(), ratesWithCustomRates, assetSymbol);
+    setValueInFiat(newValueInFiat ? newValueInFiat.toFixed(2) : '0');
   };
 
   const onInputBlur = () => {

--- a/src/models/Collectible.js
+++ b/src/models/Collectible.js
@@ -31,6 +31,7 @@ export type Collectible = {
   assetContract: string,
   tokenType: string,
   symbol?: void,
+  decimals?: void,
 };
 
 export type CollectibleTrx = {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -225,6 +225,17 @@ export const formatAmount = (amount: Value, precision: number = 6): string => {
   return new BigNumber(roundedNumber).toFixed(); // strip trailing zeros
 };
 
+/**
+ * Truncate amount if needed, preserves trailing zeros.
+ */
+export const truncateAmount = (amount: Value, precision: ?number): string => {
+  const amountBN = wrapBigNumber(amount);
+
+  return precision != null && amountBN.decimalPlaces() > precision
+    ? amountBN.toFixed(precision, 1) // 1 = ROUND_DOWN
+    : amountBN.toString();
+};
+
 export const formatTokenAmount = (amount: Value, assetSymbol: ?string): string =>
   formatAmount(amount, getDecimalPlaces(assetSymbol));
 


### PR DESCRIPTION
Scope:
- [x] Fix issue when too high precision was passed to tx or tx estimation causing ethers.js "underflow" error
- [x] Improve `ValueInput` rounding when using % selector  