### PR TITLE
fix: limit ValueInput allowed decimals to value supported by given asset

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -251,6 +251,20 @@ export const truncateAmount = (amount: Value, precision: ?number): string => {
     : amountBN.toString();
 };
 
+/**
+ * Checks if given value has too much decimal places for available precission.
+ * It also rejects NaNs & infinite values.
+ */
+export const hasTooMuchDecimals = (value: Value, decimals: ?number): boolean => {
+  const valueBN = wrapBigNumber(value);
+
+  if (!valueBN.isFinite()) return false;
+
+  if (decimals == null) return true;
+
+  return valueBN.decimalPlaces() > decimals;
+};
+
 export const formatTokenAmount = (amount: Value, assetSymbol: ?string): string =>
   formatAmount(amount, getDecimalPlaces(assetSymbol));
 


### PR DESCRIPTION
ValueInput allowed for input of more decimal places then supported by given asset, which could result in underflow later in the pipeline.

Additionally, input in fiat could also result in token amount exceeding allowed decimal places.

For compat reasons, if decimal places are not know in given context then they are not limted.