### PR TITLE
fix send token flow mixed param passed to send token component

### DIFF
--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -56,7 +56,7 @@ import { PAYMENT_NETWORK_TX_SETTLEMENT, PAYMENT_NETWORK_ACCOUNT_WITHDRAWAL } fro
 import { spacing, fontSizes, fontStyles } from 'utils/variables';
 import { getColorByTheme } from 'utils/themes';
 import { formatFiat } from 'utils/common';
-import { getBalance, getRate, mapAssetDataToAssetOption } from 'utils/assets';
+import { getBalance, getRate } from 'utils/assets';
 import { getArchanovaWalletStatus } from 'utils/archanova';
 import { isArchanovaAccountAddress } from 'utils/feedData';
 import { isAaveTransactionTag } from 'utils/aave';
@@ -66,7 +66,7 @@ import { getTokenTransactionsFromHistory } from 'utils/history';
 import assetsConfig from 'configs/assetsConfig';
 
 // selectors
-import { activeAccountSelector } from 'selectors';
+import { activeAccountAddressSelector, activeAccountSelector } from 'selectors';
 import { accountBalancesSelector } from 'selectors/balances';
 import { accountHistorySelector } from 'selectors/history';
 import { availableStakeSelector, paymentNetworkAccountBalancesSelector } from 'selectors/paymentNetwork';
@@ -97,6 +97,7 @@ type Props = {
   fetchReferralRewardsIssuerAddresses: () => void,
   isFetchingUniswapTokens: boolean,
   uniswapTokensGraphQueryFailed: boolean,
+  activeAccountAddress: string,
 };
 
 const AssetCardWrapper = styled.View`
@@ -193,20 +194,9 @@ class AssetScreen extends React.Component<Props> {
   }
 
   goToSendTokenFlow = () => {
-    const {
-      navigation,
-      balances,
-      rates,
-      baseFiatCurrency,
-    } = this.props;
+    const { navigation } = this.props;
     const { assetData } = navigation.state.params;
-    const assetDataOption = mapAssetDataToAssetOption(assetData, balances, rates, baseFiatCurrency);
-
-    // it's mixed input in SendAsset component
-    // TODO: fix when this screen is refactored
-    const assetDataNavParam = { ...assetData, ...assetDataOption };
-
-    this.props.navigation.navigate(SEND_TOKEN_FROM_ASSET_FLOW, { assetData: assetDataNavParam });
+    this.props.navigation.navigate(SEND_TOKEN_FROM_ASSET_FLOW, { assetData });
   };
 
   goToExchangeFlow = (fromAssetCode: ?string, toAssetCode?: string) => {
@@ -214,13 +204,13 @@ class AssetScreen extends React.Component<Props> {
   };
 
   openAddFundsModal = () => {
-    const { navigation } = this.props;
-    const { assetData: { token, address } } = navigation.state.params;
+    const { navigation, activeAccountAddress } = this.props;
+    const { assetData: { token } } = navigation.state.params;
 
     Modal.open(() => (
       <AddFundsModal
         token={token}
-        receiveAddress={address}
+        receiveAddress={activeAccountAddress}
       />
     ));
   }
@@ -413,6 +403,7 @@ const structuredSelector = createStructuredSelector({
   availableStake: availableStakeSelector,
   assets: accountAssetsSelector,
   activeAccount: activeAccountSelector,
+  activeAccountAddress: activeAccountAddressSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -56,7 +56,7 @@ import { PAYMENT_NETWORK_TX_SETTLEMENT, PAYMENT_NETWORK_ACCOUNT_WITHDRAWAL } fro
 import { spacing, fontSizes, fontStyles } from 'utils/variables';
 import { getColorByTheme } from 'utils/themes';
 import { formatFiat } from 'utils/common';
-import { getBalance, getRate } from 'utils/assets';
+import { getBalance, getRate, mapAssetDataToAssetOption } from 'utils/assets';
 import { getArchanovaWalletStatus } from 'utils/archanova';
 import { isArchanovaAccountAddress } from 'utils/feedData';
 import { isAaveTransactionTag } from 'utils/aave';
@@ -192,8 +192,21 @@ class AssetScreen extends React.Component<Props> {
     return !isEq;
   }
 
-  goToSendTokenFlow = (assetData: Object) => {
-    this.props.navigation.navigate(SEND_TOKEN_FROM_ASSET_FLOW, { assetData });
+  goToSendTokenFlow = () => {
+    const {
+      navigation,
+      balances,
+      rates,
+      baseFiatCurrency,
+    } = this.props;
+    const { assetData } = navigation.state.params;
+    const assetDataOption = mapAssetDataToAssetOption(assetData, balances, rates, baseFiatCurrency);
+
+    // it's mixed input in SendAsset component
+    // TODO: fix when this screen is refactored
+    const assetDataNavParam = { ...assetData, ...assetDataOption };
+
+    this.props.navigation.navigate(SEND_TOKEN_FROM_ASSET_FLOW, { assetData: assetDataNavParam });
   };
 
   goToExchangeFlow = (fromAssetCode: ?string, toAssetCode?: string) => {
@@ -345,7 +358,7 @@ class AssetScreen extends React.Component<Props> {
           <AssetCardWrapper>
             <AssetButtons
               onPressReceive={this.openAddFundsModal}
-              onPressSend={() => this.goToSendTokenFlow(assetData)}
+              onPressSend={this.goToSendTokenFlow}
               onPressExchange={isSupportedByExchange ? () => this.goToExchangeFlow(token) : null}
               noBalance={isWalletEmpty}
               isSendDisabled={!isSendActive}

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -221,6 +221,7 @@ class AssetsList extends React.Component<Props, State> {
       icon: fullIconMonoUrl,
       wallpaper: fullIconWallpaperUrl,
       iconColor: fullIconUrl,
+      imageUrl: fullIconUrl,
       isListed,
       disclaimer,
       paymentNetworkBalance,

--- a/src/screens/Assets/AssetsList.js
+++ b/src/screens/Assets/AssetsList.js
@@ -45,7 +45,6 @@ import { ASSET } from 'constants/navigationConstants';
 import { hideAssetAction } from 'actions/userSettingsActions';
 
 // utils
-import { getAccountAddress } from 'utils/accounts';
 import { getBalance, getRate } from 'utils/assets';
 import { formatMoney, formatFiat } from 'utils/common';
 import { fontStyles, spacing } from 'utils/variables';
@@ -176,7 +175,6 @@ class AssetsList extends React.Component<Props, State> {
   renderToken = ({ item: asset }) => {
     const { forceHideRemoval } = this.state;
     const {
-      activeAccount,
       baseFiatCurrency,
       navigation,
       scrollViewRef,
@@ -219,7 +217,6 @@ class AssetsList extends React.Component<Props, State> {
       amount: displayAmount,
       balance,
       balanceInFiat: formattedBalanceInFiat,
-      address: activeAccount && getAccountAddress(activeAccount),
       contractAddress: asset.address,
       icon: fullIconMonoUrl,
       wallpaper: fullIconWallpaperUrl,
@@ -267,7 +264,7 @@ class AssetsList extends React.Component<Props, State> {
               },
             );
           }}
-          address={props.address}
+          address={props.contractAddress}
           label={name}
           avatarUrl={fullIconUrl}
           balance={{


### PR DESCRIPTION
Includes:
- Fixed issue where account address is provided as token address on token send flow from Asset screen therefore failing to provide estimate.
- Additionally fixed issue where asset icon is not shown when navigated through send flow from Asset screen.