### PR TITLE
fixed amount parse using ethers big number

### DIFF
--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -27,7 +27,6 @@ import { COLLECTIBLES, ETH } from 'constants/assetsConstants';
 
 // utils
 import { getBalance } from 'utils/assets';
-import { parseTokenAmount } from 'utils/common';
 
 // services
 import { buildERC721TransactionData, encodeContractMethod } from 'services/assets';

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -20,7 +20,7 @@
 
 import get from 'lodash.get';
 import { BigNumber } from 'bignumber.js';
-import { BigNumber as EthersBigNumber } from 'ethers';
+import { BigNumber as EthersBigNumber, utils } from 'ethers';
 
 // constants
 import { COLLECTIBLES, ETH } from 'constants/assetsConstants';
@@ -84,7 +84,7 @@ export const buildEthereumTransaction = async (
   let value;
 
   if (tokenType !== COLLECTIBLES) {
-    value = EthersBigNumber.from(parseTokenAmount(amount, decimals).toString());
+    value = utils.parseUnits(amount, decimals);
     if (symbol !== ETH && !data && contractAddress) {
       data = encodeContractMethod(ERC20_CONTRACT_ABI, 'transfer', [to, value.toString()]);
       to = contractAddress;


### PR DESCRIPTION
Fixed issue where send amount is parsed multiple ways into Ethers BigNumber. Changed to use single method general Ethers parse util instead.