### PR TITLE
feature/multi-chain-etherspot-instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pillarwallet",
-  "version": "2.35.4",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -30,7 +30,7 @@ import { navigate } from 'services/navigation';
 import { migrate } from 'services/dataMigration';
 
 // constants
-import { IS_V3 } from 'constants/appConstants';
+import { IS_APP_VERSION_V3 } from 'constants/appConstants';
 import { AUTH_FLOW, ONBOARDING_FLOW, PIN_CODE_UNLOCK } from 'constants/navigationConstants';
 import { RESET_APP_LOADED, UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
 import { UPDATE_ASSETS, UPDATE_BALANCES, UPDATE_SUPPORTED_ASSETS } from 'constants/assetsConstants';
@@ -272,11 +272,12 @@ export const setupSentryAction = (user: ?Object, wallet: Object) => {
       extra: {
         walletId,
         ethAddress: address,
+        [IS_APP_VERSION_V3]: true,
       },
     });
     // eslint-disable-next-line i18next/no-literal-string
     Instabug.setUserAttribute('address', address);
-    Instabug.setUserAttribute(IS_V3, true);
+    Instabug.setUserAttribute(IS_APP_VERSION_V3, true);
     if (username) {
       Instabug.setUserAttribute('ENS', username);
     }

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -30,6 +30,7 @@ import { navigate } from 'services/navigation';
 import { migrate } from 'services/dataMigration';
 
 // constants
+import { IS_V3 } from 'constants/appConstants';
 import { AUTH_FLOW, ONBOARDING_FLOW, PIN_CODE_UNLOCK } from 'constants/navigationConstants';
 import { RESET_APP_LOADED, UPDATE_APP_SETTINGS } from 'constants/appSettingsConstants';
 import { UPDATE_ASSETS, UPDATE_BALANCES, UPDATE_SUPPORTED_ASSETS } from 'constants/assetsConstants';
@@ -275,6 +276,7 @@ export const setupSentryAction = (user: ?Object, wallet: Object) => {
     });
     // eslint-disable-next-line i18next/no-literal-string
     Instabug.setUserAttribute('address', address);
+    Instabug.setUserAttribute(IS_V3, true);
     if (username) {
       Instabug.setUserAttribute('ENS', username);
     }

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -46,6 +46,7 @@ import { ADD_COLLECTIBLE_TRANSACTION, COLLECTIBLE_TRANSACTION } from 'constants/
 import { PAYMENT_NETWORK_SUBSCRIBE_TO_TX_STATUS } from 'constants/paymentNetworkConstants';
 import { ERROR_TYPE } from 'constants/transactionsConstants';
 import { SET_TOTAL_ACCOUNT_CHAIN_CATEGORY_BALANCE, SET_FETCHING_TOTALS } from 'constants/totalsConstants';
+import { NetworkNames } from 'etherspot';
 
 // components
 import Toast from 'components/Toast';
@@ -390,6 +391,7 @@ export const fetchAllAccountsTotalsAction = () => {
     if (getState().totals.isFetching) return;
 
     dispatch({ type: SET_FETCHING_TOTALS, payload: true });
+    dispatch(fetchAllCrosschainBalances());
 
     const accounts = accountsSelector(getState());
     const smartWalletAccounts = accounts.filter(isNotKeyBasedType);
@@ -792,5 +794,26 @@ export const checkForMissedAssetsAction = () => {
       dispatch(fetchAssetsBalancesAction());
       dispatch(saveDbAction('assets', { assets: updatedAssets }, true));
     }
+  };
+};
+
+export const fetchAllCrosschainBalances = () => {
+  return async () => {
+    // eslint-disable-next-line no-unused-vars
+    const { Mainnet, Matic, Bsc, Xdai } = NetworkNames;
+
+    const mainnetBalance = await etherspotService.instances[NetworkNames.Mainnet].getAccountBalances();
+    const maticBalance = await etherspotService.instances[NetworkNames.Matic].getAccountBalances();
+    const bscBalance = await etherspotService.instances[NetworkNames.Bsc].getAccountBalances();
+    const xdaiBalance = await etherspotService.instances[NetworkNames.Xdai].getAccountBalances();
+
+    const balances = {
+      Mainnet: mainnetBalance,
+      Matic: maticBalance,
+      Bsc: bscBalance,
+      Xdai: xdaiBalance,
+    };
+
+    return balances;
   };
 };

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -798,14 +798,11 @@ export const checkForMissedAssetsAction = () => {
 
 export const fetchAllChainBalancesAction = () => {
   return async () => {
-    const networkBalancePromises = [];
     const networkBalances = {};
 
-    etherspotService.supportedNetworks.forEach((network) => {
-      networkBalancePromises.push(etherspotService.instances[network].getAccountBalances());
-    });
-
-    const resolvedBalances = await Promise.all(networkBalancePromises);
+    const resolvedBalances = await Promise.all(
+      etherspotService.supportedNetworks.map((network) => etherspotService.instances[network].getAccountBalances()),
+    );
 
     resolvedBalances.forEach((balance, idx) => {
       networkBalances[etherspotService.supportedNetworks[idx]] = balance;

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -110,7 +110,7 @@ import {
 } from './etherspotActions';
 import { setEnsNameIfNeededAction } from './ensRegistryActions';
 import { getTutorialDataAction } from './cmsActions';
-import { fetchAllAccountsTotalsAction, fetchAllCrosschainBalances } from './assetsActions';
+import { fetchAllAccountsTotalsAction, fetchAllChainBalancesAction } from './assetsActions';
 
 
 const storage = Storage.getInstance('db');
@@ -280,7 +280,7 @@ export const loginAction = (
         dispatch(checkIfKeyBasedWalletHasPositiveBalanceAction());
         dispatch(checkKeyBasedAssetTransferTransactionsAction());
         dispatch(fetchAllAccountsTotalsAction());
-        dispatch(fetchAllCrosschainBalances());
+        dispatch(fetchAllChainBalancesAction());
       }
 
       dispatch(checkForWalletBackupToastAction());

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -110,7 +110,7 @@ import {
 } from './etherspotActions';
 import { setEnsNameIfNeededAction } from './ensRegistryActions';
 import { getTutorialDataAction } from './cmsActions';
-import { fetchAllAccountsTotalsAction } from './assetsActions';
+import { fetchAllAccountsTotalsAction, fetchAllCrosschainBalances } from './assetsActions';
 
 
 const storage = Storage.getInstance('db');
@@ -269,7 +269,6 @@ export const loginAction = (
         // to get exchange supported assets in order to show only supported assets on exchange selectors
         // and show exchange button on supported asset screen only
         dispatch(getExchangeSupportedAssetsAction());
-
         // create etherspot account if does not exist, this also applies as migration from old key based wallets
         const etherspotAccount = findFirstEtherspotAccount(accounts);
         if (!etherspotAccount) {
@@ -281,6 +280,7 @@ export const loginAction = (
         dispatch(checkIfKeyBasedWalletHasPositiveBalanceAction());
         dispatch(checkKeyBasedAssetTransferTransactionsAction());
         dispatch(fetchAllAccountsTotalsAction());
+        dispatch(fetchAllCrosschainBalances());
       }
 
       dispatch(checkForWalletBackupToastAction());

--- a/src/actions/remoteConfigActions.js
+++ b/src/actions/remoteConfigActions.js
@@ -20,14 +20,23 @@
 
 import DeviceInfo from 'react-native-device-info';
 
+// services
 import { firebaseRemoteConfig, firebaseAnalytics } from 'services/firebase';
+
+// utils
 import { reportLog } from 'utils/common';
 import { log } from 'utils/logger';
 import { isTest } from 'utils/environment';
 import { getAccountEnsName, getActiveAccount } from 'utils/accounts';
+
+// config
 import { getEnv } from 'configs/envConfig';
 
+// reducers
 import type { Dispatch, GetState } from 'reducers/rootReducer';
+
+// consts
+import { IS_APP_VERSION_V3 } from '../constants/appConstants';
 
 export const loadRemoteConfigAction = () => {
   return () => {
@@ -58,6 +67,7 @@ export const setUserPropertiesAction = () => (
     network: getEnv().NETWORK_PROVIDER,
     buildNumber: DeviceInfo.getBuildNumber(),
     appVersion: DeviceInfo.getVersion(),
+    [IS_APP_VERSION_V3]: true,
   };
 
   const accountEnsName = getAccountEnsName(getActiveAccount(accounts));

--- a/src/constants/appConstants.js
+++ b/src/constants/appConstants.js
@@ -1,0 +1,21 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2019 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+export const IS_V3 = 'isV3';

--- a/src/constants/appConstants.js
+++ b/src/constants/appConstants.js
@@ -18,4 +18,4 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-export const IS_V3 = 'isV3';
+export const IS_APP_VERSION_V3 = 'isAppVersionV3';

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -62,8 +62,7 @@ class EtherspotService {
   subscription: ?Subscription;
   instances: Array<EtherspotSdk> = [];
   supportedNetworks: Array<NetworkNames> = [
-    NetworkNames.Mainnet,
-    NetworkNames.Kovan,
+    (isProdEnv() ? NetworkNames.Mainnet : NetworkNames.Kovan),
     NetworkNames.Bsc,
     NetworkNames.Matic,
     NetworkNames.Xdai,
@@ -73,7 +72,7 @@ class EtherspotService {
     const etherspotComputeContractPromises = [];
     const isMainnet = isProdEnv();
 
-    const networkName = isMainnet
+    const primaryNetworkName = isMainnet
       ? NetworkNames.Mainnet
       : NetworkNames.Kovan;
 
@@ -89,14 +88,14 @@ class EtherspotService {
       // Instantiate
       this.instances[currentNetworkName] = new EtherspotSdk(privateKey, { env: envName, currentNetworkName });
 
-      // Build up an array of computeContractAccount's to be executed later
+      // Schedule exection of computeContractAccount's
       etherspotComputeContractPromises.push(
         this.instances[currentNetworkName].computeContractAccount({ sync: true }),
       );
     });
 
     // Assign the primary instance of the default networkName to `sdk`
-    this.sdk = this.instances[networkName];
+    this.sdk = this.instances[primaryNetworkName];
 
     // Compute contract accounts. The result will always be the same.
     await Promise.all(etherspotComputeContractPromises);

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -60,7 +60,7 @@ import type { EtherspotTransactionEstimate } from 'models/Etherspot';
 class EtherspotService {
   sdk: EtherspotSdk;
   subscription: ?Subscription;
-  instances: Array = [];
+  instances: Array<EtherspotSdk> = [];
 
   async init(privateKey: string): Promise<void> {
     const etherspotComputeContractPromises = [];

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -57,13 +57,26 @@ import type { Asset, Balance } from 'models/Asset';
 import type { EthereumTransaction, TransactionPayload, TransactionResult } from 'models/Transaction';
 import type { EtherspotTransactionEstimate } from 'models/Etherspot';
 
-
 class EtherspotService {
   sdk: EtherspotSdk;
   subscription: ?Subscription;
+  instances: Array = [];
 
   async init(privateKey: string): Promise<void> {
+    const etherspotComputeContractPromises = [];
     const isMainnet = isProdEnv();
+
+    /**
+     * Defined list of supported
+     * networks that Pillar support
+     */
+    const supportedNetworks = [
+      NetworkNames.Mainnet,
+      NetworkNames.Kovan,
+      NetworkNames.Bsc,
+      NetworkNames.Matic,
+      NetworkNames.Xdai,
+    ];
 
     const networkName = isMainnet
       ? NetworkNames.Mainnet
@@ -73,11 +86,25 @@ class EtherspotService {
       ? EnvNames.MainNets
       : EnvNames.TestNets;
 
-    this.sdk = new EtherspotSdk(privateKey, { env: envName, networkName });
+    /**
+     * Cycle through the supported networks and build an
+     * array of instantiated instances
+     */
+    supportedNetworks.forEach((currentNetworkName) => {
+      // Instantiate
+      this.instances[currentNetworkName] = new EtherspotSdk(privateKey, { env: envName, currentNetworkName });
 
-    await this.sdk.computeContractAccount({ sync: true }).catch((error) => {
-      reportErrorLog('EtherspotService init computeContractAccount failed', { error });
+      // Build up an array of computeContractAccount's to be executed later
+      etherspotComputeContractPromises.push(
+        this.instances[currentNetworkName].computeContractAccount({ sync: true }),
+      );
     });
+
+    // Assign the primary instance of the default networkName to `sdk`
+    this.sdk = this.instances[networkName];
+
+    // Compute contract accounts. The result will always be the same.
+    await Promise.all(etherspotComputeContractPromises);
   }
 
   subscribe(callback: (notification: EtherspotNotification) => Promise<void>) {

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -61,16 +61,25 @@ class EtherspotService {
   sdk: EtherspotSdk;
   subscription: ?Subscription;
   instances: Array<EtherspotSdk> = [];
-  supportedNetworks: Array<NetworkNames> = [
-    (isProdEnv() ? NetworkNames.Mainnet : NetworkNames.Kovan),
-    NetworkNames.Bsc,
-    NetworkNames.Matic,
-    NetworkNames.Xdai,
-  ];
+  supportedNetworks: Array<NetworkNames> = [];
 
   async init(privateKey: string): Promise<void> {
     const etherspotComputeContractPromises = [];
     const isMainnet = isProdEnv();
+
+    /**
+     * Note: This property is assigned here because
+     * it requires the value of `isProdEnv` which,
+     * if assigned at class method level - crashes
+     * the app due to non-instantiation of the getEnv
+     * function which is called from envConfig.js
+     */
+    this.supportedNetworks = [
+      (isMainnet ? NetworkNames.Mainnet : NetworkNames.Kovan),
+      NetworkNames.Bsc,
+      NetworkNames.Matic,
+      NetworkNames.Xdai,
+    ];
 
     const primaryNetworkName = isMainnet
       ? NetworkNames.Mainnet

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -61,22 +61,17 @@ class EtherspotService {
   sdk: EtherspotSdk;
   subscription: ?Subscription;
   instances: Array<EtherspotSdk> = [];
+  supportedNetworks: Array<NetworkNames> = [
+    NetworkNames.Mainnet,
+    NetworkNames.Kovan,
+    NetworkNames.Bsc,
+    NetworkNames.Matic,
+    NetworkNames.Xdai,
+  ];
 
   async init(privateKey: string): Promise<void> {
     const etherspotComputeContractPromises = [];
     const isMainnet = isProdEnv();
-
-    /**
-     * Defined list of supported
-     * networks that Pillar support
-     */
-    const supportedNetworks = [
-      NetworkNames.Mainnet,
-      NetworkNames.Kovan,
-      NetworkNames.Bsc,
-      NetworkNames.Matic,
-      NetworkNames.Xdai,
-    ];
 
     const networkName = isMainnet
       ? NetworkNames.Mainnet
@@ -90,7 +85,7 @@ class EtherspotService {
      * Cycle through the supported networks and build an
      * array of instantiated instances
      */
-    supportedNetworks.forEach((currentNetworkName) => {
+    this.supportedNetworks.forEach((currentNetworkName) => {
       // Instantiate
       this.instances[currentNetworkName] = new EtherspotSdk(privateKey, { env: envName, currentNetworkName });
 


### PR DESCRIPTION
- Modified Etherspot Service to include multi-chain instantiation
- Bumped package to V3
- Added Instabug V3 parameters for user targeting
- Added cross-chain balance fetching in assetActions
- Invoked aforementioned action in authActions.
- Added `fetchAllCrosschainBalances` to `assetActions.js`, `dispatch`ed from `authActions.js` but this is serving as an example only - to be built on going forward with the live data hookup.