### PR TITLE
PIL-1027: pull zapper assets

### DIFF
--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -115,7 +115,7 @@ import type { Account } from 'models/Account';
 import type { Dispatch, GetState } from 'reducers/rootReducer';
 import type SDKWrapper from 'services/api';
 import type { TransactionPayload, TransactionResult, TransactionStatus } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 import type { Chain } from 'models/Chain';
 
 // actions
@@ -368,7 +368,7 @@ export const sendAssetAction = (
 
 export const updateAccountWalletAssetsBalancesForChainAction = (
   accountId: string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   chain: Chain,
 ) => {
   return (dispatch: Dispatch, getState: GetState) => {

--- a/src/actions/smartWalletActions.js
+++ b/src/actions/smartWalletActions.js
@@ -98,7 +98,7 @@ import {
   activeAccountIdSelector,
 } from 'selectors';
 import { accountHistorySelector } from 'selectors/history';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type {
@@ -952,7 +952,7 @@ export const estimateTopUpVirtualAccountAction = (amount: string = '1') => {
     dispatch({ type: RESET_ESTIMATED_TOPUP_FEE });
 
     const accountAssets = accountAssetsSelector(getState());
-    const balances = accountEthereumWalletBalancesSelector(getState());
+    const balances = accountEthereumWalletAssetsBalancesSelector(getState());
     const { decimals = 18 } = accountAssets[PPN_TOKEN] || {};
     const value = utils.parseUnits(amount, decimals);
     const tokenAddress = getPPNTokenAddress(PPN_TOKEN, accountAssets);

--- a/src/components/SWActivationModal/SWActivationModal.js
+++ b/src/components/SWActivationModal/SWActivationModal.js
@@ -58,13 +58,13 @@ import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances'
 import type { Theme } from 'models/Theme';
 import type { RootReducerState } from 'reducers/rootReducer';
 import type { ArchanovaTransactionEstimate } from 'services/archanova';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 type StateProps = {|
   deploymentEstimate: ?{ raw: Object, formatted: ArchanovaTransactionEstimate },
   gettingDeploymentEstimate: boolean,
   isOnline: boolean,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
 |};
 
 type OwnProps = {|

--- a/src/components/SWActivationModal/SWActivationModal.js
+++ b/src/components/SWActivationModal/SWActivationModal.js
@@ -52,7 +52,7 @@ import { buildArchanovaTxFeeInfo } from 'utils/archanova';
 import { firebaseRemoteConfig } from 'services/firebase';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type { Theme } from 'models/Theme';
@@ -176,7 +176,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): StateProps => ({

--- a/src/components/SendAsset/SendAsset.js
+++ b/src/components/SendAsset/SendAsset.js
@@ -59,14 +59,14 @@ import type { Collectible } from 'models/Collectible';
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
 import type { SessionData } from 'models/Session';
 import type { Contact } from 'models/Contact';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   defaultContact: ?Contact,
   source: string,
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   session: SessionData,
   useGasToken: boolean,
   assetsWithBalance: AssetOption[],

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -61,14 +61,14 @@ import type { Rates, AssetOption } from 'models/Asset';
 import type { Collectible } from 'models/Collectible';
 import type { Theme } from 'models/Theme';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 import ValueInputHeader from './ValueInputHeader';
 
 export type ExternalProps = {|
   disabled?: boolean,
   customAssets?: AssetOption[],
-  customBalances?: AssetsBalances,
+  customBalances?: WalletAssetsBalances,
   selectorOptionsTitle?: string,
   assetData: AssetOption | Collectible,
   // Called when selected asset is AssetOption
@@ -90,7 +90,7 @@ export type ExternalProps = {|
 
 type InnerProps = {|
   assets: AssetOption[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   baseFiatCurrency: ?string,
   rates: Rates,
   collectibles: Collectible[],

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -52,7 +52,7 @@ import { COLLECTIBLES, TOKENS, BTC, defaultFiatCurrency } from 'constants/assets
 import { MIN_WBTC_CAFE_AMOUNT } from 'constants/exchangeConstants';
 import { getAssetBalanceFromFiat } from 'screens/Exchange/utils';
 
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { visibleActiveAccountAssetsWithBalanceSelector } from 'selectors/assets';
 import { activeAccountMappedCollectiblesSelector } from 'selectors/collectibles';
 
@@ -381,7 +381,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: visibleActiveAccountAssetsWithBalanceSelector,
   collectibles: activeAccountMappedCollectiblesSelector,
 });

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -615,7 +615,8 @@
       "invest": "Invest"
     },
     "liquidityPools": {
-      "addLiquidity": "Add liquidity"
+      "addLiquidity": "Add liquidity",
+      "poolShare": "Pool share {{share}}%"
     },
     "rewards": {
       "availableToClaim": "Available to claim"

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -45,33 +45,27 @@ export type CategoryAssetsBalances = {|
   rewards?: WalletAssetsBalances,
 |};
 
-export type LiquidityPoolAssetBalance = {|
+export type ServiceAssetBalance = {|
   key: string,
   service: string,
   title: string,
   value: BigNumber,
   iconUrl: ?string,
-  share?: BigNumber,
   change?: BigNumber,
+|};
+
+export type LiquidityPoolAssetBalance = {|
+  ...ServiceAssetBalance,
+  share: ?BigNumber,
 |};
 
 export type InvestmentAssetBalance = {|
-  key: string,
-  service: string,
-  title: string,
-  iconUrl: ?string,
-  value: BigNumber,
-  change?: BigNumber,
+  ...ServiceAssetBalance,
 |};
 
 export type DepositAssetBalance = {|
-  key: string,
-  service: string,
-  title: string,
-  value: BigNumber,
-  iconUrl: ?string,
-  change?: BigNumber,
-  currentApy?: BigNumber,
+  ...ServiceAssetBalance,
+  currentApy: ?BigNumber,
 |};
 
 export type WalletAssetBalance = {|

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -38,24 +38,19 @@ export type ChainTotalBalancesPerAccount = {
 };
 
 export type CategoryAssetsBalances = {|
-  wallet?: AssetsBalances,
+  wallet?: WalletAssetsBalances,
   deposits?: DepositAssetBalance[],
   investments?: InvestmentAssetBalance[],
   liquidityPools?: LiquidityPoolAssetBalance[],
-  rewards?: AssetsBalances,
-|};
-
-export type WalletAssetBalance = {|
-  balance: string,
-  symbol: string,
+  rewards?: WalletAssetsBalances,
 |};
 
 export type LiquidityPoolAssetBalance = {|
   key: string,
   service: string,
   title: string,
-  iconUrl: string,
   value: BigNumber,
+  iconUrl: ?string,
   share?: BigNumber,
   change?: BigNumber,
 |};
@@ -73,20 +68,25 @@ export type DepositAssetBalance = {|
   key: string,
   service: string,
   title: string,
-  iconUrl: ?string,
   value: BigNumber,
+  iconUrl: ?string,
   change?: BigNumber,
   currentApy?: BigNumber,
 |};
 
-export type AssetBalance = WalletAssetBalance
-  | LiquidityPoolAssetBalance
-  | InvestmentAssetBalance
-  | DepositAssetBalance;
+export type WalletAssetBalance = {|
+  balance: string,
+  symbol: string,
+|};
 
-export type AssetsBalances = {
-  [symbol: string]: AssetBalance,
+export type WalletAssetsBalances = {
+  [symbol: string]: WalletAssetBalance,
 };
+
+export type AssetsBalances = WalletAssetsBalances
+  | LiquidityPoolAssetBalance[]
+  | InvestmentAssetBalance[]
+  | DepositAssetBalance[];
 
 export type AssetBalancesPerAccount = {
   [accountId: string]: AssetsBalances,

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -89,14 +89,10 @@ export type AssetsBalances = WalletAssetsBalances
   | DepositAssetBalance[];
 
 export type AssetBalancesPerAccount = {
-  [accountId: string]: AssetsBalances,
+  [accountId: string]: CategoryBalancesPerChain,
 };
 
 export type CategoryBalancesPerChain = ChainRecord<CategoryAssetsBalances>;
-
-export type ChainBalancesPerAccount = {
-  [accountId: string]: CategoryBalancesPerChain,
-};
 
 export type TotalBalancesPerChain = ChainRecord<BigNumber>;
 

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -39,16 +39,50 @@ export type ChainTotalBalancesPerAccount = {
 
 export type CategoryAssetsBalances = {|
   wallet?: AssetsBalances,
-  deposits?: AssetsBalances,
-  investments?: AssetsBalances,
-  liquidityPools?: AssetsBalances,
+  deposits?: DepositAssetBalance[],
+  investments?: InvestmentAssetBalance[],
+  liquidityPools?: LiquidityPoolAssetBalance[],
   rewards?: AssetsBalances,
 |};
 
-export type AssetBalance = {
+export type WalletAssetBalance = {|
   balance: string,
   symbol: string,
-};
+|};
+
+export type LiquidityPoolAssetBalance = {|
+  key: string,
+  service: string,
+  title: string,
+  iconUrl: string,
+  value: BigNumber,
+  share?: BigNumber,
+  change?: BigNumber,
+|};
+
+export type InvestmentAssetBalance = {|
+  key: string,
+  service: string,
+  title: string,
+  iconUrl: ?string,
+  value: BigNumber,
+  change?: BigNumber,
+|};
+
+export type DepositAssetBalance = {|
+  key: string,
+  service: string,
+  title: string,
+  iconUrl: ?string,
+  value: BigNumber,
+  change?: BigNumber,
+  currentApy?: BigNumber,
+|};
+
+export type AssetBalance = WalletAssetBalance
+  | LiquidityPoolAssetBalance
+  | InvestmentAssetBalance
+  | DepositAssetBalance;
 
 export type AssetsBalances = {
   [symbol: string]: AssetBalance,
@@ -65,5 +99,7 @@ export type ChainBalancesPerAccount = {
 };
 
 export type TotalBalancesPerChain = ChainRecord<BigNumber>;
+
+export type AssetsBalancesPerChain = ChainRecord<AssetsBalances>;
 
 export type CollectibleCountPerChain = ChainRecord<number>;

--- a/src/reducers/assetsBalancesReducer.js
+++ b/src/reducers/assetsBalancesReducer.js
@@ -27,7 +27,7 @@ import {
 } from 'constants/assetsBalancesConstants';
 
 // types
-import type { WalletAssetsBalances, ChainBalancesPerAccount } from 'models/Balances';
+import type { WalletAssetsBalances, AssetBalancesPerAccount } from 'models/Balances';
 
 
 export type SetFetchingAssetsBalancesAction = {|
@@ -37,7 +37,7 @@ export type SetFetchingAssetsBalancesAction = {|
 
 export type SetAssetsBalancesAction = {|
   type: typeof SET_ASSETS_BALANCES,
-  payload: ChainBalancesPerAccount,
+  payload: AssetBalancesPerAccount,
 |};
 
 export type SeAccountAssetsBalancesAction = {|
@@ -61,7 +61,7 @@ export type AssetsBalancesReducerAction = SetFetchingAssetsBalancesAction
   | ResetAccountBalancesAction;
 
 export type AssetsBalancesReducerState = {
-  data: ChainBalancesPerAccount,
+  data: AssetBalancesPerAccount,
   isFetching: boolean,
 };
 

--- a/src/reducers/assetsBalancesReducer.js
+++ b/src/reducers/assetsBalancesReducer.js
@@ -27,7 +27,7 @@ import {
 } from 'constants/assetsBalancesConstants';
 
 // types
-import type { AssetsBalances, ChainBalancesPerAccount } from 'models/Balances';
+import type { WalletAssetsBalances, ChainBalancesPerAccount } from 'models/Balances';
 
 
 export type SetFetchingAssetsBalancesAction = {|
@@ -46,7 +46,7 @@ export type SeAccountAssetsBalancesAction = {|
     accountId: string,
     chain: string,
     category: string,
-    balances: AssetsBalances,
+    balances: WalletAssetsBalances,
   }
 |};
 

--- a/src/reducers/keyBasedAssetTransferReducer.js
+++ b/src/reducers/keyBasedAssetTransferReducer.js
@@ -29,12 +29,12 @@ import {
 } from 'constants/keyBasedAssetTransferConstants';
 import type { KeyBasedAssetTransfer } from 'models/Asset';
 import type { Collectibles } from 'models/Collectible';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 export type KeyBasedAssetTransferReducerState = {|
   data: KeyBasedAssetTransfer[],
-  availableBalances: AssetsBalances,
+  availableBalances: WalletAssetsBalances,
   availableCollectibles: Collectibles,
   isFetchingAvailableBalances: boolean,
   isFetchingAvailableCollectibles: boolean,

--- a/src/reducers/paymentNetworkReducer.js
+++ b/src/reducers/paymentNetworkReducer.js
@@ -36,11 +36,11 @@ import {
   RESET_ESTIMATED_TOPUP_FEE,
 } from 'constants/paymentNetworkConstants';
 import type { TopUpFee, SettleTxFee } from 'models/PaymentNetwork';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 export type PaymentNetworkReducerState = {
   availableStake: string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   topUpFee: TopUpFee,
   withdrawalFee: TopUpFee,
   settleTxFee: SettleTxFee,

--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -68,7 +68,7 @@ import assetsConfig from 'configs/assetsConfig';
 
 // selectors
 import { activeAccountAddressSelector, activeAccountSelector } from 'selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountHistorySelector } from 'selectors/history';
 import { availableStakeSelector, paymentNetworkAccountBalancesSelector } from 'selectors/paymentNetwork';
 import { accountAssetsSelector } from 'selectors/assets';
@@ -408,7 +408,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   paymentNetworkBalances: paymentNetworkAccountBalancesSelector,
   history: accountHistorySelector,
   availableStake: availableStakeSelector,

--- a/src/screens/Asset/Asset.js
+++ b/src/screens/Asset/Asset.js
@@ -78,12 +78,12 @@ import type { Assets, Asset } from 'models/Asset';
 import type { ArchanovaWalletStatus } from 'models/ArchanovaWalletStatus';
 import type { Account, Accounts } from 'models/Account';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 type Props = {
   fetchAssetsBalances: () => void,
   assets: Assets,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   rates: Object,
   navigation: NavigationScreenProp<*>,
   baseFiatCurrency: ?string,
@@ -91,7 +91,7 @@ type Props = {
   smartWalletState: Object,
   accounts: Accounts,
   activeAccount: ?Account,
-  paymentNetworkBalances: AssetsBalances,
+  paymentNetworkBalances: WalletAssetsBalances,
   history: Object[],
   availableStake: number,
   getExchangeSupportedAssets: () => void,

--- a/src/screens/AssetSearch/AssetSearch.js
+++ b/src/screens/AssetSearch/AssetSearch.js
@@ -43,7 +43,7 @@ import Spinner from 'components/Spinner';
 import { getBalance } from 'utils/assets';
 import { spacing } from 'utils/variables';
 
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 import { FETCHING, ETH, PLR } from 'constants/assetsConstants';
 
@@ -388,7 +388,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
 });
 

--- a/src/screens/AssetSearch/AssetSearch.js
+++ b/src/screens/AssetSearch/AssetSearch.js
@@ -57,14 +57,14 @@ import { hideAssetAction } from 'actions/userSettingsActions';
 
 import type { Asset, Assets } from 'models/Asset';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   assetsSearchState: ?string,
   assetsSearchResults: Asset[],
   supportedAssets: Asset[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   assets: Assets,
   addAsset: (asset: Asset) => void,
   hideAsset: (asset: Asset) => void,

--- a/src/screens/Assets/deposits/DepositsTab.js
+++ b/src/screens/Assets/deposits/DepositsTab.js
@@ -46,6 +46,7 @@ import { formatPercentValue } from 'utils/format';
 // Types
 import type { SectionBase } from 'utils/types/react-native';
 import type { Chain } from 'models/Chain';
+import type { DepositAssetBalance } from 'models/Balances';
 
 // Local
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
@@ -53,7 +54,7 @@ import ChainListHeader from '../components/ChainListHeader';
 import ChainListFooter from '../components/ChainListFooter';
 import ServiceListHeader from '../components/ServiceListHeader';
 import DepositListItem from './DepositListItem';
-import { type DepositItem, useDepositsBalance, useDepositsChainBalances, useDepositsAssets } from './selectors';
+import { useDepositsBalance, useDepositsChainBalances, useDepositsAssets } from './selectors';
 
 function DepositsTab() {
   const { t, tRoot } = useTranslationWithPrefix('assets.deposits');
@@ -88,7 +89,7 @@ function DepositsTab() {
     return <ChainListHeader chain={chain} balance={balance} onPress={() => toggleExpandItems(chain)} />;
   };
 
-  const renderItem = (headerListItem: HeaderListItem<DepositItem>) => {
+  const renderItem = (headerListItem: HeaderListItem<DepositAssetBalance>) => {
     if (headerListItem.type === 'header') {
       return <ServiceListHeader title={headerListItem.key} />;
     }
@@ -119,7 +120,7 @@ function DepositsTab() {
 export default DepositsTab;
 
 type Section = {
-  ...SectionBase<HeaderListItem<DepositItem>>,
+  ...SectionBase<HeaderListItem<DepositAssetBalance>>,
   chain: Chain,
   balance: BigNumber,
 };

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -50,4 +50,3 @@ export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {
   const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
   return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.DEPOSITS);
 }
-

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -33,7 +33,7 @@ import type {
   DepositAssetBalance,
   TotalBalancesPerChain,
 } from 'models/Balances';
-import { getChainBalancesForCategory } from 'utils/balances';
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
 import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useDepositsBalance(): FiatBalance {
@@ -45,8 +45,7 @@ export function useDepositsChainBalances(): TotalBalancesPerChain {
   return useRootSelector(depositsTotalBalanceByChainsSelector);
 }
 
-
 export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {
   const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.DEPOSITS);
+  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.DEPOSITS);
 }

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -18,16 +18,23 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-import { BigNumber } from 'bignumber.js';
-
 // Selectors
 import { useRootSelector } from 'selectors';
-import { depositsTotalBalanceSelector, depositsTotalBalanceByChainsSelector } from 'selectors/balances';
+import {
+  accountAssetsBalancesSelector,
+  depositsTotalBalanceByChainsSelector,
+  depositsTotalBalanceSelector,
+} from 'selectors/balances';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { TotalBalancesPerChain } from 'models/Balances';
+import type {
+  DepositAssetBalance,
+  TotalBalancesPerChain,
+} from 'models/Balances';
+import { getChainBalancesForCategory } from 'utils/balances';
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useDepositsBalance(): FiatBalance {
   const value = useRootSelector(depositsTotalBalanceSelector);
@@ -38,21 +45,9 @@ export function useDepositsChainBalances(): TotalBalancesPerChain {
   return useRootSelector(depositsTotalBalanceByChainsSelector);
 }
 
-export type DepositItem = {|
-  key: string,
-  service: string,
-  title: string,
-  iconUrl: ?string,
-  value: BigNumber,
-  change?: BigNumber,
-  currentApy?: BigNumber,
-|};
 
-
-export function useDepositsAssets(): ChainRecord<DepositItem[]> {
-  // TODO: replace once available from Etherspot SDK
-  const deposits = [];
-
-  return { ethereum: deposits };
+export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {
+  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
+  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.DEPOSITS);
 }
 

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -18,6 +18,9 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+// Constants
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
+
 // Selectors
 import { useRootSelector } from 'selectors';
 import {
@@ -26,15 +29,13 @@ import {
   depositsTotalBalanceSelector,
 } from 'selectors/balances';
 
+// Utils
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
+
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type {
-  DepositAssetBalance,
-  TotalBalancesPerChain,
-} from 'models/Balances';
-import { getChainAssetsBalancesForCategory } from 'utils/balances';
-import { ASSET_CATEGORY } from 'constants/assetsConstants';
+import type { DepositAssetBalance, TotalBalancesPerChain } from 'models/Balances';
 
 export function useDepositsBalance(): FiatBalance {
   const value = useRootSelector(depositsTotalBalanceSelector);
@@ -46,6 +47,8 @@ export function useDepositsChainBalances(): TotalBalancesPerChain {
 }
 
 export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {
-  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.DEPOSITS);
+  return getChainAssetsBalancesForCategory(
+    useRootSelector(accountAssetsBalancesSelector),
+    ASSET_CATEGORY.DEPOSITS,
+  );
 }

--- a/src/screens/Assets/investments/InvestmentsTab.js
+++ b/src/screens/Assets/investments/InvestmentsTab.js
@@ -45,6 +45,7 @@ import { type HeaderListItem, prepareHeaderListItems } from 'utils/headerList';
 // Types
 import type { SectionBase } from 'utils/types/react-native';
 import type { Chain } from 'models/Chain';
+import type { InvestmentAssetBalance } from 'models/Balances';
 
 // Local
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
@@ -52,7 +53,6 @@ import ChainListHeader from '../components/ChainListHeader';
 import ChainListFooter from '../components/ChainListFooter';
 import ServiceListHeader from '../components/ServiceListHeader';
 import {
-  type InvestmentItem,
   useInvestmentsBalance,
   useInvestmentsChainBalances,
   useInvestmentAssets,
@@ -92,7 +92,7 @@ function InvestmentsTab() {
     return <ChainListHeader chain={chain} balance={balance} onPress={() => toggleExpandItems(chain)} />;
   };
 
-  const renderItem = (headerListItem: HeaderListItem<InvestmentItem>) => {
+  const renderItem = (headerListItem: HeaderListItem<InvestmentAssetBalance>) => {
     if (headerListItem.type === 'header') {
       return <ServiceListHeader title={headerListItem.key} />;
     }
@@ -120,7 +120,7 @@ function InvestmentsTab() {
 export default InvestmentsTab;
 
 type Section = {
-  ...SectionBase<HeaderListItem<InvestmentItem>>,
+  ...SectionBase<HeaderListItem<InvestmentAssetBalance>>,
   chain: Chain,
   balance: BigNumber,
 };

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -18,11 +18,10 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-import { BigNumber } from 'bignumber.js';
-
 // Selectors
 import { useRootSelector } from 'selectors';
 import {
+  accountAssetsBalancesSelector,
   investmentsTotalBalanceByChainsSelector,
   investmentsTotalBalanceSelector,
 } from 'selectors/balances';
@@ -30,7 +29,12 @@ import {
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { TotalBalancesPerChain } from 'models/Balances';
+import type {
+  InvestmentAssetBalance,
+  TotalBalancesPerChain,
+} from 'models/Balances';
+import { getChainBalancesForCategory } from 'utils/balances';
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useInvestmentsBalance(): FiatBalance {
   const value = useRootSelector(investmentsTotalBalanceSelector);
@@ -41,19 +45,7 @@ export function useInvestmentsChainBalances(): TotalBalancesPerChain {
   return useRootSelector(investmentsTotalBalanceByChainsSelector);
 }
 
-/** Note: items are groupped by service. */
-export type InvestmentItem = {|
-  key: string,
-  service: string,
-  title: string,
-  iconUrl: ?string,
-  value: BigNumber,
-  change?: BigNumber,
-|};
-
-export function useInvestmentAssets(): ChainRecord<InvestmentItem[]> {
-  // TODO: replace once available from Etherspot SDK
-  const investments = [];
-
-  return { ethereum: investments };
+export function useInvestmentAssets(): ChainRecord<InvestmentAssetBalance[]> {
+  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
+  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.INVESTMENTS);
 }

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -18,6 +18,9 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+// Constants
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
+
 // Selectors
 import { useRootSelector } from 'selectors';
 import {
@@ -26,15 +29,13 @@ import {
   investmentsTotalBalanceSelector,
 } from 'selectors/balances';
 
+// Utils
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
+
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type {
-  InvestmentAssetBalance,
-  TotalBalancesPerChain,
-} from 'models/Balances';
-import { getChainAssetsBalancesForCategory } from 'utils/balances';
-import { ASSET_CATEGORY } from 'constants/assetsConstants';
+import type { InvestmentAssetBalance, TotalBalancesPerChain } from 'models/Balances';
 
 export function useInvestmentsBalance(): FiatBalance {
   const value = useRootSelector(investmentsTotalBalanceSelector);
@@ -46,6 +47,8 @@ export function useInvestmentsChainBalances(): TotalBalancesPerChain {
 }
 
 export function useInvestmentAssets(): ChainRecord<InvestmentAssetBalance[]> {
-  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.INVESTMENTS);
+  return getChainAssetsBalancesForCategory(
+    useRootSelector(accountAssetsBalancesSelector),
+    ASSET_CATEGORY.INVESTMENTS,
+  );
 }

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -33,7 +33,7 @@ import type {
   InvestmentAssetBalance,
   TotalBalancesPerChain,
 } from 'models/Balances';
-import { getChainBalancesForCategory } from 'utils/balances';
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
 import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useInvestmentsBalance(): FiatBalance {
@@ -47,5 +47,5 @@ export function useInvestmentsChainBalances(): TotalBalancesPerChain {
 
 export function useInvestmentAssets(): ChainRecord<InvestmentAssetBalance[]> {
   const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.INVESTMENTS);
+  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.INVESTMENTS);
 }

--- a/src/screens/Assets/liquidityPools/LiquidityPoolListItem.js
+++ b/src/screens/Assets/liquidityPools/LiquidityPoolListItem.js
@@ -34,16 +34,20 @@ import { useFiatCurrency } from 'selectors';
 // Utils
 import { useThemedImages } from 'utils/images';
 import { spacing } from 'utils/variables';
+import { useThemeColors } from 'utils/themes';
 
 type Props = {|
   title: ?string,
+  subtitle: ?string,
   iconUrl: ?string,
   value: BigNumber,
   change?: BigNumber,
+  share?: BigNumber,
   onPress?: () => mixed,
 |};
 
-function LiquidityPoolListItem({ title, iconUrl, value, change, onPress }: Props) {
+function LiquidityPoolListItem({ title, subtitle, iconUrl, value, change, onPress }: Props) {
+  const colors = useThemeColors();
   const currency = useFiatCurrency();
 
   const { genericToken } = useThemedImages();
@@ -58,6 +62,7 @@ function LiquidityPoolListItem({ title, iconUrl, value, change, onPress }: Props
         <Text variant="medium" numberOfLines={1}>
           {title}
         </Text>
+        {!!subtitle && <Text color={colors.secondaryText}>{subtitle}</Text>}
       </TitleContainer>
 
       <RightAddOn>

--- a/src/screens/Assets/liquidityPools/LiquidityPoolsTab.js
+++ b/src/screens/Assets/liquidityPools/LiquidityPoolsTab.js
@@ -45,6 +45,7 @@ import { type HeaderListItem, prepareHeaderListItems } from 'utils/headerList';
 // Types
 import type { SectionBase } from 'utils/types/react-native';
 import type { Chain } from 'models/Chain';
+import type { LiquidityPoolAssetBalance } from 'models/Balances';
 
 // Local
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
@@ -52,7 +53,6 @@ import ChainListHeader from '../components/ChainListHeader';
 import ChainListFooter from '../components/ChainListFooter';
 import ServiceListHeader from '../components/ServiceListHeader';
 import {
-  type LiquidityPoolItem,
   useLiquidityPoolsBalance,
   useLiquidityPoolsChainBalances,
   useLiquidityPoolAssets,
@@ -92,13 +92,21 @@ function LiquidityPoolsTab() {
     return <ChainListHeader chain={chain} balance={balance} onPress={() => toggleExpandItems(chain)} />;
   };
 
-  const renderItem = (headerListItem: HeaderListItem<LiquidityPoolItem>) => {
+  const renderItem = (headerListItem: HeaderListItem<LiquidityPoolAssetBalance>) => {
     if (headerListItem.type === 'header') {
       return <ServiceListHeader title={headerListItem.key} />;
     }
 
-    const { title, iconUrl, value, change } = headerListItem.item;
-    return <LiquidityPoolListItem title={title} iconUrl={iconUrl} value={value} change={change} />;
+    const { title, iconUrl, value, change, share } = headerListItem.item;
+    return (
+      <LiquidityPoolListItem
+        title={title}
+        subtitle={share ? t('poolShare', { share }) : null}
+        iconUrl={iconUrl}
+        value={value}
+        change={change}
+      />
+    );
   };
 
   return (
@@ -120,7 +128,7 @@ function LiquidityPoolsTab() {
 export default LiquidityPoolsTab;
 
 type Section = {
-  ...SectionBase<HeaderListItem<LiquidityPoolItem>>,
+  ...SectionBase<HeaderListItem<LiquidityPoolAssetBalance>>,
   chain: Chain,
   balance: BigNumber,
 };

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -18,6 +18,9 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+// Constants
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
+
 // Selectors
 import { useRootSelector } from 'selectors';
 import {
@@ -26,15 +29,13 @@ import {
   liquidityPoolsTotalBalanceSelector,
 } from 'selectors/balances';
 
+// Utils
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
+
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type {
-  LiquidityPoolAssetBalance,
-  TotalBalancesPerChain,
-} from 'models/Balances';
-import { getChainAssetsBalancesForCategory } from 'utils/balances';
-import { ASSET_CATEGORY } from 'constants/assetsConstants';
+import type { LiquidityPoolAssetBalance, TotalBalancesPerChain } from 'models/Balances';
 
 export function useLiquidityPoolsBalance(): FiatBalance {
   const value = useRootSelector(liquidityPoolsTotalBalanceSelector);
@@ -46,6 +47,8 @@ export function useLiquidityPoolsChainBalances(): TotalBalancesPerChain {
 }
 
 export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolAssetBalance[]> {
-  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.LIQUIDITY_POOLS);
+  return getChainAssetsBalancesForCategory(
+    useRootSelector(accountAssetsBalancesSelector),
+    ASSET_CATEGORY.LIQUIDITY_POOLS,
+  );
 }

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -33,7 +33,7 @@ import type {
   LiquidityPoolAssetBalance,
   TotalBalancesPerChain,
 } from 'models/Balances';
-import { getChainBalancesForCategory } from 'utils/balances';
+import { getChainAssetsBalancesForCategory } from 'utils/balances';
 import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useLiquidityPoolsBalance(): FiatBalance {
@@ -47,5 +47,5 @@ export function useLiquidityPoolsChainBalances(): TotalBalancesPerChain {
 
 export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolAssetBalance[]> {
   const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
-  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.LIQUIDITY_POOLS);
+  return getChainAssetsBalancesForCategory(assetsBalances, ASSET_CATEGORY.LIQUIDITY_POOLS);
 }

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -18,11 +18,10 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-import { BigNumber } from 'bignumber.js';
-
 // Selectors
 import { useRootSelector } from 'selectors';
 import {
+  accountAssetsBalancesSelector,
   liquidityPoolsTotalBalanceByChainsSelector,
   liquidityPoolsTotalBalanceSelector,
 } from 'selectors/balances';
@@ -30,7 +29,12 @@ import {
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { TotalBalancesPerChain } from 'models/Balances';
+import type {
+  LiquidityPoolAssetBalance,
+  TotalBalancesPerChain,
+} from 'models/Balances';
+import { getChainBalancesForCategory } from 'utils/balances';
+import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
 export function useLiquidityPoolsBalance(): FiatBalance {
   const value = useRootSelector(liquidityPoolsTotalBalanceSelector);
@@ -41,18 +45,7 @@ export function useLiquidityPoolsChainBalances(): TotalBalancesPerChain {
   return useRootSelector(liquidityPoolsTotalBalanceByChainsSelector);
 }
 
-export type LiquidityPoolItem = {|
-  key: string,
-  service: string,
-  title: string,
-  iconUrl: string,
-  value: BigNumber,
-  change?: BigNumber,
-|};
-
-export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolItem[]> {
-  // TODO: replace once available from Etherspot SDK
-  const liquidityPools = [];
-
-  return { ethereum: liquidityPools };
+export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolAssetBalance[]> {
+  const assetsBalances = useRootSelector(accountAssetsBalancesSelector);
+  return getChainBalancesForCategory(assetsBalances, ASSET_CATEGORY.LIQUIDITY_POOLS);
 }

--- a/src/screens/ConnectedDevices/RemoveSmartWalletConnectedDevice.js
+++ b/src/screens/ConnectedDevices/RemoveSmartWalletConnectedDevice.js
@@ -59,13 +59,13 @@ import type { GasInfo } from 'models/GasInfo';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { ConnectedDevice } from 'models/ConnectedDevice';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   navigation: NavigationScreenProp<*>,
   fetchAssetsBalances: () => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   fetchGasInfo: () => void,
   gasInfo: GasInfo,
   isOnline: boolean,

--- a/src/screens/ConnectedDevices/RemoveSmartWalletConnectedDevice.js
+++ b/src/screens/ConnectedDevices/RemoveSmartWalletConnectedDevice.js
@@ -51,7 +51,7 @@ import { buildArchanovaTxFeeInfo } from 'utils/archanova';
 import archanovaService from 'services/archanova';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { useGasTokenSelector } from 'selectors/archanova';
 
 // types
@@ -246,7 +246,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   useGasToken: useGasTokenSelector,
 });
 

--- a/src/screens/EnsMigrationConfirm/EnsMigrationConfirm.js
+++ b/src/screens/EnsMigrationConfirm/EnsMigrationConfirm.js
@@ -51,7 +51,7 @@ import { buildEnsMigrationRawTransactions } from 'utils/archanova';
 
 // selectors
 import { accountsSelector, useRootSelector } from 'selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { useBiometricsSelector } from 'selectors/appSettings';
 
 // types
@@ -75,7 +75,7 @@ const EnsMigrationConfirm = () => {
   const navigation = useNavigation();
   const { t, tRoot } = useTranslationWithPrefix('migrateENSContent.details');
   const accounts = useRootSelector(accountsSelector);
-  const balances = useRootSelector(accountEthereumWalletBalancesSelector);
+  const balances = useRootSelector(accountEthereumWalletAssetsBalancesSelector);
   const useBiometrics = useRootSelector(useBiometricsSelector);
   const {
     feeInfo,

--- a/src/screens/Exchange/AssetEnableModal.js
+++ b/src/screens/Exchange/AssetEnableModal.js
@@ -43,7 +43,7 @@ import { images } from 'utils/images';
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type { RootReducerState } from 'reducers/rootReducer';
@@ -182,7 +182,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Exchange/AssetEnableModal.js
+++ b/src/screens/Exchange/AssetEnableModal.js
@@ -49,7 +49,7 @@ import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances'
 import type { RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // local
 import type { EnableData } from './ExchangeOffers';
@@ -59,7 +59,7 @@ type StateProps = {|
   isEstimating: boolean,
   feeInfo: ?TransactionFeeInfo,
   estimateErrorMessage: ?string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
 |};
 
 type OwnProps = {|

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -72,7 +72,7 @@ import type { Account, Accounts } from 'models/Account';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
 import type { WBTCFeesRaw, WBTCFeesWithRate } from 'models/WBTC';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // partials
 import ExchangeIntroModal from './ExchangeIntroModal';
@@ -97,7 +97,7 @@ type Props = {
   user: Object,
   assets: Assets,
   searchOffers: (string, string, string) => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   resetOffers: () => void,
   exchangeSearchRequest: ExchangeSearchRequest,
   exchangeAllowances: Allowance[],

--- a/src/screens/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange.js
@@ -60,7 +60,7 @@ import { isArchanovaAccount } from 'utils/accounts';
 import { noop } from 'utils/common';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 import { activeAccountExchangeAllowancesSelector, activeAccountSelector } from 'selectors';
 
@@ -494,7 +494,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
   activeAccount: activeAccountSelector,
   exchangeAllowances: activeAccountExchangeAllowancesSelector,

--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -69,7 +69,7 @@ import type { AssetsBalances } from 'models/Balances';
 
 // selectors
 import { accountAssetsSelector } from 'selectors/assets';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // partials
 import ExchangeScheme from './ExchangeScheme';
@@ -333,7 +333,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   accountAssets: accountAssetsSelector,
 });
 

--- a/src/screens/Exchange/ExchangeConfirm.js
+++ b/src/screens/Exchange/ExchangeConfirm.js
@@ -65,7 +65,7 @@ import type {
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
 import type { WBTCGatewayAddressParams, WBTCGatewayAddressResponse, WBTCFeesWithRate } from 'models/WBTC';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // selectors
 import { accountAssetsSelector } from 'selectors/assets';
@@ -82,7 +82,7 @@ type Props = {
   rates: Rates,
   baseFiatCurrency: ?string,
   exchangeSupportedAssets: Asset[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   executingExchangeTransaction: boolean,
   setDismissTransaction: () => void,
   theme: Theme,

--- a/src/screens/Exchange/ExchangeOffers.js
+++ b/src/screens/Exchange/ExchangeOffers.js
@@ -58,7 +58,7 @@ import type {
 } from 'models/Transaction';
 import type { Asset, Rates } from 'models/Asset';
 import type { SessionData } from 'models/Session';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 //  selectors
 import { activeAccountAddressSelector, activeAccountExchangeAllowancesSelector } from 'selectors';
@@ -111,7 +111,7 @@ type Props = {
   baseFiatCurrency: ?string,
   rates: Rates,
   setDismissTransaction: () => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   session: SessionData,
   activeAccountAddress: string,
   useGasToken: boolean,

--- a/src/screens/Exchange/ExchangeOffers.js
+++ b/src/screens/Exchange/ExchangeOffers.js
@@ -62,7 +62,7 @@ import type { AssetsBalances } from 'models/Balances';
 
 //  selectors
 import { activeAccountAddressSelector, activeAccountExchangeAllowancesSelector } from 'selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { useGasTokenSelector } from 'selectors/archanova';
 
 // utils
@@ -500,7 +500,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   activeAccountAddress: activeAccountAddressSelector,
   useGasToken: useGasTokenSelector,
   exchangeAllowances: activeAccountExchangeAllowancesSelector,

--- a/src/screens/Exchange/utils.js
+++ b/src/screens/Exchange/utils.js
@@ -39,7 +39,7 @@ import type { Accounts } from 'models/Account';
 import type { ArchanovaWalletStatus } from 'models/ArchanovaWalletStatus';
 import type { Allowance, Offer } from 'models/Offer';
 import type { ExchangeOptions } from 'utils/exchange';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 /* eslint-disable i18next/no-literal-string */
 
@@ -112,7 +112,7 @@ const getBtcOption = (): AssetOption => {
 const getExchangeFromAssetOptions = (
   assets: Assets,
   exchangeSupportedAssets: Asset[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   baseFiatCurrency: ?string,
   rates: Rates,
 ): AssetOption[] => {
@@ -127,7 +127,7 @@ const getExchangeFromAssetOptions = (
 
 const getExchangeToAssetOptions = (
   exchangeSupportedAssets: Asset[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   baseFiatCurrency: ?string,
   rates: Rates,
 ): AssetOption[] => {
@@ -140,7 +140,7 @@ const getExchangeToAssetOptions = (
 export const provideOptions = (
   assets: Assets,
   exchangeSupportedAssets: Asset[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   rates: Rates,
   baseFiatCurrency: ?string,
   isWbtcCafeActive?: boolean,

--- a/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferChoose.js
+++ b/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferChoose.js
@@ -67,14 +67,14 @@ import { KEY_BASED_ASSET_TRANSFER_CONFIRM, KEY_BASED_ASSET_TRANSFER_EDIT_AMOUNT 
 import type { Asset, AssetData, KeyBasedAssetTransfer, Rates } from 'models/Asset';
 import type { Collectibles } from 'models/Collectible';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 type Props = {
   fetchAvailableBalancesToTransfer: () => void,
   fetchAvailableCollectiblesToTransfer: () => void,
   isFetchingAvailableBalances: boolean,
   isFetchingAvailableCollectibles: boolean,
-  availableBalances: AssetsBalances,
+  availableBalances: WalletAssetsBalances,
   availableCollectibles: Collectibles,
   addKeyBasedAssetToTransfer: (assetData: AssetData, amount?: BigNumber) => void,
   removeKeyBasedAssetToTransfer: (assetData: AssetData) => void,

--- a/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferConfirm.js
+++ b/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferConfirm.js
@@ -50,7 +50,7 @@ import { spacing } from 'utils/variables';
 
 // Types
 import type { Rates, KeyBasedAssetTransfer } from 'models/Asset';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 const KeyBasedAssetTransferConfirm = () => {
   const { t, tRoot } = useTranslationWithPrefix('smartWalletContent.confirm');
@@ -166,7 +166,7 @@ const KeyBasedAssetTransferConfirm = () => {
 
 export default KeyBasedAssetTransferConfirm;
 
-const getRemainingBalance = (balances: AssetsBalances, assetTransfers: KeyBasedAssetTransfer[], token: string) => {
+const getRemainingBalance = (balances: WalletAssetsBalances, assetTransfers: KeyBasedAssetTransfer[], token: string) => {
   const balance = getBalanceBN(balances, token);
   const transfer = assetTransfers.find(({ assetData }) => assetData?.token === ETH);
 

--- a/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferConfirm.js
+++ b/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferConfirm.js
@@ -166,7 +166,11 @@ const KeyBasedAssetTransferConfirm = () => {
 
 export default KeyBasedAssetTransferConfirm;
 
-const getRemainingBalance = (balances: WalletAssetsBalances, assetTransfers: KeyBasedAssetTransfer[], token: string) => {
+const getRemainingBalance = (
+  balances: WalletAssetsBalances,
+  assetTransfers: KeyBasedAssetTransfer[],
+  token: string,
+) => {
   const balance = getBalanceBN(balances, token);
   const transfer = assetTransfers.find(({ assetData }) => assetData?.token === ETH);
 

--- a/src/screens/Lending/ChooseAssetDeposit.js
+++ b/src/screens/Lending/ChooseAssetDeposit.js
@@ -50,14 +50,14 @@ import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances'
 // types
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { AssetToDeposit } from 'models/Asset';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   assetsToDeposit: AssetToDeposit[],
   isFetchingAssetsToDeposit: boolean,
   fetchAssetsToDeposit: () => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   navigation: NavigationScreenProp<*>,
 };
 

--- a/src/screens/Lending/ChooseAssetDeposit.js
+++ b/src/screens/Lending/ChooseAssetDeposit.js
@@ -45,7 +45,7 @@ import { fontSizes } from 'utils/variables';
 import { getBalance } from 'utils/assets';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
@@ -140,7 +140,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Lending/EnterDepositAmount.js
+++ b/src/screens/Lending/EnterDepositAmount.js
@@ -43,7 +43,7 @@ import { ETH } from 'constants/assetsConstants';
 import { LENDING_DEPOSIT_TRANSACTION_CONFIRM } from 'constants/navigationConstants';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // utils
 import { formatAmountDisplay } from 'utils/common';
@@ -234,7 +234,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Lending/EnterDepositAmount.js
+++ b/src/screens/Lending/EnterDepositAmount.js
@@ -54,12 +54,12 @@ import { isEnoughBalanceForTransactionFee } from 'utils/assets';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { AssetToDeposit } from 'models/Asset';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   assetsToDeposit: AssetToDeposit[],
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   navigation: NavigationScreenProp<*>,
   isEstimating: boolean,
   feeInfo: ?TransactionFeeInfo,

--- a/src/screens/Lending/EnterWithdrawAmount.js
+++ b/src/screens/Lending/EnterWithdrawAmount.js
@@ -41,7 +41,7 @@ import { ETH } from 'constants/assetsConstants';
 import { LENDING_WITHDRAW_TRANSACTION_CONFIRM } from 'constants/navigationConstants';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // utils
 import { spacing } from 'utils/variables';
@@ -204,7 +204,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Lending/EnterWithdrawAmount.js
+++ b/src/screens/Lending/EnterWithdrawAmount.js
@@ -51,7 +51,7 @@ import { isEnoughBalanceForTransactionFee } from 'utils/assets';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { DepositedAsset } from 'models/Asset';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -60,7 +60,7 @@ type Props = {
   isEstimating: boolean,
   feeInfo: ?TransactionFeeInfo,
   calculateLendingWithdrawTransactionEstimate: (amount: string, asset: DepositedAsset) => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   estimateErrorMessage: ?string,
   resetEstimateTransaction: () => void,
 };
@@ -136,7 +136,7 @@ const EnterWithdrawAmount = ({
     { amount: depositAmount, asset: depositedAsset },
   );
 
-  const depositedAssetsBalances: AssetsBalances = depositedAssets.reduce(
+  const depositedAssetsBalances: WalletAssetsBalances = depositedAssets.reduce(
     (balancesObj, { currentBalance: balance, symbol }) => ({ ...balancesObj, [symbol]: { symbol, balance } }),
     {},
   );

--- a/src/screens/LiquidityPools/AddLiquidity.js
+++ b/src/screens/LiquidityPools/AddLiquidity.js
@@ -45,7 +45,7 @@ import { findSupportedAsset, isEnoughBalanceForTransactionFee } from 'utils/asse
 import { getPoolStats, calculateProportionalAssetValues, getShareOfPool } from 'utils/liquidityPools';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // actions
 import { resetEstimateTransactionAction } from 'actions/transactionEstimateActions';
@@ -292,7 +292,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/LiquidityPools/AddLiquidity.js
+++ b/src/screens/LiquidityPools/AddLiquidity.js
@@ -57,7 +57,7 @@ import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 import type { LiquidityPool } from 'models/LiquidityPools';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -73,7 +73,7 @@ type Props = {
     poolTokenAmount: string,
     tokensAssets: Asset[],
   ) => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   liquidityPoolsReducer: LiquidityPoolsReducerState,
 };
 

--- a/src/screens/LiquidityPools/ClaimRewardsReview.js
+++ b/src/screens/LiquidityPools/ClaimRewardsReview.js
@@ -39,7 +39,7 @@ import { SEND_TOKEN_PIN_CONFIRM } from 'constants/navigationConstants';
 import { ETH } from 'constants/assetsConstants';
 
 import { activeAccountAddressSelector } from 'selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 import { resetEstimateTransactionAction } from 'actions/transactionEstimateActions';
 import { calculateClaimRewardsTransactionEstimateAction } from 'actions/liquidityPoolsActions';
@@ -192,7 +192,7 @@ const mapStateToProps = ({
 
 const structuredSelector = createStructuredSelector({
   accountAddress: activeAccountAddressSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/LiquidityPools/ClaimRewardsReview.js
+++ b/src/screens/LiquidityPools/ClaimRewardsReview.js
@@ -48,14 +48,14 @@ import type { TransactionFeeInfo } from 'models/Transaction';
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 import type { UnipoolLiquidityPool } from 'models/LiquidityPools';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   navigation: NavigationScreenProp<*>,
   feeInfo: ?TransactionFeeInfo,
   accountAddress: string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   resetEstimateTransaction: () => void,
   calculateClaimRewardsTransactionEstimate: (pool: UnipoolLiquidityPool, amountToClaim: number) => void,
   isEstimating: boolean,

--- a/src/screens/LiquidityPools/LiquidityPoolDashboard.js
+++ b/src/screens/LiquidityPools/LiquidityPoolDashboard.js
@@ -64,7 +64,7 @@ import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Rates, Asset } from 'models/Asset';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
 import type { LiquidityPool } from 'models/LiquidityPools';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // local
 import StakingEnabledModal from './StakingEnabledModal';
@@ -72,7 +72,7 @@ import StakingEnabledModal from './StakingEnabledModal';
 
 type Props = {
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   baseFiatCurrency: ?string,
   rates: Rates,
   poolDataGraphQueryFailed: boolean,

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -56,7 +56,7 @@ import type { TransactionFeeInfo } from 'models/Transaction';
 import type { LiquidityPool } from 'models/LiquidityPools';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -73,7 +73,7 @@ type Props = {
     tokensAssets: Asset[],
     obtainedAssetsValues: string[],
   ) => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   liquidityPoolsState: LiquidityPoolsReducerState,
 };
 
@@ -180,7 +180,7 @@ const RemoveLiquidityScreen = ({
     const tokenMaxWithdrawn = ((tokenPool * maxAmountBurned) / totalAmount);
 
     const tokenSymbol = tokensData[tokenIndex]?.symbol;
-    const customBalances: AssetsBalances = tokenSymbol
+    const customBalances: WalletAssetsBalances = tokenSymbol
       ? {
         [tokenSymbol]: {
           balance: formatAmount(tokenMaxWithdrawn, tokensData[tokenIndex]?.decimals),

--- a/src/screens/LiquidityPools/RemoveLiquidity.js
+++ b/src/screens/LiquidityPools/RemoveLiquidity.js
@@ -44,7 +44,7 @@ import { findSupportedAsset, isEnoughBalanceForTransactionFee } from 'utils/asse
 import { getPoolStats, calculateProportionalAssetAmountsForRemoval } from 'utils/liquidityPools';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // actions
 import { resetEstimateTransactionAction } from 'actions/transactionEstimateActions';
@@ -309,7 +309,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/LiquidityPools/StakeTokens.js
+++ b/src/screens/LiquidityPools/StakeTokens.js
@@ -52,7 +52,7 @@ import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { UnipoolLiquidityPool } from 'models/LiquidityPools';
 import type { LiquidityPoolsReducerState } from 'reducers/liquidityPoolsReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -139,7 +139,7 @@ const StakeTokensScreen = ({
     { amount: assetValue, poolToken: assetData, pool },
   );
 
-  const poolTokenCustomBalances: AssetsBalances =
+  const poolTokenCustomBalances: WalletAssetsBalances =
     assetData != null
       ? {
         [assetData.symbol]: {

--- a/src/screens/PPNHome/PPNView.js
+++ b/src/screens/PPNHome/PPNView.js
@@ -90,7 +90,7 @@ import {
 } from 'selectors/paymentNetwork';
 import { accountHistorySelector } from 'selectors/history';
 import { activeAccountAddressSelector } from 'selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 
 type Props = {
@@ -479,7 +479,7 @@ const structuredSelector = createStructuredSelector({
   PPNTransactions: PPNTransactionsSelector,
   history: accountHistorySelector,
   activeAccountAddress: activeAccountAddressSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/PPNHome/PPNView.js
+++ b/src/screens/PPNHome/PPNView.js
@@ -71,7 +71,7 @@ import type { Transaction } from 'models/Transaction';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
 import type { Rates } from 'models/Asset';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // utils
 import { getRate, addressesEqual } from 'utils/assets';
@@ -108,7 +108,7 @@ type Props = {
   theme: Theme,
   onScroll: (event: Object) => void,
   activeAccountAddress: string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
 };
 
 type State = {

--- a/src/screens/PoolTogether/PoolTogetherDashboard.js
+++ b/src/screens/PoolTogether/PoolTogetherDashboard.js
@@ -47,7 +47,7 @@ import type { Accounts } from 'models/Account';
 import type { PoolPrizeInfo } from 'models/PoolTogether';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // selectors
 import { accountHistorySelector } from 'selectors/history';
@@ -87,7 +87,7 @@ type Props = {
   session: Object,
   smartWallet: Object,
   accounts: Accounts,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   poolPrizeInfo: PoolPrizeInfo,
   fetchPoolStats: (symbol: string) => void,
   isFetchingPoolStats: boolean,

--- a/src/screens/PoolTogether/PoolTogetherDashboard.js
+++ b/src/screens/PoolTogether/PoolTogetherDashboard.js
@@ -51,7 +51,7 @@ import type { AssetsBalances } from 'models/Balances';
 
 // selectors
 import { accountHistorySelector } from 'selectors/history';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // utils
 import { fontSizes } from 'utils/variables';
@@ -344,7 +344,7 @@ const mapStateToProps = ({
 
 const structuredSelector = createStructuredSelector({
   history: accountHistorySelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/PoolTogether/PoolTogetherPurchase.js
+++ b/src/screens/PoolTogether/PoolTogetherPurchase.js
@@ -69,7 +69,7 @@ import { getPurchaseTicketTransactions } from 'services/poolTogether';
 
 // types
 import type { TransactionToEstimate, TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 const ContentWrapper = styled.View`
@@ -97,7 +97,7 @@ type Props = {
   session: Object,
   smartWallet: Object,
   accounts: Accounts,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   poolPrizeInfo: PoolPrizeInfo,
   fetchPoolStats: (symbol: string) => void,
   assets: Assets,

--- a/src/screens/PoolTogether/PoolTogetherPurchase.js
+++ b/src/screens/PoolTogether/PoolTogetherPurchase.js
@@ -53,7 +53,7 @@ import type { PoolPrizeInfo } from 'models/PoolTogether';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 import { activeAccountAddressSelector } from 'selectors';
 
@@ -316,7 +316,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
   accountAddress: activeAccountAddressSelector,
 });

--- a/src/screens/PoolTogether/PoolTogetherWithdraw.js
+++ b/src/screens/PoolTogether/PoolTogetherWithdraw.js
@@ -51,7 +51,7 @@ import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Theme } from 'models/Theme';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 
 // utils
@@ -313,7 +313,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
 });
 

--- a/src/screens/PoolTogether/PoolTogetherWithdraw.js
+++ b/src/screens/PoolTogether/PoolTogetherWithdraw.js
@@ -64,7 +64,7 @@ import { getWithdrawTicketTransaction } from 'services/poolTogether';
 
 // types
 import type { TransactionFeeInfo, TransactionToEstimate } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 const ContentWrapper = styled.View`
@@ -92,7 +92,7 @@ type Props = {
   session: Object,
   smartWallet: Object,
   accounts: Accounts,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   poolPrizeInfo: PoolPrizeInfo,
   fetchPoolStats: (symbol: string) => void,
   theme: Theme,

--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -51,7 +51,7 @@ import {
   visibleActiveAccountAssetsWithBalanceSelector,
 } from 'selectors/assets';
 import { activeAccountAddressSelector } from 'selectors/selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 import { NotEnoughLiquidityError } from 'services/0x';
 import { usePoolCurrentApy } from 'services/rariSdk';
@@ -280,7 +280,7 @@ const structuredSelector = createStructuredSelector({
   assets: accountAssetsSelector,
   visibleAssets: visibleActiveAccountAssetsWithBalanceSelector,
   activeAccountAddress: activeAccountAddressSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState, props: Props): $Shape<Props> => ({

--- a/src/screens/Rari/RariAddDeposit.js
+++ b/src/screens/Rari/RariAddDeposit.js
@@ -61,7 +61,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Rates, Asset, Assets, AssetOption } from 'models/Asset';
 import type { RariPool } from 'models/RariPool';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 type Props = {
   assets: Assets,
@@ -76,7 +76,7 @@ type Props = {
   activeAccountAddress: string,
   rates: Rates,
   setEstimatingTransaction: (boolean) => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
 };
 
 const FooterWrapper = styled.View`

--- a/src/screens/Rari/RariClaimRgt.js
+++ b/src/screens/Rari/RariClaimRgt.js
@@ -41,7 +41,7 @@ import { ETH } from 'constants/assetsConstants';
 import { RARI_CLAIM_RGT_REVIEW } from 'constants/navigationConstants';
 import { RARI_GOVERNANCE_TOKEN_DATA } from 'constants/rariConstants';
 
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
 import type { NavigationScreenProp } from 'react-navigation';
@@ -186,7 +186,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState, props: Props): $Shape<Props> => ({

--- a/src/screens/Rari/RariClaimRgt.js
+++ b/src/screens/Rari/RariClaimRgt.js
@@ -46,7 +46,7 @@ import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances'
 import type { RootReducerState, Dispatch } from 'reducers/rootReducer';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -54,7 +54,7 @@ type Props = {
   feeInfo: ?TransactionFeeInfo,
   isEstimating: boolean,
   estimateErrorMessage: ?string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   userUnclaimedRgt: number,
   calculateRariClaimTransactionEstimate: (amount: number) => void,
   resetEstimateTransaction: () => void,

--- a/src/screens/Rari/RariTransfer.js
+++ b/src/screens/Rari/RariTransfer.js
@@ -49,7 +49,7 @@ import type { TransactionFeeInfo, TransactionToEstimate } from 'models/Transacti
 import type { Rates } from 'models/Asset';
 import type { RariPool } from 'models/RariPool';
 import type { Contact } from 'models/Contact';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -61,7 +61,7 @@ type Props = {
   contacts: Contact[],
   estimateTransaction: (transaction: TransactionToEstimate) => void,
   useGasToken: boolean,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   resetEstimateTransaction: () => void,
   rariFundBalance: {[RariPool]: number},
   rariTotalSupply: {[RariPool]: number},

--- a/src/screens/Rari/RariTransfer.js
+++ b/src/screens/Rari/RariTransfer.js
@@ -39,7 +39,7 @@ import { ETH, supportedFiatCurrencies, USD } from 'constants/assetsConstants';
 import { RARI_TRANSFER_REVIEW } from 'constants/navigationConstants';
 import { RARI_TOKENS_DATA, RARI_TRANSFER_TRANSACTION } from 'constants/rariConstants';
 
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { contactsSelector } from 'selectors';
 import { useGasTokenSelector } from 'selectors/archanova';
 
@@ -285,7 +285,7 @@ const mapStateToProps = ({
 const structuredSelector = createStructuredSelector({
   contacts: contactsSelector,
   useGasToken: useGasTokenSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Rari/RariWithdraw.js
+++ b/src/screens/Rari/RariWithdraw.js
@@ -49,7 +49,7 @@ import { RARI_POOLS } from 'constants/rariConstants';
 
 import { accountAssetsSelector } from 'selectors/assets';
 import { activeAccountAddressSelector } from 'selectors/selectors';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 import { NotEnoughLiquidityError } from 'services/0x';
 
@@ -295,7 +295,7 @@ const mapStateToProps = ({
 const structuredSelector = createStructuredSelector({
   assets: accountAssetsSelector,
   activeAccountAddress: activeAccountAddressSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState, props: Props): $Shape<Props> => ({

--- a/src/screens/Rari/RariWithdraw.js
+++ b/src/screens/Rari/RariWithdraw.js
@@ -58,7 +58,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Asset, AssetOption, Assets } from 'models/Asset';
 import type { RariPool } from 'models/RariPool';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 type Props = {
   assets: Assets,
@@ -67,7 +67,7 @@ type Props = {
   isEstimating: boolean,
   estimateErrorMessage: ?string,
   resetEstimateTransaction: () => void,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   setEstimatingTransaction: (boolean) => void,
   calculateRariWithdrawTransactionEstimate: Object => void,
   activeAccountAddress: string,

--- a/src/screens/RecoveryPortal/RecoveryPortalSetupConnectDevice.js
+++ b/src/screens/RecoveryPortal/RecoveryPortalSetupConnectDevice.js
@@ -57,12 +57,12 @@ import { useGasTokenSelector } from 'selectors/archanova';
 import type { GasInfo } from 'models/GasInfo';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   fetchGasInfo: () => void,
   gasInfo: GasInfo,
   isOnline: boolean,

--- a/src/screens/RecoveryPortal/RecoveryPortalSetupConnectDevice.js
+++ b/src/screens/RecoveryPortal/RecoveryPortalSetupConnectDevice.js
@@ -50,7 +50,7 @@ import { buildArchanovaTxFeeInfo } from 'utils/archanova';
 import archanovaService from 'services/archanova';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { useGasTokenSelector } from 'selectors/archanova';
 
 // types
@@ -249,7 +249,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   useGasToken: useGasTokenSelector,
 });
 

--- a/src/screens/Sablier/NewStreamReview.js
+++ b/src/screens/Sablier/NewStreamReview.js
@@ -58,7 +58,7 @@ import { themedColors } from 'utils/themes';
 // selectors
 import { activeAccountAddressSelector } from 'selectors';
 import { accountAssetsSelector } from 'selectors/assets';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type { Assets, Asset } from 'models/Asset';
@@ -277,7 +277,7 @@ const mapStateToProps = ({
 const structuredSelector = createStructuredSelector({
   activeAccountAddress: activeAccountAddressSelector,
   assets: accountAssetsSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Sablier/NewStreamReview.js
+++ b/src/screens/Sablier/NewStreamReview.js
@@ -66,7 +66,7 @@ import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { EnsRegistry } from 'reducers/ensRegistryReducer';
 import type { TransactionFeeInfo, TransactionToEstimate } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -75,7 +75,7 @@ type Props = {
   assets: Assets,
   supportedAssets: Asset[],
   ensRegistry: EnsRegistry,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   feeInfo: ?TransactionFeeInfo,
   isEstimating: boolean,
   estimateErrorMessage: ?string,

--- a/src/screens/Sablier/OutgoingStream.js
+++ b/src/screens/Sablier/OutgoingStream.js
@@ -63,7 +63,7 @@ import type { EnsRegistry } from 'reducers/ensRegistryReducer';
 import type { TransactionFeeInfo } from 'models/Transaction';
 import type { Stream } from 'models/Sablier';
 import type { Accounts } from 'models/Account';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // local
 import SablierCancellationModal from './SablierCancellationModal';
@@ -73,7 +73,7 @@ type Props = {
   navigation: NavigationScreenProp<*>,
   supportedAssets: Asset[],
   ensRegistry: EnsRegistry,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   history: Object[],
   sablierEvents: Object[],
   accounts: Accounts,

--- a/src/screens/Sablier/SablierCancellationModal.js
+++ b/src/screens/Sablier/SablierCancellationModal.js
@@ -51,7 +51,7 @@ import type { TransactionFeeInfo } from 'models/Transaction';
 import type { EnsRegistry } from 'reducers/ensRegistryReducer';
 import type { Theme } from 'models/Theme';
 import type { RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type StateProps = {|
@@ -59,7 +59,7 @@ type StateProps = {|
   feeInfo: ?TransactionFeeInfo,
   isEstimating: boolean,
   estimateErrorMessage: ?string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
 |};
 
 type OwnProps = {|

--- a/src/screens/Sablier/SablierCancellationModal.js
+++ b/src/screens/Sablier/SablierCancellationModal.js
@@ -44,7 +44,7 @@ import { spacing } from 'utils/variables';
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type { TransactionFeeInfo } from 'models/Transaction';
@@ -185,7 +185,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/Sablier/Withdraw.js
+++ b/src/screens/Sablier/Withdraw.js
@@ -59,7 +59,7 @@ import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { Assets, Asset } from 'models/Asset';
 import type { Stream } from 'models/Sablier';
 import type { TransactionFeeInfo } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
@@ -69,7 +69,7 @@ type Props = {
   navigation: NavigationScreenProp<*>,
   feeInfo: ?TransactionFeeInfo,
   isEstimating: boolean,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   estimateErrorMessage: ?string,
   resetEstimateTransaction: () => void,
 };
@@ -149,7 +149,7 @@ const Withdraw = (props: Props) => {
 
   const assetOptions = [assetData];
 
-  const streamedAssetBalance: AssetsBalances = {
+  const streamedAssetBalance: WalletAssetsBalances = {
     [assetData.symbol]: { symbol: assetData.symbol, balance: formatUnits(maxWithdraw, assetData.decimals) },
   };
 

--- a/src/screens/Sablier/Withdraw.js
+++ b/src/screens/Sablier/Withdraw.js
@@ -45,7 +45,7 @@ import { spacing } from 'utils/variables';
 
 // selectors
 import { accountAssetsSelector } from 'selectors/assets';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // actions
 import { calculateSablierWithdrawTransactionEstimateAction } from 'actions/sablierActions';
@@ -228,7 +228,7 @@ const mapStateToProps = ({
 
 const structuredSelector = createStructuredSelector({
   assets: accountAssetsSelector,
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -64,13 +64,13 @@ import type {
   TransactionToEstimate,
 } from 'models/Transaction';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   navigation: NavigationScreenProp<*>,
   keyBasedWalletAddress: string,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   isOnline: boolean,
   feeInfo: ?TransactionFeeInfo,
   isEstimating: boolean,

--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -55,7 +55,7 @@ import { reportErrorLog } from 'utils/common';
 import { fetchRinkebyETHBalance } from 'services/assets';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 
 // types
 import type {
@@ -262,7 +262,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
 });
 
 const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({

--- a/src/screens/SendToken/SendTokenAmount.js
+++ b/src/screens/SendToken/SendTokenAmount.js
@@ -33,7 +33,7 @@ import type { Transaction } from 'models/Transaction';
 import type { AssetsBalances } from 'models/Balances';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 import { accountHistorySelector } from 'selectors/history';
 
@@ -78,7 +78,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   accountAssets: accountAssetsSelector,
   accountHistory: accountHistorySelector,
 });

--- a/src/screens/SendToken/SendTokenAmount.js
+++ b/src/screens/SendToken/SendTokenAmount.js
@@ -30,7 +30,7 @@ import type { Assets } from 'models/Asset';
 import type { RootReducerState } from 'reducers/rootReducer';
 import type { SessionData } from 'models/Session';
 import type { Transaction } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // selectors
 import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
@@ -40,7 +40,7 @@ import { accountHistorySelector } from 'selectors/history';
 
 type Props = {
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   session: SessionData,
   accountAssets: Assets,
   accountHistory: Transaction[],

--- a/src/screens/Tank/FundTank/FundTank.js
+++ b/src/screens/Tank/FundTank/FundTank.js
@@ -61,7 +61,7 @@ import { defaultFiatCurrency, ETH } from 'constants/assetsConstants';
 import { estimateTopUpVirtualAccountAction } from 'actions/smartWalletActions';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { accountAssetsSelector } from 'selectors/assets';
 import { useGasTokenSelector } from 'selectors/archanova';
 
@@ -311,7 +311,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
   useGasToken: useGasTokenSelector,
 });

--- a/src/screens/Tank/FundTank/FundTank.js
+++ b/src/screens/Tank/FundTank/FundTank.js
@@ -51,7 +51,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import type { TopUpFee } from 'models/PaymentNetwork';
 import type { Assets, Rates } from 'models/Asset';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // constants
 import { FUND_CONFIRM } from 'constants/navigationConstants';
@@ -103,7 +103,7 @@ const FormWrapper = styled.View`
 type Props = {
   assets: Assets,
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   session: Object,
   estimateTopUpVirtualAccount: () => void,
   topUpFee: TopUpFee,

--- a/src/screens/Tank/SettleBalance/SettleBalance.js
+++ b/src/screens/Tank/SettleBalance/SettleBalance.js
@@ -48,7 +48,7 @@ import type { Assets, Rates } from 'models/Asset';
 import type { TxToSettle } from 'models/PaymentNetwork';
 import type { Theme } from 'models/Theme';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // utils
 import {
@@ -66,7 +66,7 @@ import { accountAssetsSelector } from 'selectors/assets';
 type Props = {
   navigation: NavigationScreenProp<*>,
   assetsOnNetwork: Object[],
-  paymentNetworkBalances: AssetsBalances,
+  paymentNetworkBalances: WalletAssetsBalances,
   baseFiatCurrency: ?string,
   rates: Rates,
   assets: Assets,

--- a/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
+++ b/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
@@ -37,12 +37,12 @@ import Toast from 'components/Toast';
 import ReviewAndConfirm from 'components/ReviewAndConfirm';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { useGasTokenSelector } from 'selectors/archanova';
 
 // types
 import type { SettleTxFee, TxToSettle } from 'models/PaymentNetwork';
-import type { AssetBalance, AssetsBalances } from 'models/Balances';
+import type { AssetsBalances, AssetBalance } from 'models/Balances';
 
 // utils
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
@@ -192,7 +192,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   useGasToken: useGasTokenSelector,
 });
 

--- a/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
+++ b/src/screens/Tank/SettleBalanceConfirm/SettleBalanceConfirm.js
@@ -42,7 +42,7 @@ import { useGasTokenSelector } from 'selectors/archanova';
 
 // types
 import type { SettleTxFee, TxToSettle } from 'models/PaymentNetwork';
-import type { AssetsBalances, AssetBalance } from 'models/Balances';
+import type { WalletAssetsBalances, WalletAssetBalance } from 'models/Balances';
 
 // utils
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
@@ -55,7 +55,7 @@ type Props = {
   session: Object,
   settleTransactions: Function,
   settleTxFee: SettleTxFee,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   estimateSettleBalance: Function,
   useGasToken: boolean,
 };
@@ -105,7 +105,7 @@ class SettleBalanceConfirm extends React.Component<Props, State> {
     // add unsettled amounts to balances
     const combinedBalances = Object.keys(balances)
       .reduce((memo, assetName) => {
-        const balanceData: AssetBalance = balances[assetName];
+        const balanceData: WalletAssetBalance = balances[assetName];
         let balance = new BigNumber(balanceData.balance);
         this.txToSettle.forEach(asset => { balance = balance.plus(asset.value); });
         return {

--- a/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
+++ b/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
@@ -50,7 +50,7 @@ import { getGasToken, getTxFeeInWei } from 'utils/transactions';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { WithdrawalFee } from 'models/PaymentNetwork';
 import type { Assets, Rates } from 'models/Asset';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // constants
 import { TANK_WITHDRAWAL_CONFIRM } from 'constants/navigationConstants';
@@ -103,7 +103,7 @@ const FormWrapper = styled.View`
 type Props = {
   assets: Assets,
   navigation: NavigationScreenProp<*>,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   availableStake: number,
   session: Object,
   estimateWithdrawFromVirtualAccount: Function,

--- a/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
+++ b/src/screens/Tank/TankWithdrawal/TankWithdrawal.js
@@ -60,7 +60,7 @@ import { defaultFiatCurrency, ETH } from 'constants/assetsConstants';
 import { estimateWithdrawFromVirtualAccountAction } from 'actions/smartWalletActions';
 
 // selectors
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { availableStakeSelector } from 'selectors/paymentNetwork';
 import { accountAssetsSelector } from 'selectors/assets';
 import { useGasTokenSelector } from 'selectors/archanova';
@@ -312,7 +312,7 @@ const mapStateToProps = ({
 });
 
 const structuredSelector = createStructuredSelector({
-  balances: accountEthereumWalletBalancesSelector,
+  balances: accountEthereumWalletAssetsBalancesSelector,
   assets: accountAssetsSelector,
   availableStake: availableStakeSelector,
   useGasToken: useGasTokenSelector,

--- a/src/screens/UnsettledAssets/UnsettledAssets.js
+++ b/src/screens/UnsettledAssets/UnsettledAssets.js
@@ -51,14 +51,14 @@ import { accountAssetsSelector } from 'selectors/assets';
 // types
 import type { Assets } from 'models/Asset';
 import type { NavigationScreenProp } from 'react-navigation';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 type Props = {
   baseFiatCurrency: string,
   assets: Assets,
   rates: Object,
-  paymentNetworkBalances: AssetsBalances,
+  paymentNetworkBalances: WalletAssetsBalances,
   navigation: NavigationScreenProp<*>,
   assetsOnNetwork: Object,
 }

--- a/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
+++ b/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
@@ -37,7 +37,7 @@ import { CHAIN } from 'constants/chainConstants';
 // Selectors
 import { useRootSelector, supportedAssetsSelector } from 'selectors';
 import { accountAssetsSelector } from 'selectors/assets';
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import { isDeployedOnChainSelector } from 'selectors/chains';
 
 // Hooks
@@ -132,7 +132,7 @@ const useTransactionFee = (request: WalletConnectCallRequest) => {
   const fee = BigNumber(getFormattedTransactionFeeValue(feeInWei ?? '', feeInfo?.gasToken)) || null;
   const gasSymbol = feeInfo?.gasToken?.symbol || ETH;
 
-  const balances = useRootSelector(accountEthereumWalletBalancesSelector);
+  const balances = useRootSelector(accountEthereumWalletAssetsBalancesSelector);
   const { amount, symbol, decimals } = useTransactionPayload(request);
   const hasNotEnoughtGas = !isEnoughBalanceForTransactionFee(balances, {
     amount,

--- a/src/selectors/assets.js
+++ b/src/selectors/assets.js
@@ -39,7 +39,7 @@ import type { Asset, Assets, Rates } from 'models/Asset';
 import type { RootReducerState } from 'reducers/rootReducer';
 import type { AssetsBalances } from 'models/Balances';
 
-import { accountEthereumWalletBalancesSelector } from 'selectors/balances';
+import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import {
   assetsSelector,
   activeAccountIdSelector,
@@ -146,7 +146,7 @@ export const assetDecimalsSelector = (assetSelector: (state: Object, props: Obje
 
 export const visibleActiveAccountAssetsWithBalanceSelector = createSelector(
   activeAccountIdSelector,
-  accountEthereumWalletBalancesSelector,
+  accountEthereumWalletAssetsBalancesSelector,
   ratesSelector,
   baseFiatCurrencySelector,
   accountAssetsSelector,

--- a/src/selectors/assets.js
+++ b/src/selectors/assets.js
@@ -37,7 +37,7 @@ import { DEFAULT_ACCOUNTS_ASSETS_DATA_KEY } from 'constants/assetsConstants';
 // types
 import type { Asset, Assets, Rates } from 'models/Asset';
 import type { RootReducerState } from 'reducers/rootReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 import { accountEthereumWalletAssetsBalancesSelector } from 'selectors/balances';
 import {
@@ -150,7 +150,7 @@ export const visibleActiveAccountAssetsWithBalanceSelector = createSelector(
   ratesSelector,
   baseFiatCurrencySelector,
   accountAssetsSelector,
-  (activeAccountId: string, balances: AssetsBalances, rates: Rates, baseFiatCurrency: ?string, assets: Assets) => {
+  (activeAccountId: string, balances: WalletAssetsBalances, rates: Rates, baseFiatCurrency: ?string, assets: Assets) => {
     if (!activeAccountId || !balances || !assets) return {};
 
     return Object.keys(assets).reduce((assetsWithBalance, symbol) => {

--- a/src/selectors/assets.js
+++ b/src/selectors/assets.js
@@ -150,7 +150,13 @@ export const visibleActiveAccountAssetsWithBalanceSelector = createSelector(
   ratesSelector,
   baseFiatCurrencySelector,
   accountAssetsSelector,
-  (activeAccountId: string, balances: WalletAssetsBalances, rates: Rates, baseFiatCurrency: ?string, assets: Assets) => {
+  (
+    activeAccountId: string,
+    balances: WalletAssetsBalances,
+    rates: Rates,
+    baseFiatCurrency: ?string,
+    assets: Assets,
+  ) => {
     if (!activeAccountId || !balances || !assets) return {};
 
     return Object.keys(assets).reduce((assetsWithBalance, symbol) => {

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -55,7 +55,7 @@ import {
 export const accountAssetsBalancesSelector = createSelector(
   assetsBalancesSelector,
   activeAccountIdSelector,
-  (balances: AssetBalancesPerAccount, activeAccountId: ?string): CategoryBalancesPerChain => {
+  (balances: AssetBalancesPerAccount, activeAccountId: ?string): CategoryBalancesPerChain | {} => {
     if (!activeAccountId) return {};
     return balances?.[activeAccountId] ?? {};
   },

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -28,7 +28,7 @@ import { getTotalBalanceInFiat } from 'utils/assets';
 import { BigNumber } from 'utils/common';
 import { sum } from 'utils/bigNumber';
 import { isEtherspotAccount } from 'utils/accounts';
-import { getChainBalancesForCategory, getTotalCategoryBalance } from 'utils/balances';
+import { getChainTotalBalancesForCategory, getTotalCategoryBalance } from 'utils/balances';
 
 // types
 import type { RootReducerState } from 'reducers/rootReducer';
@@ -39,25 +39,30 @@ import type {
   CategoryTotalBalancesPerChain,
   TotalBalancesPerChain,
   AssetsBalances,
+  CategoryBalancesPerChain,
 } from 'models/Balances';
 
 // selectors
 import {
-  balancesSelector,
+  assetsBalancesSelector,
   fiatCurrencySelector,
   ratesSelector,
   activeAccountIdSelector,
   activeAccountSelector,
 } from './selectors';
 
-
-export const accountEthereumWalletBalancesSelector = createSelector(
-  balancesSelector,
+export const accountAssetsBalancesSelector = createSelector(
+  assetsBalancesSelector,
   activeAccountIdSelector,
-  (balances, activeAccountId): AssetsBalances => {
+  (balances, activeAccountId): CategoryBalancesPerChain => {
     if (!activeAccountId) return {};
-    return balances?.[activeAccountId]?.[CHAIN.ETHEREUM]?.[ASSET_CATEGORY.WALLET] || {};
+    return balances?.[activeAccountId] ?? {};
   },
+);
+
+export const accountEthereumWalletAssetsBalancesSelector = createSelector(
+  accountAssetsBalancesSelector,
+  (accountBalances): AssetsBalances => accountBalances?.[CHAIN.ETHEREUM]?.[ASSET_CATEGORY.WALLET] || {},
 );
 
 export const keyBasedWalletHasPositiveBalanceSelector = createSelector(
@@ -113,28 +118,28 @@ export const depositsTotalBalanceByChainsSelector: (RootReducerState) => TotalBa
   activeAccountTotalBalancesSelector,
   (
     accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.DEPOSITS),
+  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.DEPOSITS),
 );
 
 export const investmentsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(
   activeAccountTotalBalancesSelector,
   (
     accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.INVESTMENTS),
+  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.INVESTMENTS),
 );
 
 export const liquidityPoolsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(
   activeAccountTotalBalancesSelector,
   (
     accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.LIQUIDITY_POOLS),
+  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.LIQUIDITY_POOLS),
 );
 
 export const rewardsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(
   activeAccountTotalBalancesSelector,
   (
     accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.REWARDS),
+  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.REWARDS),
 );
 
 export const depositsTotalBalanceSelector: (RootReducerState) => BigNumber = createSelector(

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -40,8 +40,8 @@ import type {
   TotalBalancesPerChain,
   WalletAssetsBalances,
   CategoryBalancesPerChain,
+  AssetBalancesPerAccount,
 } from 'models/Balances';
-import type { AssetBalancesPerAccount } from 'models/Balances';
 
 // selectors
 import {

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -38,7 +38,7 @@ import type {
   ChainTotalBalancesPerAccount,
   CategoryTotalBalancesPerChain,
   TotalBalancesPerChain,
-  AssetsBalances,
+  WalletAssetsBalances,
   CategoryBalancesPerChain,
 } from 'models/Balances';
 
@@ -62,7 +62,7 @@ export const accountAssetsBalancesSelector = createSelector(
 
 export const accountEthereumWalletAssetsBalancesSelector = createSelector(
   accountAssetsBalancesSelector,
-  (accountBalances): AssetsBalances => accountBalances?.[CHAIN.ETHEREUM]?.[ASSET_CATEGORY.WALLET] || {},
+  (accountBalances): WalletAssetsBalances => accountBalances?.[CHAIN.ETHEREUM]?.[ASSET_CATEGORY.WALLET] || {},
 );
 
 export const keyBasedWalletHasPositiveBalanceSelector = createSelector(
@@ -92,7 +92,7 @@ export const paymentNetworkTotalBalanceSelector: (RootReducerState) => BigNumber
     // currently not supported by Etherspot
     if (isEtherspotAccount(activeAccount)) return BigNumber(0);
 
-    const balances: AssetsBalances = { [PLR]: { balance: ppnBalance.toString(), symbol: PLR } };
+    const balances: WalletAssetsBalances = { [PLR]: { balance: ppnBalance.toString(), symbol: PLR } };
     return BigNumber(getTotalBalanceInFiat(balances, rates, currency));
   },
 );

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -41,6 +41,7 @@ import type {
   WalletAssetsBalances,
   CategoryBalancesPerChain,
 } from 'models/Balances';
+import type { AssetBalancesPerAccount } from 'models/Balances';
 
 // selectors
 import {
@@ -54,7 +55,7 @@ import {
 export const accountAssetsBalancesSelector = createSelector(
   assetsBalancesSelector,
   activeAccountIdSelector,
-  (balances, activeAccountId): CategoryBalancesPerChain => {
+  (balances: AssetBalancesPerAccount, activeAccountId: ?string): CategoryBalancesPerChain => {
     if (!activeAccountId) return {};
     return balances?.[activeAccountId] ?? {};
   },

--- a/src/selectors/paymentNetwork.js
+++ b/src/selectors/paymentNetwork.js
@@ -40,7 +40,7 @@ import type { Asset, Assets } from 'models/Asset';
 import type { Transaction } from 'models/Transaction';
 import type { RootReducerState } from 'reducers/rootReducer';
 import type { PaymentNetworkReducerState } from 'reducers/paymentNetworkReducer';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 // selectors
 import {
@@ -58,7 +58,7 @@ const ppnTrxTags = [
   PAYMENT_NETWORK_TX_SETTLEMENT,
 ];
 
-export const paymentNetworkAccountBalancesSelector: ((state: RootReducerState) => AssetsBalances) = createSelector(
+export const paymentNetworkAccountBalancesSelector: ((state: RootReducerState) => WalletAssetsBalances) = createSelector(
   paymentNetworkBalancesSelector,
   activeAccountIdSelector,
   (balances, activeAccountId) => {
@@ -92,7 +92,7 @@ export const combinedPPNTransactionsSelector: ((state: RootReducerState) => Tran
   },
 );
 
-export const paymentNetworkNonZeroBalancesSelector: ((state: RootReducerState) => AssetsBalances) = createSelector(
+export const paymentNetworkNonZeroBalancesSelector: ((state: RootReducerState) => WalletAssetsBalances) = createSelector(
   PPNIncomingTransactionsSelector,
   accountHistorySelector,
   supportedAssetsSelector,

--- a/src/selectors/paymentNetwork.js
+++ b/src/selectors/paymentNetwork.js
@@ -58,7 +58,9 @@ const ppnTrxTags = [
   PAYMENT_NETWORK_TX_SETTLEMENT,
 ];
 
-export const paymentNetworkAccountBalancesSelector: ((state: RootReducerState) => WalletAssetsBalances) = createSelector(
+export const paymentNetworkAccountBalancesSelector: ((
+  state: RootReducerState,
+) => WalletAssetsBalances) = createSelector(
   paymentNetworkBalancesSelector,
   activeAccountIdSelector,
   (balances, activeAccountId) => {
@@ -92,7 +94,9 @@ export const combinedPPNTransactionsSelector: ((state: RootReducerState) => Tran
   },
 );
 
-export const paymentNetworkNonZeroBalancesSelector: ((state: RootReducerState) => WalletAssetsBalances) = createSelector(
+export const paymentNetworkNonZeroBalancesSelector: ((
+  state: RootReducerState,
+) => WalletAssetsBalances) = createSelector(
   PPNIncomingTransactionsSelector,
   accountHistorySelector,
   supportedAssetsSelector,

--- a/src/selectors/selectors.js
+++ b/src/selectors/selectors.js
@@ -50,7 +50,7 @@ export const useRates = () => useRootSelector(ratesSelector);
 export const fiatCurrencySelector = (root: RootReducerState) =>
   root.appSettings.data.baseFiatCurrency ?? defaultFiatCurrency;
 
-export const balancesSelector = ({ assetsBalances }: RootReducerState) => assetsBalances.data;
+export const assetsBalancesSelector = ({ assetsBalances }: RootReducerState) => assetsBalances.data;
 export const collectiblesSelector = ({ collectibles }: RootReducerState) => collectibles.data;
 export const collectiblesHistorySelector =
   ({ collectibles }: RootReducerState) => collectibles.transactionHistory;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -47,6 +47,7 @@ import type { ClaimTokenAction } from 'actions/referralsActions';
 import type { AltalixTrxParams, SendwyreRates, SendwyreTrxParams } from 'models/FiatToCryptoProviders';
 import type { WBTCGatewayAddressParams, WBTCGatewayAddressResponse } from 'models/WBTC';
 import type { AxiosXHR } from 'axios';
+import type { WalletAssetBalance } from 'models/Balances';
 
 // services
 import {
@@ -563,7 +564,7 @@ class SDKWrapper {
     return fetchLastBlockNumber(network);
   }
 
-  async fetchBalances({ address, assets }: BalancePayload) {
+  async fetchBalances({ address, assets }: BalancePayload): Promise<WalletAssetBalance[]> {
     // try to get all the balances in one call (mainnet and kovan only)
     const balances = await fetchAddressBalancesFromProxyContract(assets, address);
     if (!isEmpty(balances)) return balances;

--- a/src/services/assets.js
+++ b/src/services/assets.js
@@ -49,6 +49,7 @@ import { firebaseRemoteConfig } from 'services/firebase';
 
 // types
 import type { Asset, Assets } from 'models/Asset';
+import type { WalletAssetBalance } from 'models/Balances';
 
 
 type Address = string;
@@ -88,12 +89,6 @@ type ETHTransferOptions = {
   signOnly?: ?boolean,
   data?: string,
 };
-
-type FetchBalancesResponse = Array<{
-  balance: string,
-  symbol: string,
-}>;
-
 
 export const encodeContractMethod = (
   contractAbi: string | Object[],
@@ -314,7 +309,7 @@ export function fetchERC20Balance(
   return contract.balanceOf(walletAddress).then((wei) => utils.formatUnits(wei, decimals));
 }
 
-export function fetchAssetBalancesOnChain(assets: Asset[], walletAddress: string): Promise<FetchBalancesResponse> {
+export function fetchAssetBalancesOnChain(assets: Asset[], walletAddress: string): Promise<WalletAssetBalance[]> {
   const promises = assets
     .map(async (asset: Asset) => {
       const balance = asset.symbol === ETH
@@ -333,7 +328,7 @@ export function fetchAssetBalancesOnChain(assets: Asset[], walletAddress: string
 export async function fetchAddressBalancesFromProxyContract(
   assets: Asset[],
   accountAddress: string,
-): Promise<FetchBalancesResponse> {
+): Promise<WalletAssetBalance[]> {
   if (!['homestead', 'kovan'].includes(getEnv().NETWORK_PROVIDER)) return [];
 
   const tokens = assets.map(({ address }) => address);

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -56,7 +56,7 @@ import { ETH } from 'constants/assetsConstants';
 import type { Asset } from 'models/Asset';
 import type { EthereumTransaction, TransactionPayload, TransactionResult } from 'models/Transaction';
 import type { EtherspotTransactionEstimate } from 'models/Etherspot';
-import type { AssetBalance } from 'models/Balances';
+import type { WalletAssetBalance } from 'models/Balances';
 
 class EtherspotService {
   sdk: EtherspotSdk;
@@ -140,7 +140,7 @@ class EtherspotService {
       });
   }
 
-  async getBalances(accountAddress: string, assets: Asset[]): Promise<AssetBalance[]> {
+  async getBalances(accountAddress: string, assets: Asset[]): Promise<WalletAssetBalance[]> {
     const assetAddresses = assets
       // 0x0...0 is default ETH address in our assets, but it's not a token
       .filter(({ address }) => !addressesEqual(address, EthersConstants.AddressZero))
@@ -169,7 +169,7 @@ class EtherspotService {
       return []; // logged above, no balances
     }
 
-    // map to our AssetBalance type
+    // map to our WalletAssetBalance type
     return accountBalances.items.reduce((balances, { balance, token }) => {
       // if SDK returned token value is null then it's ETH
       const asset = assets.find(({

--- a/src/services/zapper.js
+++ b/src/services/zapper.js
@@ -37,7 +37,6 @@ type ZapperAsset = {
   tokenAddress: string,
   label?: string,
   img?: string,
-  noImage?: boolean,
   reserve?: number,
   balance: number,
   balanceUSD: number,

--- a/src/services/zapper.js
+++ b/src/services/zapper.js
@@ -37,9 +37,13 @@ type ZapperAsset = {
   tokenAddress: string,
   label?: string,
   img?: string,
+  noImage?: boolean,
   reserve?: number,
   balance: number,
   balanceUSD: number,
+  protocol: string,
+  share?: number,
+  supply?: number,
 };
 
 type ZapperMeta = {

--- a/src/utils/__tests__/assets.test.js
+++ b/src/utils/__tests__/assets.test.js
@@ -31,7 +31,7 @@ import { mockSupportedAssets } from 'testUtils/jestSetup';
 
 // types
 import type { Rates } from 'models/Asset';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 describe('Assets utils', () => {
@@ -81,7 +81,7 @@ describe('Assets utils', () => {
 
   describe('balanceInEth', () => {
     it('returns the total in ETH', () => {
-      const balances: AssetsBalances = {
+      const balances: WalletAssetsBalances = {
         ETH: { symbol: 'ETH', balance: '2.321000' },
         PLR: { symbol: 'PLR', balance: '1200' },
       };
@@ -92,7 +92,7 @@ describe('Assets utils', () => {
     });
 
     it('returns 0 when there are no rates for ETH', () => {
-      const balances: AssetsBalances = {
+      const balances: WalletAssetsBalances = {
         PLR: { symbol: 'PLR', balance: '1200' },
       };
 
@@ -110,7 +110,7 @@ describe('Assets utils', () => {
     });
 
     it('returns the balance', () => {
-      const balances: AssetsBalances = {
+      const balances: WalletAssetsBalances = {
         ETH: { symbol: 'ETH', balance: '2.321000' },
       };
 
@@ -122,7 +122,7 @@ describe('Assets utils', () => {
   describe('getTotalBalanceInFiat', () => {
     describe('for empty values', () => {
       it('returns 0', () => {
-        const balances: AssetsBalances = {};
+        const balances: WalletAssetsBalances = {};
 
         const balance = getTotalBalanceInFiat(balances, {}, 'GBP');
 
@@ -133,7 +133,7 @@ describe('Assets utils', () => {
     describe('when there are ETH and PLR assets', () => {
       describe('when assets have no rate', () => {
         it('returns 0 balance', () => {
-          const balances: AssetsBalances = {
+          const balances: WalletAssetsBalances = {
             MANA: { symbol: 'MANA', balance: '1200.0' },
           };
 
@@ -147,7 +147,7 @@ describe('Assets utils', () => {
         const ethBalance = 1.2;
 
         it('returns the ETH balance', () => {
-          const balances: AssetsBalances = {
+          const balances: WalletAssetsBalances = {
             ETH: { symbol: 'ETH', balance: `${ethBalance}` },
           };
 
@@ -160,7 +160,7 @@ describe('Assets utils', () => {
           const plrBalance = 3.4;
 
           it('returns the totals balance', () => {
-            const balances: AssetsBalances = {
+            const balances: WalletAssetsBalances = {
               ETH: { symbol: 'ETH', balance: `${ethBalance}` },
               PLR: { symbol: 'PLR', balance: `${plrBalance}` },
             };

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -44,7 +44,7 @@ import type { Collectible } from 'models/Collectible';
 import type { Value } from 'utils/common';
 import type {
   WalletAssetBalance,
-  AssetsBalances,
+  WalletAssetsBalances,
 } from 'models/Balances';
 
 
@@ -63,7 +63,7 @@ export const transformAssetsToObject = (assetsArray: Asset[] = []): Assets => {
   }, {});
 };
 
-export const transformBalancesToObject = (balancesArray: WalletAssetBalance[] = []): AssetsBalances => {
+export const transformBalancesToObject = (balancesArray: WalletAssetBalance[] = []): WalletAssetsBalances => {
   return balancesArray.reduce((memo, balance) => {
     memo[balance.symbol] = balance;
     return memo;
@@ -80,7 +80,7 @@ export const sortAssets = (assets: Assets): Asset[] => {
   return sortAssetsArray(assetsList);
 };
 
-export const getBalanceBN = (balances: ?AssetsBalances, asset: ?string): BigNumber => {
+export const getBalanceBN = (balances: ?WalletAssetsBalances, asset: ?string): BigNumber => {
   if (!balances || !asset) return BigNumber('0');
   return BigNumber(balances[asset]?.balance ?? '0');
 };
@@ -88,7 +88,7 @@ export const getBalanceBN = (balances: ?AssetsBalances, asset: ?string): BigNumb
 /**
  * @deprecated: do not use because of rounding issues
  */
-export const getBalance = (balances: ?AssetsBalances, asset: string): number => {
+export const getBalance = (balances: ?WalletAssetsBalances, asset: string): number => {
   if (!balances) return 0;
 
   const assetBalance = get(balances, asset);
@@ -177,7 +177,7 @@ export const calculateMaxAmount = (
 };
 
 export const isEnoughBalanceForTransactionFee = (
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   transaction: {
     txFeeInWei: ?Value,
     gasToken?: ?GasToken,
@@ -219,7 +219,7 @@ export const isEnoughBalanceForTransactionFee = (
   return balanceInWei.gte(txFeeInWeiBN);
 };
 
-export const balanceInEth = (balances: AssetsBalances, rates: Rates): number => {
+export const balanceInEth = (balances: WalletAssetsBalances, rates: Rates): number => {
   const balanceValues: WalletAssetBalance[] = (Object.values(balances): any);
 
   return balanceValues.reduce((total, item) => {
@@ -236,7 +236,7 @@ export const balanceInEth = (balances: AssetsBalances, rates: Rates): number => 
   }, 0);
 };
 
-export const getTotalBalanceInFiat = (balances: AssetsBalances, rates: Rates, currency: string): number => {
+export const getTotalBalanceInFiat = (balances: WalletAssetsBalances, rates: Rates, currency: string): number => {
   const ethRates = rates[ETH];
   if (!ethRates) {
     return 0;
@@ -373,7 +373,7 @@ export const getFormattedBalanceInFiat = (
 
 const getAssetOptionBalance = (
   symbol: string,
-  balances: ?AssetsBalances,
+  balances: ?WalletAssetsBalances,
   rates: ?Rates,
   fiatCurrency: ?string,
 ): ?AssetOptionBalance => {
@@ -393,7 +393,7 @@ const getAssetOptionBalance = (
 
 export const getAssetOption = (
   asset: Asset,
-  balances: ?AssetsBalances,
+  balances: ?WalletAssetsBalances,
   rates: ?Rates,
   baseFiatCurrency: ?string,
 ): AssetOption => {
@@ -415,7 +415,7 @@ export const getAssetOption = (
 
 export const mapAssetDataToAssetOption = (
   assetData: AssetData,
-  balances?: ?AssetsBalances,
+  balances?: ?WalletAssetsBalances,
   rates?: ?Rates,
   fiatCurrency?: ?string,
 ): AssetOption => {

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -43,7 +43,7 @@ import type { GasToken } from 'models/Transaction';
 import type { Collectible } from 'models/Collectible';
 import type { Value } from 'utils/common';
 import type {
-  AssetBalance,
+  WalletAssetBalance,
   AssetsBalances,
 } from 'models/Balances';
 
@@ -63,7 +63,7 @@ export const transformAssetsToObject = (assetsArray: Asset[] = []): Assets => {
   }, {});
 };
 
-export const transformBalancesToObject = (balancesArray: AssetBalance[] = []): AssetsBalances => {
+export const transformBalancesToObject = (balancesArray: WalletAssetBalance[] = []): AssetsBalances => {
   return balancesArray.reduce((memo, balance) => {
     memo[balance.symbol] = balance;
     return memo;
@@ -220,7 +220,7 @@ export const isEnoughBalanceForTransactionFee = (
 };
 
 export const balanceInEth = (balances: AssetsBalances, rates: Rates): number => {
-  const balanceValues: AssetBalance[] = (Object.values(balances): any);
+  const balanceValues: WalletAssetBalance[] = (Object.values(balances): any);
 
   return balanceValues.reduce((total, item) => {
     const balance = +item.balance;

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -55,7 +55,7 @@ export const getTotalCategoryBalance = (
   }));
 };
 
-export const getChainBalancesForCategory = (
+export const getChainAssetsBalancesForCategory = (
   accountAssetsBalances: ?CategoryBalancesPerChain,
   category: string,
 ): AssetsBalancesPerChain => mapValues(

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -21,15 +21,20 @@ import { mapValues } from 'lodash';
 import { BigNumber } from 'bignumber.js';
 
 // types
-import type { CategoryTotalBalancesPerChain, TotalBalancesPerChain } from 'models/Balances';
+import type {
+  CategoryBalancesPerChain,
+  CategoryTotalBalancesPerChain,
+  TotalBalancesPerChain,
+} from 'models/Balances';
 import { sum } from 'utils/bigNumber';
+import { AssetsBalancesPerChain } from 'models/Balances';
 
-export const getChainBalancesForCategory = (
-  accountTotals: ?CategoryTotalBalancesPerChain,
+export const getChainTotalBalancesForCategory = (
+  accountTotalBalances: ?CategoryTotalBalancesPerChain,
   category: string,
 ): TotalBalancesPerChain => mapValues(
-  accountTotals ?? {},
-  (categoryBalances, chain) => accountTotals?.[chain]?.[category] || BigNumber(0),
+  accountTotalBalances ?? {},
+  (categoryBalances, chain) => accountTotalBalances?.[chain]?.[category] || BigNumber(0),
 );
 
 export const getTotalBalance = (entries: { [key: string]: BigNumber}): BigNumber => {
@@ -38,12 +43,20 @@ export const getTotalBalance = (entries: { [key: string]: BigNumber}): BigNumber
 };
 
 export const getTotalCategoryBalance = (
-  accountTotals: ?CategoryTotalBalancesPerChain,
+  accountTotalBalances: ?CategoryTotalBalancesPerChain,
   category: string,
 ): BigNumber => {
-  const balancesOnChains = (Object.values(accountTotals || {}): any);
+  const balancesOnChains = (Object.values(accountTotalBalances || {}): any);
 
   return sum(balancesOnChains.map((chainTotals) => {
     return chainTotals?.[category] || BigNumber(0);
   }));
 };
+
+export const getChainBalancesForCategory = (
+  accountAssetsBalances: ?CategoryBalancesPerChain,
+  category: string,
+): AssetsBalancesPerChain => mapValues(
+  accountAssetsBalances ?? {},
+  (categoryBalances, chain) => accountAssetsBalances?.[chain]?.[category],
+);

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -36,7 +36,7 @@ export const getChainTotalBalancesForCategory = (
   category: string,
 ): TotalBalancesPerChain => mapValues(
   accountTotalBalances ?? {},
-  (categoryBalances, chain) => accountTotalBalances?.[chain]?.[category] || BigNumber(0),
+  (categoryBalances) => categoryBalances?.[category] || BigNumber(0),
 );
 
 export const getTotalBalance = (entries: { [key: string]: BigNumber}): BigNumber => {
@@ -60,5 +60,5 @@ export const getChainAssetsBalancesForCategory = (
   category: string,
 ): AssetsBalancesPerChain => mapValues(
   accountAssetsBalances ?? {},
-  (categoryBalances, chain) => accountAssetsBalances?.[chain]?.[category],
+  (categoryBalances) => categoryBalances?.[category],
 );

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -20,14 +20,16 @@
 import { mapValues } from 'lodash';
 import { BigNumber } from 'bignumber.js';
 
+// utils
+import { sum } from 'utils/bigNumber';
+
 // types
 import type {
   CategoryBalancesPerChain,
   CategoryTotalBalancesPerChain,
   TotalBalancesPerChain,
 } from 'models/Balances';
-import { sum } from 'utils/bigNumber';
-import { AssetsBalancesPerChain } from 'models/Balances';
+import type { AssetsBalancesPerChain } from 'models/Balances';
 
 export const getChainTotalBalancesForCategory = (
   accountTotalBalances: ?CategoryTotalBalancesPerChain,

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -29,7 +29,6 @@ import type {
   CategoryTotalBalancesPerChain,
   TotalBalancesPerChain,
 } from 'models/Balances';
-import type { AssetsBalancesPerChain } from 'models/Balances';
 
 export const getChainTotalBalancesForCategory = (
   accountTotalBalances: ?CategoryTotalBalancesPerChain,
@@ -55,10 +54,11 @@ export const getTotalCategoryBalance = (
   }));
 };
 
+// TODO: add return AssetsBalancesPerChain later and fix Flow
 export const getChainAssetsBalancesForCategory = (
   accountAssetsBalances: ?CategoryBalancesPerChain,
   category: string,
-): AssetsBalancesPerChain => mapValues(
+) => mapValues(
   accountAssetsBalances ?? {},
   (categoryBalances) => categoryBalances?.[category],
 );

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -37,7 +37,7 @@ import ERC20_CONTRACT_ABI from 'abi/erc20.json';
 // types
 import type { FeeInfo } from 'models/PaymentNetwork';
 import type { EthereumTransaction, GasToken, TransactionPayload } from 'models/Transaction';
-import type { AssetsBalances } from 'models/Balances';
+import type { WalletAssetsBalances } from 'models/Balances';
 
 
 export const getTxFeeInWei = (useGasToken: boolean, feeInfo: ?FeeInfo): BigNumber | number => {
@@ -53,7 +53,7 @@ export const getGasToken = (useGasToken: boolean, feeInfo: ?FeeInfo): ?GasToken 
 // note: returns negative if total balance is lower
 export const calculateETHTransactionAmountAfterFee = (
   ethAmount: BigNumber,
-  balances: AssetsBalances,
+  balances: WalletAssetsBalances,
   totalFeeInEth: BigNumber,
 ): BigNumber => {
   const ethBalance = new BigNumber(getBalance(balances, ETH));


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1027/wire-up-live-data-with-v2-ui

Part 2.

Includes:
- Pulling service assets balances from Zapper.
- Once again some reasoning name refactor for `Balances`.

Notes:
- I don't like the approach of putting service balances with extra items, but as for this moment this is most pragmatic approach for our internal release.
- Some meta data might be missing such as images for Liquidity Pool tokens (not provided by Zapper) or Deposits APY (need to build extra request flow).