### PR TITLE
Fix: wallet asset totals calculation and wallet side chains display

### DIFF
--- a/src/actions/__tests__/assetsActions.test.js
+++ b/src/actions/__tests__/assetsActions.test.js
@@ -168,16 +168,9 @@ describe('Assets actions', () => {
       category: ASSET_CATEGORY.WALLET,
       balances: { ETH: { balance: '0.000000000000000001', symbol: 'ETH' } },
     };
-    const updateTotalBalancePayload = {
-      accountId: mockAccounts[0].id,
-      chain: CHAIN.ETHEREUM,
-      category: ASSET_CATEGORY.WALLET,
-      balance: BigNumber(0),
-    };
     const expectedActions = [
       { type: SET_FETCHING_ASSETS_BALANCES, payload: true },
       { type: SET_ACCOUNT_ASSETS_BALANCES, payload: updateBalancesPayload },
-      { type: SET_ACCOUNT_TOTAL_BALANCE, payload: updateTotalBalancePayload },
       { type: SET_FETCHING_ASSETS_BALANCES, payload: false },
     ];
     return store.dispatch(fetchAssetsBalancesAction())

--- a/src/actions/__tests__/assetsActions.test.js
+++ b/src/actions/__tests__/assetsActions.test.js
@@ -20,7 +20,6 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import ReduxAsyncQueue from 'redux-async-queue';
-import { BigNumber } from 'utils/common';
 
 // actions
 import { sendAssetAction, fetchAssetsBalancesAction, getSupportedTokens } from 'actions/assetsActions';
@@ -40,7 +39,6 @@ import {
   SET_FETCHING_ASSETS_BALANCES,
 } from 'constants/assetsBalancesConstants';
 import { INITIAL_REMOTE_CONFIG } from 'constants/remoteConfigConstants';
-import { SET_ACCOUNT_TOTAL_BALANCE } from 'constants/totalsBalancesConstants';
 import { CHAIN } from 'constants/chainConstants';
 
 // services

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -103,7 +103,6 @@ import {
   assetsBalancesSelector,
   fiatCurrencySelector,
 } from 'selectors';
-import { totalBalancesSelector } from 'selectors/totalBalances';
 
 // types
 import type { Asset, AssetsByAccount } from 'models/Asset';
@@ -414,7 +413,7 @@ export const fetchAccountWalletBalancesAction = (account: Account) => {
       );
     }));
 
-    const accountsTotalBalances = totalBalancesSelector(getState());
+    const accountsTotalBalances = getState().totalBalances.data;
     dispatch(saveDbAction('totalBalances', { data: accountsTotalBalances }, true));
   };
 };
@@ -572,7 +571,7 @@ export const fetchAllAccountsTotalBalancesAction = () => {
 
     dispatch({ type: SET_FETCHING_TOTAL_BALANCES, payload: false });
 
-    const accountsTotalBalances = totalBalancesSelector(getState());
+    const accountsTotalBalances = getState().totalBalances.data;
     dispatch(saveDbAction('totalBalances', { data: accountsTotalBalances }, true));
 
     const accountsAssetsBalances = assetsBalancesSelector(getState());
@@ -608,7 +607,7 @@ export const resetAccountAssetsBalancesAction = (accountId: string) => {
     const updatedBalances = assetsBalancesSelector(getState());
     dispatch(saveDbAction('assetsBalances', { data: updatedBalances }, true));
 
-    const updatedTotalBalances = totalBalancesSelector(getState());
+    const updatedTotalBalances = getState().totalBalances.data;
     dispatch(saveDbAction('totalBalances', { data: updatedTotalBalances }, true));
   };
 };

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -72,11 +72,7 @@ import {
 } from 'services/zapper';
 
 // utils
-import {
-  getAssetsAsList,
-  getRate,
-  transformBalancesToObject,
-} from 'utils/assets';
+import { getAssetsAsList, transformBalancesToObject } from 'utils/assets';
 import { getSupportedChains } from 'utils/chains';
 import {
   parseTokenAmount,
@@ -97,7 +93,7 @@ import {
   isArchanovaAccountAddress,
 } from 'utils/accounts';
 import { catchTransactionError } from 'utils/wallet';
-import { sum, sumBy } from 'utils/bigNumber';
+import { sumBy } from 'utils/bigNumber';
 
 // selectors
 import { accountAssetsSelector, makeAccountEnabledAssetsSelector } from 'selectors/assets';
@@ -106,7 +102,6 @@ import {
   supportedAssetsSelector,
   assetsBalancesSelector,
   fiatCurrencySelector,
-  ratesSelector,
 } from 'selectors';
 import { totalBalancesSelector } from 'selectors/totalBalances';
 
@@ -417,28 +412,6 @@ export const fetchAccountWalletBalancesAction = (account: Account) => {
       await dispatch(
         updateAccountWalletAssetsBalancesForChainAction(accountId, chain, transformBalancesToObject(newBalances)),
       );
-
-      const rates = ratesSelector(getState());
-      const currency = fiatCurrencySelector(getState());
-
-      const assetsFiatBalances = newBalances.map((asset) => {
-        if (!asset?.balance) return BigNumber(0);
-
-        const rate = getRate(rates, asset.symbol, currency);
-        return BigNumber(asset.balance).times(rate);
-      });
-
-      const totalBalance = sum(assetsFiatBalances);
-
-      dispatch({
-        type: SET_ACCOUNT_TOTAL_BALANCE,
-        payload: {
-          accountId,
-          chain,
-          category: ASSET_CATEGORY.WALLET,
-          balance: totalBalance,
-        },
-      });
     }));
 
     const accountsTotalBalances = totalBalancesSelector(getState());

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -97,7 +97,7 @@ import {
   isArchanovaAccountAddress,
 } from 'utils/accounts';
 import { catchTransactionError } from 'utils/wallet';
-import { sum } from 'utils/bigNumber';
+import { sum, sumBy } from 'utils/bigNumber';
 
 // selectors
 import { accountAssetsSelector, makeAccountEnabledAssetsSelector } from 'selectors/assets';
@@ -565,8 +565,8 @@ export const fetchAllAccountsTotalBalancesAction = () => {
               });
 
               // add to total balance
-              const balancesValues = assetsBalances.map(({ value }) => value);
-              categoryTotalBalance = sum([categoryTotalBalance, ...balancesValues]);
+              const totalValue = sumBy(assetsBalances, (balance) => balance.value);
+              categoryTotalBalance = categoryTotalBalance.plus(totalValue);
 
               return [...combinedBalances, ...assetsBalances];
             }, []);

--- a/src/actions/assetsActions.js
+++ b/src/actions/assetsActions.js
@@ -108,7 +108,7 @@ import {
   fiatCurrencySelector,
   ratesSelector,
 } from 'selectors';
-import { totalBalancesSelector } from 'selectors/balances';
+import { totalBalancesSelector } from 'selectors/totalBalances';
 
 // types
 import type { Asset, AssetsByAccount } from 'models/Asset';

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -25,7 +25,6 @@ import { ACCOUNT_TYPES } from 'constants/accountsConstants';
 import type { ChainRecord } from 'models/Chain';
 
 export type AccountTypes = $Values<typeof ACCOUNT_TYPES>;
-
 export type EtherspotAccount = {|
   type: typeof ACCOUNT_TYPES.ETHERSPOT_SMART_WALLET,
   id: string,
@@ -73,3 +72,5 @@ export type KeyBasedAccount = {|
 export type KeyBasedAccountExtra = {||};
 
 export type Account = EtherspotAccount | ArchanovaAccount | KeyBasedAccount;
+
+export type AccountRecord<T> = { [accountId: string]: T };

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -23,34 +23,6 @@ import { BigNumber } from 'bignumber.js';
 // types
 import type { ChainRecord } from 'models/Chain';
 
-export type CategoryRecord<T> = {|
-  wallet?: T,
-  deposits?: T,
-  investments?: T,
-  liquidityPools?: T,
-  rewards?: T,
-|};
-
-export type ServiceRecord<T> = {|
-  deposits?: T,
-  investments?: T,
-  liquidityPools?: T,
-  rewards?: T,
-|};
-
-export type BalancePerChain = ChainRecord<BigNumber>;
-
-export type CategoryTotalBalancesX = CategoryRecord<BalancePerChain>;
-export type CategoryTotalBalancesPerAccount = { [accountId: string]: CategoryTotalBalancesX };
-
-export type ServiceTotalBalances = ServiceRecord<BalancePerChain>;
-export type ServiceTotalBalancesPerAccount = { [accountId: string]: ServiceTotalBalances };
-
-export type WalletTotalBalancesPerAccount = { [accoundId: string]: BalancePerChain };
-
-
-//// LEGACY
-
 export type CategoryTotalBalances = {|
   wallet?: BigNumber,
   deposits?: BigNumber,
@@ -117,4 +89,3 @@ export type CategoryBalancesPerChain = ChainRecord<CategoryAssetsBalances>;
 
 export type TotalBalancesPerChain = ChainRecord<BigNumber>;
 
-export type CollectibleCountPerChain = ChainRecord<number>;

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -23,6 +23,34 @@ import { BigNumber } from 'bignumber.js';
 // types
 import type { ChainRecord } from 'models/Chain';
 
+export type CategoryRecord<T> = {|
+  wallet?: T,
+  deposits?: T,
+  investments?: T,
+  liquidityPools?: T,
+  rewards?: T,
+|};
+
+export type ServiceRecord<T> = {|
+  deposits?: T,
+  investments?: T,
+  liquidityPools?: T,
+  rewards?: T,
+|};
+
+export type BalancePerChain = ChainRecord<BigNumber>;
+
+export type CategoryTotalBalancesX = CategoryRecord<BalancePerChain>;
+export type CategoryTotalBalancesPerAccount = { [accountId: string]: CategoryTotalBalancesX };
+
+export type ServiceTotalBalances = ServiceRecord<BalancePerChain>;
+export type ServiceTotalBalancesPerAccount = { [accountId: string]: ServiceTotalBalances };
+
+export type WalletTotalBalancesPerAccount = { [accoundId: string]: BalancePerChain };
+
+
+//// LEGACY
+
 export type CategoryTotalBalances = {|
   wallet?: BigNumber,
   deposits?: BigNumber,

--- a/src/models/Balances.js
+++ b/src/models/Balances.js
@@ -23,20 +23,6 @@ import { BigNumber } from 'bignumber.js';
 // types
 import type { ChainRecord } from 'models/Chain';
 
-export type CategoryTotalBalances = {|
-  wallet?: BigNumber,
-  deposits?: BigNumber,
-  investments?: BigNumber,
-  liquidityPools?: BigNumber,
-  rewards?: BigNumber,
-|};
-
-export type CategoryTotalBalancesPerChain = ChainRecord<CategoryTotalBalances>;
-
-export type ChainTotalBalancesPerAccount = {
-  [accountId: string]: CategoryTotalBalancesPerChain,
-};
-
 export type CategoryAssetsBalances = {|
   wallet?: WalletAssetsBalances,
   deposits?: DepositAssetBalance[],
@@ -86,6 +72,3 @@ export type AssetBalancesPerAccount = {
 };
 
 export type CategoryBalancesPerChain = ChainRecord<CategoryAssetsBalances>;
-
-export type TotalBalancesPerChain = ChainRecord<BigNumber>;
-

--- a/src/models/TotalBalances.js
+++ b/src/models/TotalBalances.js
@@ -1,0 +1,61 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2021 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+import { BigNumber } from 'bignumber.js';
+
+// types
+import type { AccountRecord } from 'models/Account';
+import type { ChainRecord } from 'models/Chain';
+
+/**
+ * Total balances are represented in top-down nesting:
+ *  - level 1. Account
+ *  - level 2. Category
+ *  - level 3. Chain
+ *
+ * This hierarchy represents the order in which they are most frequently used.
+ */
+
+// Category balances are calculated using selectors in redux
+export type CategoryRecord<T> = {|
+  wallet?: T,
+  deposits?: T,
+  investments?: T,
+  liquidityPools?: T,
+  rewards?: T,
+|};
+
+export type TotalBalances = AccountRecord<AccountTotalBalances>;
+export type AccountTotalBalances = CategoryRecord<CategoryTotalBalances>;
+export type CategoryTotalBalances = ChainRecord<BigNumber>;
+
+// Stored balances are stored directly in redux
+export type StoreRecord<T> = {|
+  deposits?: T,
+  investments?: T,
+  liquidityPools?: T,
+  rewards?: T,
+|};
+
+export type StoredTotalBalances = AccountRecord<StoredAccountTotalBalances>;
+export type StoredAccountTotalBalances = StoreRecord<CategoryTotalBalances>;
+
+// Wallet balances are calculated using selectors in redux
+export type WalletTotalBalances = AccountRecord<CategoryTotalBalances>;

--- a/src/models/TotalBalances.js
+++ b/src/models/TotalBalances.js
@@ -46,7 +46,7 @@ export type TotalBalances = AccountRecord<AccountTotalBalances>;
 export type AccountTotalBalances = CategoryRecord<ChainRecord<BigNumber>>;
 
 // Stored balances are stored directly in redux
-export type StoreRecord<T> = {|
+export type StoreCategoryRecord<T> = {|
   deposits?: T,
   investments?: T,
   liquidityPools?: T,
@@ -54,7 +54,7 @@ export type StoreRecord<T> = {|
 |};
 
 export type StoreTotalBalances = AccountRecord<StoreAccountTotalBalances>;
-export type StoreAccountTotalBalances = StoreRecord<ChainRecord<BigNumber>>;
+export type StoreAccountTotalBalances = StoreCategoryRecord<ChainRecord<BigNumber>>;
 
 // Wallet balances are calculated using selectors in redux
 export type WalletTotalBalances = AccountRecord<ChainRecord<BigNumber>>;

--- a/src/models/TotalBalances.js
+++ b/src/models/TotalBalances.js
@@ -35,11 +35,11 @@ import type { ChainRecord } from 'models/Chain';
 
 // Category balances are calculated using selectors in redux
 export type CategoryRecord<T> = {|
-  wallet?: T,
-  deposits?: T,
-  investments?: T,
-  liquidityPools?: T,
-  rewards?: T,
+  wallet: T,
+  deposits: T,
+  investments: T,
+  liquidityPools: T,
+  rewards: T,
 |};
 
 export type TotalBalances = AccountRecord<AccountTotalBalances>;
@@ -53,11 +53,8 @@ export type StoreRecord<T> = {|
   rewards?: T,
 |};
 
-export type StoredTotalBalances = AccountRecord<StoredAccountTotalBalances>;
-export type StoredAccountTotalBalances = StoreRecord<ChainRecord<BigNumber>>;
+export type StoreTotalBalances = AccountRecord<StoreAccountTotalBalances>;
+export type StoreAccountTotalBalances = StoreRecord<ChainRecord<BigNumber>>;
 
 // Wallet balances are calculated using selectors in redux
 export type WalletTotalBalances = AccountRecord<ChainRecord<BigNumber>>;
-
-// Collectibles do not have balances but are counted
-export type AccountCollectibleCount = ChainRecord<number>;

--- a/src/models/TotalBalances.js
+++ b/src/models/TotalBalances.js
@@ -59,3 +59,6 @@ export type StoredAccountTotalBalances = StoreRecord<CategoryTotalBalances>;
 
 // Wallet balances are calculated using selectors in redux
 export type WalletTotalBalances = AccountRecord<CategoryTotalBalances>;
+
+// Collectibles do not have balances but are counted
+export type AccountCollectibleCount = ChainRecord<number>;

--- a/src/models/TotalBalances.js
+++ b/src/models/TotalBalances.js
@@ -43,8 +43,7 @@ export type CategoryRecord<T> = {|
 |};
 
 export type TotalBalances = AccountRecord<AccountTotalBalances>;
-export type AccountTotalBalances = CategoryRecord<CategoryTotalBalances>;
-export type CategoryTotalBalances = ChainRecord<BigNumber>;
+export type AccountTotalBalances = CategoryRecord<ChainRecord<BigNumber>>;
 
 // Stored balances are stored directly in redux
 export type StoreRecord<T> = {|
@@ -55,10 +54,10 @@ export type StoreRecord<T> = {|
 |};
 
 export type StoredTotalBalances = AccountRecord<StoredAccountTotalBalances>;
-export type StoredAccountTotalBalances = StoreRecord<CategoryTotalBalances>;
+export type StoredAccountTotalBalances = StoreRecord<ChainRecord<BigNumber>>;
 
 // Wallet balances are calculated using selectors in redux
-export type WalletTotalBalances = AccountRecord<CategoryTotalBalances>;
+export type WalletTotalBalances = AccountRecord<ChainRecord<BigNumber>>;
 
 // Collectibles do not have balances but are counted
 export type AccountCollectibleCount = ChainRecord<number>;

--- a/src/reducers/totalBalancesReducer.js
+++ b/src/reducers/totalBalancesReducer.js
@@ -74,7 +74,7 @@ export const initialState = {
 
 const setNewBalance = (balancesState, accountId, chain, category, newBalance) => {
   const accountState = balancesState[accountId] ?? {};
-  const categoryState = accountState[category];
+  const categoryState = accountState[category] ?? {};
   return {
     ...balancesState,
     [accountId]: {

--- a/src/reducers/totalBalancesReducer.js
+++ b/src/reducers/totalBalancesReducer.js
@@ -30,12 +30,11 @@ import {
 import { BigNumber } from 'utils/common';
 
 // types
-import type { ServiceTotalBalancesPerAccount, ChainTotalBalancesPerAccount } from 'models/Balances';
+import type { ServiceTotalBalancesPerAccount } from 'models/Balances';
 
 
 export type TotalBalancesReducerState = {
-  data: ChainTotalBalancesPerAccount,
-  dataX: ServiceTotalBalancesPerAccount,
+  data: ServiceTotalBalancesPerAccount,
   isFetching: boolean,
 };
 
@@ -46,7 +45,7 @@ export type SetFetchingTotalBalancesAction = {|
 
 export type SetTotalBalancesAction = {|
   type: typeof SET_TOTAL_BALANCES,
-  payload: ChainTotalBalancesPerAccount,
+  payload: ServiceTotalBalancesPerAccount,
 |};
 
 export type SetAccountTotalChainCategoryBalanceAction = {|
@@ -71,20 +70,19 @@ export type TotalBalancesReducerAction = SetFetchingTotalBalancesAction
 
 export const initialState = {
   data: {},
-  dataX: {},
   isFetching: false,
 };
 
 const setNewBalance = (balancesState, accountId, chain, category, newBalance) => {
   const accountState = balancesState[accountId] ?? {};
-  const chainState = accountState[chain];
+  const categoryState = accountState[category];
   return {
     ...balancesState,
     [accountId]: {
       ...accountState,
-      [chain]: {
-        ...chainState,
-        [category]: newBalance,
+      [category]: {
+        ...categoryState,
+        [chain]: newBalance,
       },
     },
   };

--- a/src/reducers/totalBalancesReducer.js
+++ b/src/reducers/totalBalancesReducer.js
@@ -30,11 +30,12 @@ import {
 import { BigNumber } from 'utils/common';
 
 // types
-import type { ChainTotalBalancesPerAccount } from 'models/Balances';
+import type { ServiceTotalBalancesPerAccount, ChainTotalBalancesPerAccount } from 'models/Balances';
 
 
 export type TotalBalancesReducerState = {
   data: ChainTotalBalancesPerAccount,
+  dataX: ServiceTotalBalancesPerAccount,
   isFetching: boolean,
 };
 
@@ -70,19 +71,24 @@ export type TotalBalancesReducerAction = SetFetchingTotalBalancesAction
 
 export const initialState = {
   data: {},
+  dataX: {},
   isFetching: false,
 };
 
-const setNewBalance = (balancesState, accountId, chain, category, newBalance) => ({
-  ...balancesState,
-  [accountId]: {
-    ...(balancesState?.[accountId] ?? {}),
-    [chain]: {
-      ...(balancesState?.[accountId]?.[chain] ?? {}),
-      [category]: newBalance,
+const setNewBalance = (balancesState, accountId, chain, category, newBalance) => {
+  const accountState = balancesState[accountId] ?? {};
+  const chainState = accountState[chain];
+  return {
+    ...balancesState,
+    [accountId]: {
+      ...accountState,
+      [chain]: {
+        ...chainState,
+        [category]: newBalance,
+      },
     },
-  },
-});
+  };
+};
 
 
 export default function totalBalancesReducer(

--- a/src/reducers/totalBalancesReducer.js
+++ b/src/reducers/totalBalancesReducer.js
@@ -30,11 +30,10 @@ import {
 import { BigNumber } from 'utils/common';
 
 // types
-import type { ServiceTotalBalancesPerAccount } from 'models/Balances';
-
+import type { StoreTotalBalances } from 'models/TotalBalances';
 
 export type TotalBalancesReducerState = {
-  data: ServiceTotalBalancesPerAccount,
+  data: StoreTotalBalances,
   isFetching: boolean,
 };
 
@@ -45,7 +44,7 @@ export type SetFetchingTotalBalancesAction = {|
 
 export type SetTotalBalancesAction = {|
   type: typeof SET_TOTAL_BALANCES,
-  payload: ServiceTotalBalancesPerAccount,
+  payload: StoreTotalBalances,
 |};
 
 export type SetAccountTotalChainCategoryBalanceAction = {|

--- a/src/screens/Accounts/Accounts.js
+++ b/src/screens/Accounts/Accounts.js
@@ -33,13 +33,12 @@ import Button from 'components/Button';
 
 // utils
 import { getAccountName, isNotKeyBasedType } from 'utils/accounts';
+import { calculateTotalBalance } from 'utils/totalBalances';
 import { spacing } from 'utils/variables';
 import { images } from 'utils/images';
 import { responsiveSize } from 'utils/ui';
 import { useTheme } from 'utils/themes';
-import { getTotalCategoryBalances } from 'screens/Home/utils';
 import { formatFiat } from 'utils/common';
-import { getTotalBalance } from 'utils/balances';
 
 // constants
 import { KEY_BASED_ASSET_TRANSFER_INTRO } from 'constants/navigationConstants';
@@ -52,18 +51,19 @@ import { switchAccountAction } from 'actions/accountsActions';
 import { fetchAllAccountsTotalBalancesAction } from 'actions/assetsActions';
 
 // selectors
-import { totalBalancesSelector, keyBasedWalletHasPositiveBalanceSelector } from 'selectors/balances';
 import { useFiatCurrency } from 'selectors';
+import { keyBasedWalletHasPositiveBalanceSelector } from 'selectors/balances';
+import { totalBalancesSelector } from 'selectors/totalBalances';
 
 // services
 import { firebaseRemoteConfig } from 'services/firebase';
 
 // types
+import type { RenderItemProps } from 'utils/types/react-native';
 import type { Account } from 'models/Account';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { BlockchainNetwork } from 'models/BlockchainNetwork';
-import type { RenderItemProps } from 'utils/types/react-native';
-import type { ChainTotalBalancesPerAccount } from 'models/Balances';
+import type { TotalBalances } from 'models/TotalBalances';
 
 
 const ITEM_TYPE = {
@@ -87,7 +87,7 @@ type Props = {|
   switchAccount: (accountId: string) => void,
   fetchAllAccountsTotalBalances: () => void,
   keyBasedWalletHasPositiveBalance: boolean,
-  totalBalances: ChainTotalBalancesPerAccount,
+  totalBalances: TotalBalances,
 |};
 
 const AccountsScreen = ({
@@ -164,8 +164,7 @@ const AccountsScreen = ({
       const { id, isActive, type } = account;
       const isActiveWallet = !!isActive && isEthereumActive;
 
-      const totalCategoryBalances = getTotalCategoryBalances(totalBalances[id] ?? {});
-      const totalBalance = getTotalBalance(totalCategoryBalances);
+      const totalBalance = calculateTotalBalance(totalBalances[id] ?? {});
       const totalBalanceFormatted = formatFiat(totalBalance, fiatCurrency);
 
       return {

--- a/src/screens/Assets/deposits/DepositsTab.js
+++ b/src/screens/Assets/deposits/DepositsTab.js
@@ -54,7 +54,7 @@ import type { DepositAssetBalance } from 'models/Balances';
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
 import ServiceListHeader from '../components/ServiceListHeader';
 import DepositListItem from './DepositListItem';
-import { useDepositsBalance, useDepositsChainBalances, useDepositsAssets } from './selectors';
+import { useDepositsTotalBalance, useDepositsBalancePerChain, useDepositsAssets } from './selectors';
 
 function DepositsTab() {
   const { t, tRoot } = useTranslationWithPrefix('assets.deposits');
@@ -64,7 +64,7 @@ function DepositsTab() {
   const initialChain: ?Chain = navigation.getParam('chain');
   const { expandItemsPerChain, toggleExpandItems } = useExpandItemsPerChain(initialChain);
 
-  const totalBalance = useDepositsBalance();
+  const totalBalance = useDepositsTotalBalance();
   const sections = useSectionData(expandItemsPerChain);
   const currency = useFiatCurrency();
 
@@ -127,7 +127,7 @@ type Section = {
 
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
-  const balancePerChain = useDepositsChainBalances();
+  const balancePerChain = useDepositsBalancePerChain();
   const assetsPerChain = useDepositsAssets();
 
   return chains.map((chain) => {

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -34,12 +34,12 @@ import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 import type { DepositAssetBalance } from 'models/Balances';
 
-export function useDepositsBalance(): FiatBalance {
-  const value = sumRecord(useDepositsChainBalances());
+export function useDepositsTotalBalance(): FiatBalance {
+  const value = sumRecord(useDepositsBalancePerChain());
   return { value };
 }
 
-export function useDepositsChainBalances(): ChainRecord<BigNumber> {
+export function useDepositsBalancePerChain(): ChainRecord<BigNumber> {
   return useRootSelector(accountDepositsBalancePerChainSelector);
 }
 

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -23,7 +23,7 @@ import { BigNumber } from 'bignumber.js';
 // Selectors
 import { useRootSelector } from 'selectors';
 import { accountAssetsBalancesSelector } from 'selectors/balances';
-import { accountDepositsTotalBalancesSelector } from 'selectors/totalBalances';
+import { accountDepositsBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainDepositAssetsBalances } from 'utils/balances';
@@ -40,7 +40,7 @@ export function useDepositsBalance(): FiatBalance {
 }
 
 export function useDepositsChainBalances(): ChainRecord<BigNumber> {
-  return useRootSelector(accountDepositsTotalBalancesSelector);
+  return useRootSelector(accountDepositsBalancePerChainSelector);
 }
 
 export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {

--- a/src/screens/Assets/deposits/selectors.js
+++ b/src/screens/Assets/deposits/selectors.js
@@ -18,29 +18,29 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+import { BigNumber } from 'bignumber.js';
+
 // Selectors
 import { useRootSelector } from 'selectors';
-import {
-  accountAssetsBalancesSelector,
-  depositsTotalBalanceByChainsSelector,
-  depositsTotalBalanceSelector,
-} from 'selectors/balances';
+import { accountAssetsBalancesSelector } from 'selectors/balances';
+import { accountDepositsTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainDepositAssetsBalances } from 'utils/balances';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { DepositAssetBalance, TotalBalancesPerChain } from 'models/Balances';
+import type { DepositAssetBalance } from 'models/Balances';
 
 export function useDepositsBalance(): FiatBalance {
-  const value = useRootSelector(depositsTotalBalanceSelector);
+  const value = sumRecord(useDepositsChainBalances());
   return { value };
 }
 
-export function useDepositsChainBalances(): TotalBalancesPerChain {
-  return useRootSelector(depositsTotalBalanceByChainsSelector);
+export function useDepositsChainBalances(): ChainRecord<BigNumber> {
+  return useRootSelector(accountDepositsTotalBalancesSelector);
 }
 
 export function useDepositsAssets(): ChainRecord<DepositAssetBalance[]> {

--- a/src/screens/Assets/investments/InvestmentsTab.js
+++ b/src/screens/Assets/investments/InvestmentsTab.js
@@ -53,8 +53,8 @@ import type { InvestmentAssetBalance } from 'models/Balances';
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
 import ServiceListHeader from '../components/ServiceListHeader';
 import {
-  useInvestmentsBalance,
-  useInvestmentsChainBalances,
+  useInvestmentsTotalBalance,
+  useInvestmentsBalancePerChain,
   useInvestmentAssets,
 } from './selectors';
 import InvestmentListItem from './InvestmentListItem';
@@ -67,7 +67,7 @@ function InvestmentsTab() {
   const initialChain: ?Chain = navigation.getParam('chain');
   const { expandItemsPerChain, toggleExpandItems } = useExpandItemsPerChain(initialChain);
 
-  const totalBalance = useInvestmentsBalance();
+  const totalBalance = useInvestmentsTotalBalance();
   const sections = useSectionData(expandItemsPerChain);
   const currency = useFiatCurrency();
 
@@ -127,7 +127,7 @@ type Section = {
 
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
-  const balancePerChain = useInvestmentsChainBalances();
+  const balancePerChain = useInvestmentsBalancePerChain();
   const assetsPerChain = useInvestmentAssets();
 
   return chains.map((chain) => {

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -23,7 +23,7 @@ import { BigNumber } from 'bignumber.js';
 // Selectors
 import { useRootSelector } from 'selectors';
 import { accountAssetsBalancesSelector } from 'selectors/balances';
-import { accountInvestmentsTotalBalancesSelector } from 'selectors/totalBalances';
+import { accountInvestmentsBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainInvestmentAssetsBalances } from 'utils/balances';
@@ -40,7 +40,7 @@ export function useInvestmentsBalance(): FiatBalance {
 }
 
 export function useInvestmentsChainBalances(): ChainRecord<BigNumber> {
-  return useRootSelector(accountInvestmentsTotalBalancesSelector);
+  return useRootSelector(accountInvestmentsBalancePerChainSelector);
 }
 
 export function useInvestmentAssets(): ChainRecord<InvestmentAssetBalance[]> {

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -34,12 +34,12 @@ import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 import type { InvestmentAssetBalance } from 'models/Balances';
 
-export function useInvestmentsBalance(): FiatBalance {
-  const value = sumRecord(useInvestmentsChainBalances());
+export function useInvestmentsTotalBalance(): FiatBalance {
+  const value = sumRecord(useInvestmentsBalancePerChain());
   return { value };
 }
 
-export function useInvestmentsChainBalances(): ChainRecord<BigNumber> {
+export function useInvestmentsBalancePerChain(): ChainRecord<BigNumber> {
   return useRootSelector(accountInvestmentsBalancePerChainSelector);
 }
 

--- a/src/screens/Assets/investments/selectors.js
+++ b/src/screens/Assets/investments/selectors.js
@@ -18,29 +18,29 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+import { BigNumber } from 'bignumber.js';
+
 // Selectors
 import { useRootSelector } from 'selectors';
-import {
-  accountAssetsBalancesSelector,
-  investmentsTotalBalanceByChainsSelector,
-  investmentsTotalBalanceSelector,
-} from 'selectors/balances';
+import { accountAssetsBalancesSelector } from 'selectors/balances';
+import { accountInvestmentsTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainInvestmentAssetsBalances } from 'utils/balances';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { InvestmentAssetBalance, TotalBalancesPerChain } from 'models/Balances';
+import type { InvestmentAssetBalance } from 'models/Balances';
 
 export function useInvestmentsBalance(): FiatBalance {
-  const value = useRootSelector(investmentsTotalBalanceSelector);
+  const value = sumRecord(useInvestmentsChainBalances());
   return { value };
 }
 
-export function useInvestmentsChainBalances(): TotalBalancesPerChain {
-  return useRootSelector(investmentsTotalBalanceByChainsSelector);
+export function useInvestmentsChainBalances(): ChainRecord<BigNumber> {
+  return useRootSelector(accountInvestmentsTotalBalancesSelector);
 }
 
 export function useInvestmentAssets(): ChainRecord<InvestmentAssetBalance[]> {

--- a/src/screens/Assets/liquidityPools/LiquidityPoolsTab.js
+++ b/src/screens/Assets/liquidityPools/LiquidityPoolsTab.js
@@ -53,8 +53,8 @@ import type { LiquidityPoolAssetBalance } from 'models/Balances';
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
 import ServiceListHeader from '../components/ServiceListHeader';
 import {
-  useLiquidityPoolsBalance,
-  useLiquidityPoolsChainBalances,
+  useLiquidityPoolsTotalBalance,
+  useLiquidityPoolsBalancePerChain,
   useLiquidityPoolAssets,
 } from './selectors';
 import LiquidityPoolListItem from './LiquidityPoolListItem';
@@ -67,7 +67,7 @@ function LiquidityPoolsTab() {
   const initialChain: ?Chain = navigation.getParam('chain');
   const { expandItemsPerChain, toggleExpandItems } = useExpandItemsPerChain(initialChain);
 
-  const totalBalance = useLiquidityPoolsBalance();
+  const totalBalance = useLiquidityPoolsTotalBalance();
   const sections = useSectionData(expandItemsPerChain);
   const currency = useFiatCurrency();
 
@@ -135,7 +135,7 @@ type Section = {
 
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
-  const balancePerChain = useLiquidityPoolsChainBalances();
+  const balancePerChain = useLiquidityPoolsBalancePerChain();
   const assetsPerChain = useLiquidityPoolAssets();
 
   return chains.map((chain) => {

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -18,29 +18,29 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+import type { BigNumber } from 'bignumber.js';
+
 // Selectors
 import { useRootSelector } from 'selectors';
-import {
-  accountAssetsBalancesSelector,
-  liquidityPoolsTotalBalanceByChainsSelector,
-  liquidityPoolsTotalBalanceSelector,
-} from 'selectors/balances';
+import { accountAssetsBalancesSelector } from 'selectors/balances';
+import { accountLiquidityPoolsTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainLiquidityPoolAssetsBalances } from 'utils/balances';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
-import type { LiquidityPoolAssetBalance, TotalBalancesPerChain } from 'models/Balances';
+import type { LiquidityPoolAssetBalance } from 'models/Balances';
 
 export function useLiquidityPoolsBalance(): FiatBalance {
-  const value = useRootSelector(liquidityPoolsTotalBalanceSelector);
+  const value = sumRecord(useLiquidityPoolsChainBalances());
   return { value };
 }
 
-export function useLiquidityPoolsChainBalances(): TotalBalancesPerChain {
-  return useRootSelector(liquidityPoolsTotalBalanceByChainsSelector);
+export function useLiquidityPoolsChainBalances(): ChainRecord<BigNumber> {
+  return useRootSelector(accountLiquidityPoolsTotalBalancesSelector);
 }
 
 export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolAssetBalance[]> {

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -34,12 +34,12 @@ import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 import type { LiquidityPoolAssetBalance } from 'models/Balances';
 
-export function useLiquidityPoolsBalance(): FiatBalance {
-  const value = sumRecord(useLiquidityPoolsChainBalances());
+export function useLiquidityPoolsTotalBalance(): FiatBalance {
+  const value = sumRecord(useLiquidityPoolsBalancePerChain());
   return { value };
 }
 
-export function useLiquidityPoolsChainBalances(): ChainRecord<BigNumber> {
+export function useLiquidityPoolsBalancePerChain(): ChainRecord<BigNumber> {
   return useRootSelector(accountLiquidityPoolsBalancePerChainSelector);
 }
 

--- a/src/screens/Assets/liquidityPools/selectors.js
+++ b/src/screens/Assets/liquidityPools/selectors.js
@@ -23,7 +23,7 @@ import type { BigNumber } from 'bignumber.js';
 // Selectors
 import { useRootSelector } from 'selectors';
 import { accountAssetsBalancesSelector } from 'selectors/balances';
-import { accountLiquidityPoolsTotalBalancesSelector } from 'selectors/totalBalances';
+import { accountLiquidityPoolsBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
 import { getChainLiquidityPoolAssetsBalances } from 'utils/balances';
@@ -40,7 +40,7 @@ export function useLiquidityPoolsBalance(): FiatBalance {
 }
 
 export function useLiquidityPoolsChainBalances(): ChainRecord<BigNumber> {
-  return useRootSelector(accountLiquidityPoolsTotalBalancesSelector);
+  return useRootSelector(accountLiquidityPoolsBalancePerChainSelector);
 }
 
 export function useLiquidityPoolAssets(): ChainRecord<LiquidityPoolAssetBalance[]> {

--- a/src/screens/Assets/rewards/RewardsTab.js
+++ b/src/screens/Assets/rewards/RewardsTab.js
@@ -46,7 +46,7 @@ import type { Chain } from 'models/Chain';
 
 // Local
 import { type FlagPerChain, useExpandItemsPerChain } from '../utils';
-import { type RewardItem, useRewardsBalance, useRewardsChainBalances, useRewardsAssets } from './selectors';
+import { type RewardItem, useRewardsTotalBalance, useRewardsBalancePerChain, useRewardsAssets } from './selectors';
 import RewardListItem from './RewardListItem';
 
 function RewardsTab() {
@@ -58,7 +58,7 @@ function RewardsTab() {
   const initialChain: ?Chain = navigation.getParam('chain');
   const { expandItemsPerChain, toggleExpandItems } = useExpandItemsPerChain(initialChain);
 
-  const totalBalance = useRewardsBalance();
+  const totalBalance = useRewardsTotalBalance();
   const sections = useSectionData(expandItemsPerChain);
 
   const renderListHeader = () => {
@@ -102,7 +102,7 @@ type Section = {
 
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
-  const balancePerChain = useRewardsChainBalances();
+  const balancePerChain = useRewardsBalancePerChain();
   const assetsPerChain = useRewardsAssets();
 
   return chains.map((chain) => {

--- a/src/screens/Assets/rewards/selectors.js
+++ b/src/screens/Assets/rewards/selectors.js
@@ -30,11 +30,11 @@ import { sumRecord } from 'utils/bigNumber';
 // Types
 import type { ChainRecord } from 'models/Chain';
 
-export function useRewardsBalance(): BigNumber {
-  return sumRecord(useRewardsChainBalances());
+export function useRewardsTotalBalance(): BigNumber {
+  return sumRecord(useRewardsBalancePerChain());
 }
 
-export function useRewardsChainBalances(): ChainRecord<BigNumber> {
+export function useRewardsBalancePerChain(): ChainRecord<BigNumber> {
   return useRootSelector(accountRewardsBalancePerChainSelector);
 }
 export type RewardItem = {|

--- a/src/screens/Assets/rewards/selectors.js
+++ b/src/screens/Assets/rewards/selectors.js
@@ -22,20 +22,21 @@ import { BigNumber } from 'bignumber.js';
 
 // Selectors
 import { useRootSelector } from 'selectors';
-import { rewardsTotalBalanceByChainsSelector, rewardsTotalBalanceSelector } from 'selectors/balances';
+import { accountRewardsBalancesSelector } from 'selectors/totalBalances';
+
+// Utils
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
-import type { TotalBalancesPerChain } from 'models/Balances';
 
 export function useRewardsBalance(): BigNumber {
-  return useRootSelector(rewardsTotalBalanceSelector);
+  return sumRecord(useRewardsChainBalances());
 }
 
-export function useRewardsChainBalances(): TotalBalancesPerChain {
-  return useRootSelector(rewardsTotalBalanceByChainsSelector);
+export function useRewardsChainBalances(): ChainRecord<BigNumber> {
+  return useRootSelector(accountRewardsBalancesSelector);
 }
-
 export type RewardItem = {|
   key: string,
   service: string,

--- a/src/screens/Assets/rewards/selectors.js
+++ b/src/screens/Assets/rewards/selectors.js
@@ -22,7 +22,7 @@ import { BigNumber } from 'bignumber.js';
 
 // Selectors
 import { useRootSelector } from 'selectors';
-import { accountRewardsBalancesSelector } from 'selectors/totalBalances';
+import { accountRewardsBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
 import { sumRecord } from 'utils/bigNumber';
@@ -35,7 +35,7 @@ export function useRewardsBalance(): BigNumber {
 }
 
 export function useRewardsChainBalances(): ChainRecord<BigNumber> {
-  return useRootSelector(accountRewardsBalancesSelector);
+  return useRootSelector(accountRewardsBalancePerChainSelector);
 }
 export type RewardItem = {|
   key: string,

--- a/src/screens/Assets/wallet/WalletTab.js
+++ b/src/screens/Assets/wallet/WalletTab.js
@@ -57,7 +57,7 @@ import type { Chain } from 'models/Chain';
 import PillarPaySummary from '../components/PillarPaySummary';
 import WalletListItem from './WalletListItem';
 import { type FlagPerChain, useExpandItemsPerChain, buildAssetDataNavigationParam } from '../utils';
-import { type WalletItem, useWalletTotalBalance, useWalletBalancePerChain, useWalletAssets } from './selectors';
+import { type WalletItem, useWalletTotalBalance, useWalletBalancePerChain, useWalletAssetsPerChain } from './selectors';
 
 function WalletTab() {
   const { tRoot } = useTranslationWithPrefix('assets.wallet');
@@ -171,7 +171,7 @@ type Section = {
 
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
-  const assetsPerChain = useWalletAssets();
+  const assetsPerChain = useWalletAssetsPerChain();
   const balancePerChain = useWalletBalancePerChain();
 
   return chains.map((chain) => {

--- a/src/screens/Assets/wallet/WalletTab.js
+++ b/src/screens/Assets/wallet/WalletTab.js
@@ -43,7 +43,6 @@ import { ASSET, EXCHANGE_FLOW, SEND_TOKEN_FROM_HOME_FLOW } from 'constants/navig
 import { useRootSelector, useFiatCurrency, activeAccountAddressSelector } from 'selectors';
 import { assetRegistrySelector } from 'selectors/assets';
 import { useIsPillarPaySupported } from 'selectors/archanova';
-import { walletBalancesPerChainSelector } from 'selectors/balances';
 import { useSupportedChains } from 'selectors/chains';
 
 // Utils
@@ -58,7 +57,7 @@ import type { Chain } from 'models/Chain';
 import PillarPaySummary from '../components/PillarPaySummary';
 import WalletListItem from './WalletListItem';
 import { type FlagPerChain, useExpandItemsPerChain, buildAssetDataNavigationParam } from '../utils';
-import { type WalletItem, useWalletBalance, useWalletAssets } from './selectors';
+import { type WalletItem, useWalletBalance, useWalletBalancePerChain, useWalletAssets } from './selectors';
 
 function WalletTab() {
   const { tRoot } = useTranslationWithPrefix('assets.wallet');
@@ -173,7 +172,7 @@ type Section = {
 const useSectionData = (expandItemsPerChain: FlagPerChain): Section[] => {
   const chains = useSupportedChains();
   const assetsPerChain = useWalletAssets();
-  const balancePerChain = useRootSelector(walletBalancesPerChainSelector);
+  const balancePerChain = useWalletBalancePerChain();
 
   return chains.map((chain) => {
     const items = assetsPerChain[chain] ?? [];

--- a/src/screens/Assets/wallet/WalletTab.js
+++ b/src/screens/Assets/wallet/WalletTab.js
@@ -57,7 +57,7 @@ import type { Chain } from 'models/Chain';
 import PillarPaySummary from '../components/PillarPaySummary';
 import WalletListItem from './WalletListItem';
 import { type FlagPerChain, useExpandItemsPerChain, buildAssetDataNavigationParam } from '../utils';
-import { type WalletItem, useWalletBalance, useWalletBalancePerChain, useWalletAssets } from './selectors';
+import { type WalletItem, useWalletTotalBalance, useWalletBalancePerChain, useWalletAssets } from './selectors';
 
 function WalletTab() {
   const { tRoot } = useTranslationWithPrefix('assets.wallet');
@@ -67,7 +67,7 @@ function WalletTab() {
   const initialChain: ?Chain = navigation.getParam('chain');
   const { expandItemsPerChain, toggleExpandItems } = useExpandItemsPerChain(initialChain);
 
-  const totalBalance = useWalletBalance();
+  const totalBalance = useWalletTotalBalance();
   const sections = useSectionData(expandItemsPerChain);
   const currency = useFiatCurrency();
   const assetRegistry = useRootSelector(assetRegistrySelector);

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -23,7 +23,7 @@ import { BigNumber } from 'bignumber.js';
 // Selectors
 import { useRootSelector } from 'selectors';
 import { visibleActiveAccountAssetsWithBalanceSelector } from 'selectors/assets';
-import { accountWalletTotalBalancesSelector } from 'selectors/totalBalances';
+import { accountWalletBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
 import { defaultSortAssetOptions } from 'utils/assets';
@@ -39,7 +39,7 @@ export function useWalletBalance(): FiatBalance {
 }
 
 export function useWalletBalancePerChain(): ChainRecord<BigNumber> {
-  return useRootSelector(accountWalletTotalBalancesSelector);
+  return useRootSelector(accountWalletBalancePerChainSelector);
 }
 
 export type WalletItem = {|

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -19,6 +19,7 @@
 */
 
 import { BigNumber } from 'bignumber.js';
+import { mapValues } from 'lodash';
 
 // Selectors
 import { useRootSelector, supportedAssetsSelector } from 'selectors';
@@ -31,7 +32,7 @@ import { findSupportedAssetBySymbol } from 'utils/assets';
 import { getChainWalletAssetsBalances } from 'utils/balances';
 import { sumRecord } from 'utils/bigNumber';
 import { getImageUrl } from 'utils/images';
-import { recordValues, mapRecordValues } from 'utils/object';
+import { recordValues } from 'utils/object';
 
 // Types
 import type { Asset } from 'models/Asset';
@@ -61,7 +62,7 @@ export const useWalletAssetsPerChain = (): ChainRecord<WalletItem[]> => {
   const walletAssetsPerChain = getChainWalletAssetsBalances(useRootSelector(accountAssetsBalancesSelector));
   const supportedAssets = useRootSelector(supportedAssetsSelector);
 
-  return mapRecordValues(walletAssetsPerChain, (balancesRecord: WalletAssetsBalances, chain: Chain) => {
+  return mapValues(walletAssetsPerChain, (balancesRecord: WalletAssetsBalances, chain: Chain) => {
     const balanceList = recordValues(balancesRecord);
     return mapNotNil(balanceList, (balance) => buildWalletItem(balance, chain, supportedAssets));
   });

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -19,7 +19,6 @@
 */
 
 import { BigNumber } from 'bignumber.js';
-import { mapValues } from 'lodash';
 
 // Selectors
 import { useRootSelector, supportedAssetsSelector } from 'selectors';
@@ -30,6 +29,7 @@ import { accountWalletBalancePerChainSelector } from 'selectors/totalBalances';
 import { mapNotNil } from 'utils/array';
 import { findSupportedAssetBySymbol } from 'utils/assets';
 import { getChainWalletAssetsBalances } from 'utils/balances';
+import { mapChainRecordValues } from 'utils/chains';
 import { sumRecord } from 'utils/bigNumber';
 import { getImageUrl } from 'utils/images';
 import { recordValues } from 'utils/object';
@@ -62,7 +62,7 @@ export const useWalletAssetsPerChain = (): ChainRecord<WalletItem[]> => {
   const walletAssetsPerChain = getChainWalletAssetsBalances(useRootSelector(accountAssetsBalancesSelector));
   const supportedAssets = useRootSelector(supportedAssetsSelector);
 
-  return mapValues(walletAssetsPerChain, (balancesRecord: WalletAssetsBalances, chain: Chain) => {
+  return mapChainRecordValues(walletAssetsPerChain, (balancesRecord: WalletAssetsBalances, chain: Chain) => {
     const balanceList = recordValues(balancesRecord);
     return mapNotNil(balanceList, (balance) => buildWalletItem(balance, chain, supportedAssets));
   });

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -23,18 +23,23 @@ import { BigNumber } from 'bignumber.js';
 // Selectors
 import { useRootSelector } from 'selectors';
 import { visibleActiveAccountAssetsWithBalanceSelector } from 'selectors/assets';
-import { walletTotalBalanceSelector } from 'selectors/balances';
+import { accountWalletTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
 import { defaultSortAssetOptions } from 'utils/assets';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 
 export function useWalletBalance(): FiatBalance {
-  const value = useRootSelector(walletTotalBalanceSelector);
+  const value = sumRecord(useWalletBalancePerChain());
   return { value };
+}
+
+export function useWalletBalancePerChain(): ChainRecord<BigNumber> {
+  return useRootSelector(accountWalletTotalBalancesSelector);
 }
 
 export type WalletItem = {|

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -33,7 +33,7 @@ import { sumRecord } from 'utils/bigNumber';
 import type { ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 
-export function useWalletBalance(): FiatBalance {
+export function useWalletTotalBalance(): FiatBalance {
   const value = sumRecord(useWalletBalancePerChain());
   return { value };
 }

--- a/src/screens/Assets/wallet/selectors.js
+++ b/src/screens/Assets/wallet/selectors.js
@@ -21,16 +21,22 @@
 import { BigNumber } from 'bignumber.js';
 
 // Selectors
-import { useRootSelector } from 'selectors';
-import { visibleActiveAccountAssetsWithBalanceSelector } from 'selectors/assets';
+import { useRootSelector, supportedAssetsSelector } from 'selectors';
+import { accountAssetsBalancesSelector } from 'selectors/balances';
 import { accountWalletBalancePerChainSelector } from 'selectors/totalBalances';
 
 // Utils
-import { defaultSortAssetOptions } from 'utils/assets';
+import { mapNotNil } from 'utils/array';
+import { findSupportedAssetBySymbol } from 'utils/assets';
+import { getChainWalletAssetsBalances } from 'utils/balances';
 import { sumRecord } from 'utils/bigNumber';
+import { getImageUrl } from 'utils/images';
+import { recordValues, mapRecordValues } from 'utils/object';
 
 // Types
-import type { ChainRecord } from 'models/Chain';
+import type { Asset } from 'models/Asset';
+import type { WalletAssetBalance, WalletAssetsBalances } from 'models/Balances';
+import type { Chain, ChainRecord } from 'models/Chain';
 import type { FiatBalance } from 'models/Value';
 
 export function useWalletTotalBalance(): FiatBalance {
@@ -51,16 +57,25 @@ export type WalletItem = {|
   change?: BigNumber,
 |};
 
-export const useWalletAssets = (): ChainRecord<WalletItem[]> => {
-  const assets = useRootSelector(visibleActiveAccountAssetsWithBalanceSelector);
+export const useWalletAssetsPerChain = (): ChainRecord<WalletItem[]> => {
+  const walletAssetsPerChain = getChainWalletAssetsBalances(useRootSelector(accountAssetsBalancesSelector));
+  const supportedAssets = useRootSelector(supportedAssetsSelector);
 
-  const ethereum = defaultSortAssetOptions(assets).map((asset) => ({
-    key: `ethereum-${asset.address ?? ''}`,
+  return mapRecordValues(walletAssetsPerChain, (balancesRecord: WalletAssetsBalances, chain: Chain) => {
+    const balanceList = recordValues(balancesRecord);
+    return mapNotNil(balanceList, (balance) => buildWalletItem(balance, chain, supportedAssets));
+  });
+};
+
+const buildWalletItem = ({ symbol, balance }: WalletAssetBalance, chain: Chain, supportedAssets: Asset[]) => {
+  const asset = findSupportedAssetBySymbol(supportedAssets, symbol);
+  if (!asset) return null;
+
+  return {
+    key: `${chain}-${symbol}`,
     title: asset.name,
-    iconUrl: asset.imageUrl,
+    iconUrl: getImageUrl(asset.iconUrl, 3),
     symbol: asset.symbol,
-    value: BigNumber(asset.balance?.balance ?? 0),
-  }));
-
-  return { ethereum };
+    value: BigNumber(balance || 0),
+  };
 };

--- a/src/screens/Home/AssetsSection.js
+++ b/src/screens/Home/AssetsSection.js
@@ -44,18 +44,19 @@ import { useChainsConfig, useAssetCategoriesConfig } from 'utils/uiConfig';
 import { spacing } from 'utils/variables';
 
 // Types
-import type { CategoryTotalBalancesPerChain, CategoryTotalBalances, CollectibleCountPerChain } from 'models/Balances';
+import type { CategoryTotalBalances, CollectibleCountPerChain } from 'models/Balances';
+import type { AccountTotalBalances } from 'models/TotalBalances';
 import type { AssetCategory } from 'models/AssetCategory';
 import type { Chain } from 'models/Chain';
 
 // Local
 import CategoryListItem from './components/CategoryListItem';
 import ChainListItem from './components/ChainListItem';
-import { getTotalCollectibleCount } from './utils';
+import { calculateTotalCollectibleCount } from './utils';
 
 type Props = {|
   categoryBalances: CategoryTotalBalances,
-  categoryBalancesPerChain: CategoryTotalBalancesPerChain,
+  categoryBalancesPerChain: AccountTotalBalances,
   collectibleCountPerChain: CollectibleCountPerChain,
 |};
 
@@ -75,7 +76,7 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
   const chainsConfig = useChainsConfig();
   const categoriesConfig = useAssetCategoriesConfig();
 
-  const totalCollectibleCount = getTotalCollectibleCount(collectibleCountPerChain);
+  const totalCollectibleCount = calculateTotalCollectibleCount(collectibleCountPerChain);
 
   const navigateToAssetDetails = (category: AssetCategory, chain: Chain) => {
     navigation.navigate(ASSETS, { category, chain });
@@ -119,7 +120,7 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
   };
 
   const renderChainWithBalance = (category: $Keys<CategoryTotalBalances>, chain: Chain) => {
-    const balance = categoryBalancesPerChain?.[chain]?.[category] ?? BigNumber(0);
+    const balance = categoryBalancesPerChain?.[category]?.[chain] ?? BigNumber(0);
     const formattedBalance = formatFiatValue(balance, fiatCurrency);
 
     const { title } = chainsConfig[chain];

--- a/src/screens/Home/AssetsSection.js
+++ b/src/screens/Home/AssetsSection.js
@@ -40,14 +40,15 @@ import { useDeploymentStatus } from 'hooks/deploymentStatus';
 // Utils
 import { formatValue, formatFiatValue } from 'utils/format';
 import { LIST_ITEMS_APPEARANCE } from 'utils/layoutAnimations';
+import { calculateTotalBalancePerCategory } from 'utils/totalBalances';
 import { useChainsConfig, useAssetCategoriesConfig } from 'utils/uiConfig';
 import { spacing } from 'utils/variables';
 
 // Types
-import type { CategoryTotalBalances, CollectibleCountPerChain } from 'models/Balances';
-import type { AccountTotalBalances } from 'models/TotalBalances';
 import type { AssetCategory } from 'models/AssetCategory';
-import type { Chain } from 'models/Chain';
+import type { Chain, ChainRecord } from 'models/Chain';
+import type { AccountTotalBalances, CategoryRecord } from 'models/TotalBalances';
+
 
 // Local
 import CategoryListItem from './components/CategoryListItem';
@@ -55,14 +56,13 @@ import ChainListItem from './components/ChainListItem';
 import { calculateTotalCollectibleCount } from './utils';
 
 type Props = {|
-  categoryBalances: CategoryTotalBalances,
-  categoryBalancesPerChain: AccountTotalBalances,
-  collectibleCountPerChain: CollectibleCountPerChain,
+  accountTotalBalances: AccountTotalBalances,
+  accountCollectibleCounts: ChainRecord<number>,
 |};
 
 type FlagPerCategory = { [AssetCategory]: ?boolean };
 
-function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectibleCountPerChain }: Props) {
+function AssetsSection({ accountTotalBalances, accountCollectibleCounts }: Props) {
   const { t } = useTranslationWithPrefix('home.assets');
   const navigation = useNavigation();
 
@@ -76,7 +76,8 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
   const chainsConfig = useChainsConfig();
   const categoriesConfig = useAssetCategoriesConfig();
 
-  const totalCollectibleCount = calculateTotalCollectibleCount(collectibleCountPerChain);
+  const balancePerCategory = calculateTotalBalancePerCategory(accountTotalBalances);
+  const totalCollectibleCount = calculateTotalCollectibleCount(accountCollectibleCounts);
 
   const navigateToAssetDetails = (category: AssetCategory, chain: Chain) => {
     navigation.navigate(ASSETS, { category, chain });
@@ -98,8 +99,8 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
     navigateToAssetDetails(category, CHAIN.ETHEREUM);
   };
 
-  const renderCategoryWithBalance = (category: $Keys<CategoryTotalBalances>) => {
-    const balance = categoryBalances[category] ?? BigNumber(0);
+  const renderCategoryWithBalance = (category: $Keys<CategoryRecord<BigNumber>>) => {
+    const balance = balancePerCategory[category] ?? BigNumber(0);
     const formattedBalance = formatFiatValue(balance, fiatCurrency);
 
     const { title, iconName } = categoriesConfig[category];
@@ -119,8 +120,8 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
     );
   };
 
-  const renderChainWithBalance = (category: $Keys<CategoryTotalBalances>, chain: Chain) => {
-    const balance = categoryBalancesPerChain?.[category]?.[chain] ?? BigNumber(0);
+  const renderChainWithBalance = (category: $Keys<CategoryRecord<BigNumber>>, chain: Chain) => {
+    const balance = accountTotalBalances?.[category]?.[chain] ?? BigNumber(0);
     const formattedBalance = formatFiatValue(balance, fiatCurrency);
 
     const { title } = chainsConfig[chain];
@@ -159,7 +160,7 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
       <ChainListItem
         key={`collectibles-${chain}`}
         title={chainsConfig[chain].title}
-        value={formatValue(collectibleCountPerChain[chain] ?? 0)}
+        value={formatValue(accountCollectibleCounts[chain] ?? 0)}
         isDeployed={isDeployedOnChain[chain]}
         onPress={() => navigateToAssetDetails(ASSET_CATEGORY.COLLECTIBLES, chain)}
         onPressDeploy={() => showDeploymentInterjection(chain)}
@@ -169,7 +170,7 @@ function AssetsSection({ categoryBalances, categoryBalancesPerChain, collectible
 
   return (
     <Container>
-      {!!categoryBalances && Object.keys(categoryBalances).map((category) => renderCategoryWithBalance(category))}
+      {Object.keys(balancePerCategory).map((category) => renderCategoryWithBalance(category))}
 
       {renderCollectiblesCategory()}
 

--- a/src/screens/Home/ChartsSection.js
+++ b/src/screens/Home/ChartsSection.js
@@ -22,24 +22,26 @@ import * as React from 'react';
 import { View } from 'react-native';
 import PagerView from 'react-native-pager-view';
 import styled from 'styled-components/native';
+import { BigNumber } from 'bignumber.js';
 import { clamp } from 'lodash';
 
 // Components
 import PagerControl from 'components/modern/PagerControl';
 
 // Types
-import type { CategoryTotalBalances, TotalBalancesPerChain } from 'models/Balances';
+import type { ChainRecord } from 'models/Chain';
+import type { CategoryRecord } from 'models/TotalBalances';
 
 // Local
 import AssetPieChart from './components/AssetPieChart';
 import ChainPieChart from './components/ChainPieChart';
 
 type Props = {|
-  categoryBalances: CategoryTotalBalances,
-  chainBalances: TotalBalancesPerChain,
+  balancePerCategory: CategoryRecord<BigNumber>,
+  balancePerChain: ChainRecord<BigNumber>,
 |};
 
-function ChartsSection({ categoryBalances, chainBalances }: Props) {
+function ChartsSection({ balancePerCategory, balancePerChain }: Props) {
   const pagerRef = React.useRef<any>();
 
   const [currentPage, setCurrentPage] = React.useState(0);
@@ -58,10 +60,10 @@ function ChartsSection({ categoryBalances, chainBalances }: Props) {
     <Container>
       <PagerView ref={pagerRef} onPageScroll={handlePageScroll} style={styles.pageView}>
         <View key="assets" collapsable={false}>
-          <AssetPieChart categoryBalances={categoryBalances} />
+          <AssetPieChart balancePerCategory={balancePerCategory} />
         </View>
         <View key="chains" collapsable={false}>
-          <ChainPieChart chainBalances={chainBalances} />
+          <ChainPieChart balancePerChain={balancePerChain} />
         </View>
       </PagerView>
       <PagerControl pageCount={2} currentPage={currentPage} onChangePage={handleChangePage} />

--- a/src/screens/Home/FloatingActions.js
+++ b/src/screens/Home/FloatingActions.js
@@ -37,7 +37,7 @@ import { sumRecord } from 'utils/bigNumber';
 
 // Selectors
 import { useRootSelector, activeAccountAddressSelector, useActiveAccount } from 'selectors';
-import { accountWalletTotalBalancesSelector } from 'selectors/totalBalances';
+import { accountWalletBalancePerChainSelector } from 'selectors/totalBalances';
 import { useArchanovaWalletStatus } from 'selectors/archanova';
 
 function FloatingActions() {
@@ -81,7 +81,7 @@ function FloatingActions() {
 }
 
 const useEnabledActions = () => {
-  const walletTotalBalance = sumRecord(useRootSelector(accountWalletTotalBalancesSelector));
+  const walletTotalBalance = sumRecord(useRootSelector(accountWalletBalancePerChainSelector));
   const activeAccount = useActiveAccount();
   const smartWalletState = useArchanovaWalletStatus();
 

--- a/src/screens/Home/FloatingActions.js
+++ b/src/screens/Home/FloatingActions.js
@@ -33,10 +33,11 @@ import { CONNECT_FLOW, EXCHANGE_FLOW, SEND_TOKEN_FROM_HOME_FLOW } from 'constant
 
 // Utils
 import { isArchanovaAccount } from 'utils/accounts';
+import { sumRecord } from 'utils/bigNumber';
 
 // Selectors
 import { useRootSelector, activeAccountAddressSelector, useActiveAccount } from 'selectors';
-import { walletTotalBalanceSelector } from 'selectors/balances';
+import { accountWalletTotalBalancesSelector } from 'selectors/totalBalances';
 import { useArchanovaWalletStatus } from 'selectors/archanova';
 
 function FloatingActions() {
@@ -80,7 +81,7 @@ function FloatingActions() {
 }
 
 const useEnabledActions = () => {
-  const walletTotalBalance = useRootSelector(walletTotalBalanceSelector);
+  const walletTotalBalance = sumRecord(useRootSelector(accountWalletTotalBalancesSelector));
   const activeAccount = useActiveAccount();
   const smartWalletState = useArchanovaWalletStatus();
 

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -42,8 +42,9 @@ import { useUser } from 'selectors/user';
 import { useRootSelector } from 'selectors';
 
 // Utils
+import { sumRecord } from 'utils/bigNumber';
+import { calculateTotalBalancePerCategory, calculateTotalBalancePerChain } from 'utils/totalBalances';
 import { useThemeColors } from 'utils/themes';
-import { getTotalBalance } from 'utils/balances';
 
 // Local
 import BalanceSection from './BalanceSection';
@@ -51,24 +52,22 @@ import ChartsSection from './ChartsSection';
 import AssetsSection from './AssetsSection';
 import FloatingActions from './FloatingActions';
 import {
+  useAccountTotalBalances,
   useCollectibleCountPerChain,
-  useCategoryBalancesPerChain,
-  getTotalCategoryBalances,
-  getTotalChainBalances,
 } from './utils';
 
 function Home() {
   const navigation = useNavigation();
   const colors = useThemeColors();
 
-  const categoryBalancesPerChain = useCategoryBalancesPerChain();
+  const accountTotalBalances = useAccountTotalBalances();
   const collectibleCountPerChain = useCollectibleCountPerChain();
   const user = useUser();
   const dispatch = useDispatch();
 
-  const categoryBalances = getTotalCategoryBalances(categoryBalancesPerChain);
-  const chainBalances = getTotalChainBalances(categoryBalancesPerChain);
-  const totalBalance = getTotalBalance(categoryBalances);
+  const balancePerCategory = calculateTotalBalancePerCategory(accountTotalBalances);
+  const balancePerChain = calculateTotalBalancePerChain(accountTotalBalances);
+  const totalBalance = sumRecord(balancePerCategory);
 
   const isRefreshing = useRootSelector(({ totalBalances }) => !!totalBalances.isFetching);
   const onRefresh = () => dispatch(fetchAllAccountsTotalBalancesAction());
@@ -86,12 +85,7 @@ function Home() {
       <Content
         contentContainerStyle={{ paddingBottom: FloatingButtons.SCROLL_VIEW_BOTTOM_INSET }}
         paddingHorizontal={0}
-        refreshControl={(
-          <RefreshControl
-            refreshing={isRefreshing}
-            onRefresh={onRefresh}
-          />
-        )}
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
       >
         <Stories />
 
@@ -99,11 +93,11 @@ function Home() {
 
         <WalletConnectRequests />
 
-        <ChartsSection categoryBalances={categoryBalances} chainBalances={chainBalances} />
+        <ChartsSection categoryBalances={balancePerCategory} chainBalances={balancePerChain} />
 
         <AssetsSection
-          categoryBalances={categoryBalances}
-          categoryBalancesPerChain={categoryBalancesPerChain}
+          categoryBalances={balancePerCategory}
+          categoryBalancesPerChain={accountTotalBalances}
           collectibleCountPerChain={collectibleCountPerChain}
         />
       </Content>

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -38,8 +38,9 @@ import WalletConnectRequests from 'screens/WalletConnect/Requests';
 import { MENU, HOME_HISTORY } from 'constants/navigationConstants';
 
 // Selectors
-import { useUser } from 'selectors/user';
 import { useRootSelector } from 'selectors';
+import { accountTotalBalancesSelector } from 'selectors/totalBalances';
+import { useUser } from 'selectors/user';
 
 // Utils
 import { sumRecord } from 'utils/bigNumber';
@@ -51,17 +52,14 @@ import BalanceSection from './BalanceSection';
 import ChartsSection from './ChartsSection';
 import AssetsSection from './AssetsSection';
 import FloatingActions from './FloatingActions';
-import {
-  useAccountTotalBalances,
-  useCollectibleCountPerChain,
-} from './utils';
+import { useAccountCollectibleCounts } from './utils';
 
 function Home() {
   const navigation = useNavigation();
   const colors = useThemeColors();
 
-  const accountTotalBalances = useAccountTotalBalances();
-  const collectibleCountPerChain = useCollectibleCountPerChain();
+  const accountTotalBalances = useRootSelector(accountTotalBalancesSelector);
+  const accountCollectibleCounts = useAccountCollectibleCounts();
   const user = useUser();
   const dispatch = useDispatch();
 
@@ -93,12 +91,11 @@ function Home() {
 
         <WalletConnectRequests />
 
-        <ChartsSection categoryBalances={balancePerCategory} chainBalances={balancePerChain} />
+        <ChartsSection balancePerCategory={balancePerCategory} balancePerChain={balancePerChain} />
 
         <AssetsSection
-          categoryBalances={balancePerCategory}
-          categoryBalancesPerChain={accountTotalBalances}
-          collectibleCountPerChain={collectibleCountPerChain}
+          accountTotalBalances={accountTotalBalances}
+          accountCollectibleCounts={accountCollectibleCounts}
         />
       </Content>
 

--- a/src/screens/Home/components/AssetPieChart.js
+++ b/src/screens/Home/components/AssetPieChart.js
@@ -30,7 +30,7 @@ import { formatPercentValue } from 'utils/format';
 import { useThemeColors } from 'utils/themes';
 import { fontSizes } from 'utils/variables';
 import { useAssetCategoriesConfig } from 'utils/uiConfig';
-import { getTotalBalance } from 'utils/balances';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { CategoryRecord } from 'models/TotalBalances';
@@ -98,7 +98,7 @@ const useChartProps = (balances: CategoryRecord<BigNumber>) => {
   const data: ChartDatum[] = [];
   const colorScale: string[] = [];
 
-  const total = getTotalBalance(balances);
+  const total = sumRecord(balances);
 
   // Zero balance case
   if (total.isZero()) {

--- a/src/screens/Home/components/AssetPieChart.js
+++ b/src/screens/Home/components/AssetPieChart.js
@@ -23,9 +23,9 @@ import { useWindowDimensions } from 'react-native';
 import styled from 'styled-components/native';
 import Svg, { Circle } from 'react-native-svg';
 import { VictoryPie, VictoryLabel } from 'victory-native';
+import { BigNumber } from 'bignumber.js';
 
 // Utils
-import { BigNumber } from 'utils/common';
 import { formatPercentValue } from 'utils/format';
 import { useThemeColors } from 'utils/themes';
 import { fontSizes } from 'utils/variables';
@@ -33,14 +33,14 @@ import { useAssetCategoriesConfig } from 'utils/uiConfig';
 import { getTotalBalance } from 'utils/balances';
 
 // Types
-import type { CategoryTotalBalances } from 'models/Balances';
+import type { CategoryRecord } from 'models/TotalBalances';
 
 type Props = {|
-  categoryBalances: CategoryTotalBalances,
+  balancePerCategory: CategoryRecord<BigNumber>,
 |};
 
-function AssetPieChart({ categoryBalances }: Props) {
-  const { data, colorScale } = useChartProps(categoryBalances);
+function AssetPieChart({ balancePerCategory }: Props) {
+  const { data, colorScale } = useChartProps(balancePerCategory);
   const colors = useThemeColors();
 
   const window = useWindowDimensions();
@@ -91,7 +91,7 @@ type ChartDatum = {|
   value: number,
 |};
 
-const useChartProps = (balances: CategoryTotalBalances) => {
+const useChartProps = (balances: CategoryRecord<BigNumber>) => {
   const config = useAssetCategoriesConfig();
   const colors = useThemeColors();
 

--- a/src/screens/Home/components/ChainPieChart.js
+++ b/src/screens/Home/components/ChainPieChart.js
@@ -23,9 +23,9 @@ import { useWindowDimensions } from 'react-native';
 import styled from 'styled-components/native';
 import Svg, { Circle } from 'react-native-svg';
 import { VictoryPie, VictoryLabel } from 'victory-native';
+import { BigNumber } from 'bignumber.js';
 
 // Utils
-import { BigNumber } from 'utils/common';
 import { formatPercentValue } from 'utils/format';
 import { useThemeColors } from 'utils/themes';
 import { fontSizes } from 'utils/variables';
@@ -33,14 +33,14 @@ import { useChainsConfig } from 'utils/uiConfig';
 import { getTotalBalance } from 'utils/balances';
 
 // Types
-import type { TotalBalancesPerChain } from 'models/Balances';
+import type { ChainRecord } from 'models/Chain';
 
 type Props = {|
-  chainBalances: TotalBalancesPerChain,
+  balancePerChain: ChainRecord<BigNumber>,
 |};
 
-function ChainPieChart({ chainBalances }: Props) {
-  const { data, colorScale } = useChartProps(chainBalances);
+function ChainPieChart({ balancePerChain }: Props) {
+  const { data, colorScale } = useChartProps(balancePerChain);
   const colors = useThemeColors();
 
   const window = useWindowDimensions();
@@ -91,7 +91,7 @@ type ChartDatum = {|
   value: number,
 |};
 
-const useChartProps = (balances: TotalBalancesPerChain) => {
+const useChartProps = (balances: ChainRecord<BigNumber>) => {
   const config = useChainsConfig();
   const colors = useThemeColors();
 

--- a/src/screens/Home/components/ChainPieChart.js
+++ b/src/screens/Home/components/ChainPieChart.js
@@ -30,7 +30,7 @@ import { formatPercentValue } from 'utils/format';
 import { useThemeColors } from 'utils/themes';
 import { fontSizes } from 'utils/variables';
 import { useChainsConfig } from 'utils/uiConfig';
-import { getTotalBalance } from 'utils/balances';
+import { sumRecord } from 'utils/bigNumber';
 
 // Types
 import type { ChainRecord } from 'models/Chain';
@@ -98,7 +98,7 @@ const useChartProps = (balances: ChainRecord<BigNumber>) => {
   const data: ChartDatum[] = [];
   const colorScale: string[] = [];
 
-  const total = getTotalBalance(balances);
+  const total = sumRecord(balances);
 
   // Zero balance case
   if (total.isZero()) {

--- a/src/screens/Home/utils.js
+++ b/src/screens/Home/utils.js
@@ -18,44 +18,42 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+import { BigNumber } from 'bignumber.js';
 import { mapValues } from 'lodash';
 
 // Selectors
 import { useRootSelector } from 'selectors';
-import { activeAccountTotalBalancesSelector } from 'selectors/balances';
+import { accountTotalBalancesSelector } from 'selectors/totalBalances';
 import { accountCollectiblesSelector } from 'selectors/collectibles';
 
 // Utils
 import { getTotalBalance } from 'utils/balances';
-import { sum } from 'utils/bigNumber';
 
 // Types
 import type {
+  AccountTotalBalances,
+  AccountCollectibleCount,
   CategoryTotalBalances,
-  TotalBalancesPerChain,
-  CategoryTotalBalancesPerChain,
-  CollectibleCountPerChain,
-} from 'models/Balances';
+  CategoryRecord,
+} from 'models/TotalBalances';
 
-export function useCategoryBalancesPerChain(): CategoryTotalBalancesPerChain {
-  return useRootSelector(activeAccountTotalBalancesSelector);
+export function useBalancesPerCategoryPerChain(): AccountTotalBalances {
+  return useRootSelector(accountTotalBalancesSelector);
 }
 
-export function useCollectibleCountPerChain(): CollectibleCountPerChain {
+export function useTotalBalance(): CategoryRecord<BigNumber> {
+  const accountTotalBalances = useAccountTotalBalances();
+  return mapValues(accountTotalBalances, categoryTotalBalances => getTotalBalance(categoryTotalBalances));
+}
+
+// TODO: support side-chains
+export function useAccountCollectibleCount(): AccountCollectibleCount {
   const ethereum = useRootSelector(accountCollectiblesSelector).length;
   return { ethereum };
 }
 
-export function getTotalCategoryBalances(chains: CategoryTotalBalancesPerChain): CategoryTotalBalances {
-  const chainBalances = Object.keys(chains ?? {}).map((key) => chains[key]);
-
-  return {
-    wallet: sum(chainBalances.map((chain) => chain?.wallet)),
-    deposits: sum(chainBalances.map((chain) => chain?.deposits)),
-    investments: sum(chainBalances.map((chain) => chain?.investments)),
-    liquidityPools: sum(chainBalances.map((chain) => chain?.liquidityPools)),
-    rewards: sum(chainBalances.map((chain) => chain?.rewards)),
-  };
+export function calculateCategoryTotalBalances(balances: AccountTotalBalances): CategoryTotalBalances {
+  return mapValues(balances, (categoryBalances: CategoryTotalBalances) => getTotalBalance(categoryBalances));
 }
 
 export function getTotalChainBalances(chains: CategoryTotalBalancesPerChain): TotalBalancesPerChain {

--- a/src/screens/Home/utils.js
+++ b/src/screens/Home/utils.js
@@ -18,47 +18,22 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-import { BigNumber } from 'bignumber.js';
-import { mapValues } from 'lodash';
-
 // Selectors
 import { useRootSelector } from 'selectors';
 import { accountCollectiblesSelector } from 'selectors/collectibles';
-import { accountTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
-import { sumBy, sumRecord } from 'utils/bigNumber';
 import { recordValues } from 'utils/object';
 
 // Types
-import type { CollectibleCountPerChain } from 'models/Balances';
 import type { ChainRecord } from 'models/Chain';
-import type { AccountTotalBalances, CategoryRecord } from 'models/TotalBalances';
 
-export function useAccountTotalBalances(): AccountTotalBalances {
-  return useRootSelector(accountTotalBalancesSelector);
-}
-
-export function caculateTotalBalancePerCategory(accountBalances: AccountTotalBalances): CategoryRecord<BigNumber> {
-  return mapValues(accountBalances, (balancePerChain: ChainRecord<BigNumber>) => sumRecord(balancePerChain));
-}
-
-export function caculateTotalBalancePerChain(accountBalances: AccountTotalBalances): ChainRecord<BigNumber> {
-  const balancesPerChain = recordValues(accountBalances);
-  return {
-    ethereum: sumBy(balancesPerChain, (balance) => balance?.ethereum),
-    polygon: sumBy(balancesPerChain, (balance) => balance?.polygon),
-    binance: sumBy(balancesPerChain, (balance) => balance?.binance),
-    xdai: sumBy(balancesPerChain, (balance) => balance?.xdai),
-  };
-}
-
-export function useCollectibleCountPerChain(): CollectibleCountPerChain {
+export function useAccountCollectibleCounts(): ChainRecord<number> {
   const ethereum = useRootSelector(accountCollectiblesSelector).length;
   return { ethereum };
 }
 
-export function calculateTotalCollectibleCount(collectibleCountPerChain: CollectibleCountPerChain): number {
-  const counts = recordValues(collectibleCountPerChain);
-  return counts.reduce((total, count) => count != null ? total + count : total, 0);
+export function calculateTotalCollectibleCount(accountCollectibleCounts: ChainRecord<number>): number {
+  const counts = recordValues(accountCollectibleCounts);
+  return counts.reduce((total, count) => (count != null ? total + count : total), 0);
 }

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -17,16 +17,17 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+
 import { createSelector } from 'reselect';
+import { BigNumber } from 'bignumber.js';
 import { mapValues } from 'lodash';
 
 // constants
 import { PLR } from 'constants/assetsConstants';
 
 // utils
-import { pickSupportedAssetsWithSymbols, getTotalBalanceInFiat } from 'utils/assets';
-import { BigNumber } from 'utils/common';
 import { isEtherspotAccount } from 'utils/accounts';
+import { pickSupportedAssetsWithSymbols, getTotalBalanceInFiat } from 'utils/assets';
 import { getWalletAssetsSymbols } from 'utils/balances';
 
 // types

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -75,7 +75,7 @@ export const keyBasedWalletHasPositiveBalanceSelector = createSelector(
 
 export const totalBalancesSelector = ({
   totalBalances,
-}: RootReducerState): ChainTotalBalancesPerAccount => totalBalances.data;
+}: RootReducerState): ChainTotalBalancesPerAccount => ({});
 
 export const activeAccountTotalBalancesSelector: (RootReducerState) => CategoryTotalBalancesPerChain = createSelector(
   activeAccountIdSelector,

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -75,7 +75,7 @@ export const keyBasedWalletHasPositiveBalanceSelector = createSelector(
 
 export const totalBalancesSelector = ({
   totalBalances,
-}: RootReducerState): ChainTotalBalancesPerAccount => ({});
+}: RootReducerState): ChainTotalBalancesPerAccount => totalBalances.data;
 
 export const activeAccountTotalBalancesSelector: (RootReducerState) => CategoryTotalBalancesPerChain = createSelector(
   activeAccountIdSelector,
@@ -122,20 +122,6 @@ export const walletBalancesPerChainSelector: Selector<TotalBalancesPerChain> = c
   (accountAssetsBalances: CategoryTotalBalancesPerChain): TotalBalancesPerChain => {
     return getChainTotalBalancesForCategory(accountAssetsBalances, ASSET_CATEGORY.WALLET);
   },
-);
-
-export const depositsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(
-  activeAccountTotalBalancesSelector,
-  (
-    accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.DEPOSITS),
-);
-
-export const investmentsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(
-  activeAccountTotalBalancesSelector,
-  (
-    accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  ): TotalBalancesPerChain => getChainTotalBalancesForCategory(accountTotalBalances, ASSET_CATEGORY.INVESTMENTS),
 );
 
 export const liquidityPoolsTotalBalanceByChainsSelector: (RootReducerState) => TotalBalancesPerChain = createSelector(

--- a/src/selectors/balances.js
+++ b/src/selectors/balances.js
@@ -20,7 +20,6 @@
 
 import { createSelector } from 'reselect';
 import { BigNumber } from 'bignumber.js';
-import { mapValues } from 'lodash';
 
 // constants
 import { PLR } from 'constants/assetsConstants';
@@ -29,6 +28,7 @@ import { PLR } from 'constants/assetsConstants';
 import { isEtherspotAccount } from 'utils/accounts';
 import { pickSupportedAssetsWithSymbols, getTotalBalanceInFiat } from 'utils/assets';
 import { getWalletAssetsSymbols } from 'utils/balances';
+import { mapRecordValues } from 'utils/object';
 
 // types
 import type { RootReducerState, Selector } from 'reducers/rootReducer';
@@ -87,7 +87,7 @@ export const assetsCompatSelector: Selector<AssetsByAccount> = createSelector(
   assetsBalancesSelector,
   supportedAssetsSelector,
   (assetsBalances: AssetBalancesPerAccount, supportedAssets: Asset[]) => {
-    return mapValues(assetsBalances, (accountAssetsBalances: CategoryBalancesPerChain) => {
+    return mapRecordValues(assetsBalances, (accountAssetsBalances: CategoryBalancesPerChain) => {
       const symbols = getWalletAssetsSymbols(accountAssetsBalances);
       return pickSupportedAssetsWithSymbols(supportedAssets, symbols);
     });

--- a/src/selectors/selectors.js
+++ b/src/selectors/selectors.js
@@ -64,7 +64,7 @@ export const accountsSelector = ({ accounts }: RootReducerState) => accounts.dat
 export const activeAccountSelector =
   ({ accounts }: RootReducerState) => accounts.data.find(({ isActive }) => isActive);
 
-export const activeAccountIdSelector = createSelector(
+export const activeAccountIdSelector: Selector<string> = createSelector(
   activeAccountSelector,
   activeAccount => activeAccount ? activeAccount.id : null,
 );

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -38,12 +38,12 @@ import type {
   CategoryAssetsBalances,
   WalletAssetsBalances,
 } from 'models/Balances';
+import type { ChainRecord } from 'models/Chain';
 import type {
   TotalBalances,
   AccountTotalBalances,
+  StoreTotalBalances,
   WalletTotalBalances,
-  StoredTotalBalances,
-  BalancePerChain,
 } from 'models/TotalBalances';
 
 export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = createSelector(
@@ -61,9 +61,9 @@ export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = create
 export const totalBalancesSelector: Selector<TotalBalances> = createSelector(
   walletTotalBalancesSelector,
   (root: RootReducerState) => root.totalBalances.data,
-  (walletBalances: WalletTotalBalances, storedTotalBalances: StoredTotalBalances): TotalBalances => {
-    const wrappedWalletBalances = mapValues(walletBalances, (wallet: BalancePerChain) => ({ wallet }));
-    return merge(wrappedWalletBalances, storedTotalBalances);
+  (walletBalances: WalletTotalBalances, storeBalances: StoreTotalBalances): TotalBalances => {
+    const wrappedWalletBalances = mapValues(walletBalances, (wallet: ChainRecord<BigNumber>) => ({ wallet }));
+    return merge(wrappedWalletBalances, storeBalances);
   },
 );
 
@@ -75,13 +75,23 @@ export const accountTotalBalancesSelector: Selector<AccountTotalBalances> = crea
   },
 );
 
-export const accountWalletTotalBalancesSelector: Selector<BalancePerChain> = createSelector(
+export const accountWalletTotalBalancesSelector: Selector<ChainRecord<BigNumber>> = createSelector(
   activeAccountIdSelector,
   walletTotalBalancesSelector,
-  (accountId: string, walletBalances: WalletTotalBalances): BalancePerChain => {
+  (accountId: string, walletBalances: WalletTotalBalances): ChainRecord<BigNumber> => {
     return walletBalances[accountId] ?? {};
   },
 );
+
+export const accountDepositsTotalBalancesSelector = (root: RootReducerState) => {
+  const accountId = activeAccountIdSelector(root);
+  return root.totalBalances.data[accountId].deposits ?? {};
+};
+
+export const accountInvestmentsTotalBalancesSelector = (root: RootReducerState) => {
+  const accountId = activeAccountIdSelector(root);
+  return root.totalBalances.data[accountId].deposits ?? {};
+};
 
 const calculateWalletAssetsFiatValue = (
   assetBalances: WalletAssetsBalances,

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -20,7 +20,7 @@
 
 import { BigNumber } from 'bignumber.js';
 import { createSelector } from 'reselect';
-import { map, mapValues, merge } from 'lodash';
+import { map, merge } from 'lodash';
 
 // Selectors
 import { assetsBalancesSelector, activeAccountIdSelector, ratesSelector, fiatCurrencySelector } from 'selectors';
@@ -28,6 +28,7 @@ import { assetsBalancesSelector, activeAccountIdSelector, ratesSelector, fiatCur
 // Utils
 import { getRate } from 'utils/assets';
 import { sum } from 'utils/bigNumber';
+import { mapChainRecordValues } from 'utils/chains';
 import { mapRecordValues } from 'utils/object';
 
 // Types
@@ -53,7 +54,7 @@ export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = create
   fiatCurrencySelector,
   (assetsBalancesPerAccount: AssetBalancesPerAccount, rates: Rates, currency: string): WalletTotalBalances =>
     mapRecordValues(assetsBalancesPerAccount, (assetsBalancesPerChain: CategoryBalancesPerChain) =>
-      mapValues(assetsBalancesPerChain, (assetBalances: CategoryAssetsBalances) =>
+      mapChainRecordValues(assetsBalancesPerChain, (assetBalances: CategoryAssetsBalances) =>
         calculateWalletAssetsFiatValue(assetBalances.wallet ?? {}, rates, currency),
       ),
     ),

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -1,0 +1,103 @@
+// @flow
+/*
+    Pillar Wallet: the personal data locker
+    Copyright (C) 2021 Stiftung Pillar Project
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+import { BigNumber } from 'bignumber.js';
+import { createSelector } from 'reselect';
+import { map, mapValues, merge } from 'lodash';
+
+// Selectors
+import { assetsBalancesSelector, activeAccountIdSelector, ratesSelector, fiatCurrencySelector } from 'selectors';
+
+// Utils
+import { getRate } from 'utils/assets';
+import { sum } from 'utils/bigNumber';
+
+// Types
+import type { RootReducerState, Selector } from 'reducers/rootReducer';
+import type { Rates } from 'models/Asset';
+import type { AssetBalancesPerAccount, CategoryBalancesPerChain, WalletAssetsBalances } from 'models/Balances';
+import type {
+  TotalBalances,
+  AccountTotalBalances,
+  WalletTotalBalances,
+  StoredTotalBalances,
+  CategoryTotalBalances,
+} from 'models/TotalBalances';
+
+export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = createSelector(
+  assetsBalancesSelector,
+  ratesSelector,
+  fiatCurrencySelector,
+  (assetsBalancesPerAccount: AssetBalancesPerAccount, rates: Rates, currency: string): WalletTotalBalances => {
+    return mapValues(assetsBalancesPerAccount, (assetsBalances: CategoryBalancesPerChain) =>
+      getCategoryTotalBalances(assetsBalances, rates, currency),
+    );
+  },
+);
+
+export const totalBalancesSelector: Selector<TotalBalances> = createSelector(
+  walletTotalBalancesSelector,
+  (root: RootReducerState) => root.totalBalances.dataX,
+  (walletBalances: WalletTotalBalances, storedTotalBalances: StoredTotalBalances): TotalBalances => {
+    const wrappedWalletBalances = mapValues(walletBalances, (wallet: CategoryTotalBalances) => ({ wallet }));
+    return merge(wrappedWalletBalances, storedTotalBalances);
+  },
+);
+
+export const accountWalletTotalBalancesSelector: Selector<CategoryTotalBalances> = createSelector(
+  activeAccountIdSelector,
+  walletTotalBalancesSelector,
+  (accountId: string, walletBalances: WalletTotalBalances): CategoryTotalBalances => {
+    return walletBalances[accountId] ?? {};
+  },
+);
+
+export const accountTotalBalancesSelector: Selector<AccountTotalBalances> = createSelector(
+  activeAccountIdSelector,
+  totalBalancesSelector,
+  (accountId: string, totalBalancesPerAccount: TotalBalances): AccountTotalBalances => {
+    return totalBalancesPerAccount[accountId] ?? {};
+  },
+);
+
+const getCategoryTotalBalances = (
+  assetsBalancesPerChain: CategoryBalancesPerChain,
+  rates: Rates,
+  currency: string,
+): CategoryTotalBalances => {
+  return mapValues(assetsBalancesPerChain, (assetBalances: WalletAssetsBalances) =>
+    getTotalWalletBalanceInFiat(assetBalances, rates, currency),
+  );
+};
+
+const getTotalWalletBalanceInFiat = (
+  assetBalances: WalletAssetsBalances,
+  rates: Rates,
+  currency: string,
+): BigNumber => {
+  const assetBalancesInFiat = map(assetBalances, (asset) => {
+    if (!asset?.balance) return BigNumber(0);
+
+    const rate = getRate(rates, asset.symbol, currency);
+    return BigNumber(asset.balance).times(rate);
+  });
+
+  return sum(assetBalancesInFiat);
+};

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -75,7 +75,7 @@ export const accountTotalBalancesSelector: Selector<AccountTotalBalances> = crea
   },
 );
 
-export const accountWalletTotalBalancesSelector: Selector<ChainRecord<BigNumber>> = createSelector(
+export const accountWalletBalancePerChainSelector: Selector<ChainRecord<BigNumber>> = createSelector(
   activeAccountIdSelector,
   walletTotalBalancesSelector,
   (accountId: string, walletBalances: WalletTotalBalances): ChainRecord<BigNumber> => {
@@ -83,22 +83,22 @@ export const accountWalletTotalBalancesSelector: Selector<ChainRecord<BigNumber>
   },
 );
 
-export const accountDepositsTotalBalancesSelector = (root: RootReducerState) => {
+export const accountDepositsBalancePerChainSelector = (root: RootReducerState) => {
   const accountId = activeAccountIdSelector(root);
   return root.totalBalances.data[accountId].deposits ?? {};
 };
 
-export const accountInvestmentsTotalBalancesSelector = (root: RootReducerState) => {
+export const accountInvestmentsBalancePerChainSelector = (root: RootReducerState) => {
   const accountId = activeAccountIdSelector(root);
   return root.totalBalances.data[accountId].investments ?? {};
 };
 
-export const accountLiquidityPoolsTotalBalancesSelector = (root: RootReducerState) => {
+export const accountLiquidityPoolsBalancePerChainSelector = (root: RootReducerState) => {
   const accountId = activeAccountIdSelector(root);
   return root.totalBalances.data[accountId].liquidityPools ?? {};
 };
 
-export const accountRewardsBalancesSelector = (root: RootReducerState) => {
+export const accountRewardsBalancePerChainSelector = (root: RootReducerState) => {
   const accountId = activeAccountIdSelector(root);
   return root.totalBalances.data[accountId].rewards ?? {};
 };

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -90,7 +90,17 @@ export const accountDepositsTotalBalancesSelector = (root: RootReducerState) => 
 
 export const accountInvestmentsTotalBalancesSelector = (root: RootReducerState) => {
   const accountId = activeAccountIdSelector(root);
-  return root.totalBalances.data[accountId].deposits ?? {};
+  return root.totalBalances.data[accountId].investments ?? {};
+};
+
+export const accountLiquidityPoolsTotalBalancesSelector = (root: RootReducerState) => {
+  const accountId = activeAccountIdSelector(root);
+  return root.totalBalances.data[accountId].liquidityPools ?? {};
+};
+
+export const accountRewardsBalancesSelector = (root: RootReducerState) => {
+  const accountId = activeAccountIdSelector(root);
+  return root.totalBalances.data[accountId].rewards ?? {};
 };
 
 const calculateWalletAssetsFiatValue = (

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -43,7 +43,7 @@ import type {
   AccountTotalBalances,
   WalletTotalBalances,
   StoredTotalBalances,
-  CategoryTotalBalances,
+  BalancePerChain,
 } from 'models/TotalBalances';
 
 export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = createSelector(
@@ -60,9 +60,9 @@ export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = create
 
 export const totalBalancesSelector: Selector<TotalBalances> = createSelector(
   walletTotalBalancesSelector,
-  (root: RootReducerState) => root.totalBalances.dataX,
+  (root: RootReducerState) => root.totalBalances.data,
   (walletBalances: WalletTotalBalances, storedTotalBalances: StoredTotalBalances): TotalBalances => {
-    const wrappedWalletBalances = mapValues(walletBalances, (wallet: CategoryTotalBalances) => ({ wallet }));
+    const wrappedWalletBalances = mapValues(walletBalances, (wallet: BalancePerChain) => ({ wallet }));
     return merge(wrappedWalletBalances, storedTotalBalances);
   },
 );
@@ -75,10 +75,10 @@ export const accountTotalBalancesSelector: Selector<AccountTotalBalances> = crea
   },
 );
 
-export const accountWalletTotalBalancesSelector: Selector<CategoryTotalBalances> = createSelector(
+export const accountWalletTotalBalancesSelector: Selector<BalancePerChain> = createSelector(
   activeAccountIdSelector,
   walletTotalBalancesSelector,
-  (accountId: string, walletBalances: WalletTotalBalances): CategoryTotalBalances => {
+  (accountId: string, walletBalances: WalletTotalBalances): BalancePerChain => {
     return walletBalances[accountId] ?? {};
   },
 );

--- a/src/selectors/totalBalances.js
+++ b/src/selectors/totalBalances.js
@@ -20,7 +20,7 @@
 
 import { BigNumber } from 'bignumber.js';
 import { createSelector } from 'reselect';
-import { map, merge } from 'lodash';
+import { map, mapValues, merge } from 'lodash';
 
 // Selectors
 import { assetsBalancesSelector, activeAccountIdSelector, ratesSelector, fiatCurrencySelector } from 'selectors';
@@ -53,9 +53,9 @@ export const walletTotalBalancesSelector: Selector<WalletTotalBalances> = create
   fiatCurrencySelector,
   (assetsBalancesPerAccount: AssetBalancesPerAccount, rates: Rates, currency: string): WalletTotalBalances =>
     mapRecordValues(assetsBalancesPerAccount, (assetsBalancesPerChain: CategoryBalancesPerChain) =>
-      mapRecordValues(assetsBalancesPerChain, (assetBalances: CategoryAssetsBalances) => {
-        return calculateWalletAssetsFiatValue(assetBalances.wallet ?? {}, rates, currency);
-      }),
+      mapValues(assetsBalancesPerChain, (assetBalances: CategoryAssetsBalances) =>
+        calculateWalletAssetsFiatValue(assetBalances.wallet ?? {}, rates, currency),
+      ),
     ),
 );
 

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -18,49 +18,20 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 import { mapValues } from 'lodash';
-import { BigNumber } from 'bignumber.js';
 
-// constants
+// Constants
 import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
-// utils
-import { sum } from 'utils/bigNumber';
-
-// types
+// Types
 import type {
   CategoryBalancesPerChain,
-  CategoryTotalBalancesPerChain,
-  InvestmentAssetBalance,
-  LiquidityPoolAssetBalance,
-  TotalBalancesPerChain,
   WalletAssetsBalances,
   DepositAssetBalance,
+  InvestmentAssetBalance,
+  LiquidityPoolAssetBalance,
 } from 'models/Balances';
 import type { ChainRecord } from 'models/Chain';
 
-export const getChainTotalBalancesForCategory = (
-  accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  category: string,
-): TotalBalancesPerChain => mapValues(
-  accountTotalBalances ?? {},
-  (categoryBalances) => categoryBalances?.[category] || BigNumber(0),
-);
-
-export const getTotalBalance = (entries: { [key: string]: BigNumber}): BigNumber => {
-  const balances = Object.keys(entries).map((key) => entries[key] || BigNumber(0));
-  return sum(balances);
-};
-
-export const getTotalCategoryBalance = (
-  accountTotalBalances: ?CategoryTotalBalancesPerChain,
-  category: string,
-): BigNumber => {
-  const balancesOnChains = (Object.values(accountTotalBalances || {}): any);
-
-  return sum(balancesOnChains.map((chainTotals) => {
-    return chainTotals?.[category] || BigNumber(0);
-  }));
-};
 
 export const getChainDepositAssetsBalances = (
   accountAssetsBalances: ?CategoryBalancesPerChain,

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -24,9 +24,6 @@ import { mapValues, pickBy } from 'lodash';
 // Constants
 import { ASSET_CATEGORY } from 'constants/assetsConstants';
 
-// Utils
-import { mapRecordValues } from 'utils/object';
-
 // Types
 import type {
   CategoryBalancesPerChain,
@@ -41,7 +38,7 @@ import type { ChainRecord } from 'models/Chain';
 export const getChainWalletAssetsBalances = (
   assetsBalances: ?CategoryBalancesPerChain,
 ): ChainRecord<WalletAssetsBalances> => {
-  return mapRecordValues(assetsBalances ?? {}, (categoryBalances) =>
+  return mapValues(assetsBalances ?? {}, (categoryBalances) =>
     filterNonZeroAssetBalances(categoryBalances?.wallet ?? {}),
   );
 };

--- a/src/utils/balances.js
+++ b/src/utils/balances.js
@@ -19,10 +19,10 @@
 */
 
 import { BigNumber } from 'bignumber.js';
-import { mapValues, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 
-// Constants
-import { ASSET_CATEGORY } from 'constants/assetsConstants';
+// Utils
+import { mapChainRecordValues } from 'utils/chains';
 
 // Types
 import type {
@@ -37,32 +37,25 @@ import type { ChainRecord } from 'models/Chain';
 
 export const getChainWalletAssetsBalances = (
   assetsBalances: ?CategoryBalancesPerChain,
-): ChainRecord<WalletAssetsBalances> => {
-  return mapValues(assetsBalances ?? {}, (categoryBalances) =>
+): ChainRecord<WalletAssetsBalances> =>
+  mapChainRecordValues(assetsBalances ?? {}, (categoryBalances) =>
     filterNonZeroAssetBalances(categoryBalances?.wallet ?? {}),
   );
-};
 
 export const getChainDepositAssetsBalances = (
-  accountAssetsBalances: ?CategoryBalancesPerChain,
-): ChainRecord<DepositAssetBalance[]> => mapValues(
-  accountAssetsBalances ?? {},
-  (categoryBalances) => categoryBalances?.[ASSET_CATEGORY.DEPOSITS],
-);
+  assetsBalances: ?CategoryBalancesPerChain,
+): ChainRecord<DepositAssetBalance[]> =>
+  mapChainRecordValues(assetsBalances ?? {}, (categoryBalances) => categoryBalances?.deposits ?? []);
 
 export const getChainLiquidityPoolAssetsBalances = (
-  accountAssetsBalances: ?CategoryBalancesPerChain,
-): ChainRecord<LiquidityPoolAssetBalance[]> => mapValues(
-  accountAssetsBalances ?? {},
-  (categoryBalances) => categoryBalances?.[ASSET_CATEGORY.LIQUIDITY_POOLS],
-);
+  assetsBalances: ?CategoryBalancesPerChain,
+): ChainRecord<LiquidityPoolAssetBalance[]> =>
+  mapChainRecordValues(assetsBalances ?? {}, (categoryBalances) => categoryBalances?.liquidityPools ?? []);
 
 export const getChainInvestmentAssetsBalances = (
-  accountAssetsBalances: ?CategoryBalancesPerChain,
-): ChainRecord<InvestmentAssetBalance[]> => mapValues(
-  accountAssetsBalances ?? {},
-  (categoryBalances) => categoryBalances?.[ASSET_CATEGORY.INVESTMENTS],
-);
+  assetsBalances: ?CategoryBalancesPerChain,
+): ChainRecord<InvestmentAssetBalance[]> =>
+  mapChainRecordValues(assetsBalances ?? {}, (categoryBalances) => categoryBalances?.investments ?? []);
 
 export const getWalletAssetsSymbols = (accountAssetsBalances: ?CategoryBalancesPerChain): string[] => {
   const walletAssetsBalancesPerChain = getChainWalletAssetsBalances(accountAssetsBalances);

--- a/src/utils/bigNumber.js
+++ b/src/utils/bigNumber.js
@@ -20,6 +20,12 @@
 
 import { BigNumber } from 'bignumber.js';
 
+// Utils
+import { recordValues } from 'utils/object';
+
+// Types
+import type { Record } from 'utils/object';
+
 export const wrapBigNumber = (value: BigNumber | number | string): BigNumber => {
   if (value instanceof BigNumber) return value;
   return new BigNumber(value);
@@ -34,7 +40,7 @@ export const wrapBigNumberOrNil = (value: ?BigNumber | number | string): ?BigNum
  *
  * It returns 0 when input is empty or contain only nulls.
  */
-export function sum(values: (?BigNumber)[]): BigNumber {
+export function sum(values: BigNumber[] | (?BigNumber)[]): BigNumber {
   let total = BigNumber(0);
 
   values.forEach((value) => {
@@ -53,4 +59,14 @@ export function sum(values: (?BigNumber)[]): BigNumber {
  */
 export function sumOrNull(values: (?BigNumber)[]): BigNumber | null {
   return values.some((v) => v != null) ? sum(values) : null;
+}
+
+export function sumRecord(valuesRecord: ?Record<BigNumber>) {
+  const values = recordValues(valuesRecord ?? {});
+  return sum(values);
+}
+
+export function sumBy<Element>(elements: Element[], valueSelector: (element: Element) => ?BigNumber): BigNumber {
+  const values: (?BigNumber)[] = elements.map(valueSelector);
+  return sum(values);
 }

--- a/src/utils/chains.js
+++ b/src/utils/chains.js
@@ -27,10 +27,11 @@ import { CHAIN, CHAIN_ID } from 'constants/chainConstants';
 
 // Utils
 import { isEtherspotAccount } from 'utils/accounts';
+import { mapRecordValues } from 'utils/object';
 
 // Types
 import type { Account } from 'models/Account';
-import type { Chain } from 'models/Chain';
+import type { Chain, ChainRecord } from 'models/Chain';
 
 export const chainFromChainId: { [number]: Chain } = {
   [CHAIN_ID.ETHEREUM_MAINNET]: CHAIN.ETHEREUM,
@@ -67,3 +68,14 @@ export const nativeSymbolPerChain = {
   binance: BNB,
   xdai: DAI,
 };
+
+/**
+ * Flow-supported version of mapRecordValues counterpart for ChainRecord.
+ */
+export function mapChainRecordValues<Value, Target>(
+  record: ChainRecord<Value>,
+  selector: (value: Value, chain: Chain) => Target,
+): ChainRecord<Target> {
+  // $FlowFixMe: exact vs inexact
+  return mapRecordValues(record, selector);
+}

--- a/src/utils/chains.js
+++ b/src/utils/chains.js
@@ -30,7 +30,7 @@ import { isEtherspotAccount } from 'utils/accounts';
 
 // Types
 import type { Account } from 'models/Account';
-import type { Chain } from 'models/Chain';
+import type { Chain, ChainRecord } from 'models/Chain';
 
 export const chainFromChainId: { [number]: Chain } = {
   [CHAIN_ID.ETHEREUM_MAINNET]: CHAIN.ETHEREUM,

--- a/src/utils/chains.js
+++ b/src/utils/chains.js
@@ -30,7 +30,7 @@ import { isEtherspotAccount } from 'utils/accounts';
 
 // Types
 import type { Account } from 'models/Account';
-import type { Chain, ChainRecord } from 'models/Chain';
+import type { Chain } from 'models/Chain';
 
 export const chainFromChainId: { [number]: Chain } = {
   [CHAIN_ID.ETHEREUM_MAINNET]: CHAIN.ETHEREUM,

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -20,6 +20,15 @@
 
 import { omitBy, isNil } from 'lodash';
 
+export type Record<T> = { [string]: T };
+
+/**
+ * Properly typed version of `Object.values`.
+ */
+export function recordValues<T>(record: Record<T>): T[] {
+  return Object.keys(record).map((key) => record[key]);
+}
+
 /**
  * Returns a copy of the object but without any `undefined` or `null` properties.
  */

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -20,7 +20,7 @@
 
 import { omitBy, isNil } from 'lodash';
 
-export type Record<Value, Key: string = string> = { [Key]: Value };
+export type Record<Value> = { [string]: Value };
 
 /**
  * Properly typed version of `Object.values`.
@@ -32,9 +32,9 @@ export function recordValues<Value>(record: Record<Value>): Value[] {
 /**
  * Improved version of lodash mapValue.
  */
-export function mapRecordValues<Value, Target, Key: string>(
-  record: Record<Value, Key>,
-  selector: (value: Value, key: Key) => Target,
+export function mapRecordValues<Value, Target>(
+  record: Record<Value>,
+  selector: (value: Value, key: string) => Target,
 ): Record<Target> {
   const result = {};
   Object.keys(record).forEach((key) => {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -20,13 +20,28 @@
 
 import { omitBy, isNil } from 'lodash';
 
-export type Record<T> = { [string]: T };
+export type Record<Value, Key: string = string> = { [Key]: Value };
 
 /**
  * Properly typed version of `Object.values`.
  */
-export function recordValues<T>(record: Record<T>): T[] {
+export function recordValues<Value>(record: Record<Value>): Value[] {
   return Object.keys(record).map((key) => record[key]);
+}
+
+/**
+ * Improved version of lodash mapValue.
+ */
+export function mapRecordValues<Value, Target, Key: string>(
+  record: Record<Value, Key>,
+  selector: (value: Value, key: Key) => Target,
+): Record<Target> {
+  const result = {};
+  Object.keys(record).forEach((key) => {
+    result[key] = selector(record[key], key);
+  });
+
+  return result;
 }
 
 /**

--- a/src/utils/totalBalances.js
+++ b/src/utils/totalBalances.js
@@ -19,31 +19,31 @@
 */
 
 import { BigNumber } from 'bignumber.js';
-import { mapValues } from 'lodash';
-
-// Selectors
-import { useRootSelector } from 'selectors';
-import { accountCollectiblesSelector } from 'selectors/collectibles';
-import { accountTotalBalancesSelector } from 'selectors/totalBalances';
 
 // Utils
 import { sumBy, sumRecord } from 'utils/bigNumber';
 import { recordValues } from 'utils/object';
 
 // Types
-import type { CollectibleCountPerChain } from 'models/Balances';
 import type { ChainRecord } from 'models/Chain';
 import type { AccountTotalBalances, CategoryRecord } from 'models/TotalBalances';
 
-export function useAccountTotalBalances(): AccountTotalBalances {
-  return useRootSelector(accountTotalBalancesSelector);
+export function calculateTotalBalance(accountBalances: AccountTotalBalances): BigNumber {
+  const totalBalancePerCategory = calculateTotalBalancePerCategory(accountBalances);
+  return sumRecord(totalBalancePerCategory);
 }
 
-export function caculateTotalBalancePerCategory(accountBalances: AccountTotalBalances): CategoryRecord<BigNumber> {
-  return mapValues(accountBalances, (balancePerChain: ChainRecord<BigNumber>) => sumRecord(balancePerChain));
+export function calculateTotalBalancePerCategory(accountBalances: AccountTotalBalances): CategoryRecord<BigNumber> {
+  return {
+    wallet: sumRecord(accountBalances.wallet),
+    deposits: sumRecord(accountBalances.deposits),
+    investments: sumRecord(accountBalances.investments),
+    liquidityPools: sumRecord(accountBalances.liquidityPools),
+    rewards: sumRecord(accountBalances.rewards),
+  };
 }
 
-export function caculateTotalBalancePerChain(accountBalances: AccountTotalBalances): ChainRecord<BigNumber> {
+export function calculateTotalBalancePerChain(accountBalances: AccountTotalBalances): ChainRecord<BigNumber> {
   const balancesPerChain = recordValues(accountBalances);
   return {
     ethereum: sumBy(balancesPerChain, (balance) => balance?.ethereum),
@@ -53,12 +53,3 @@ export function caculateTotalBalancePerChain(accountBalances: AccountTotalBalanc
   };
 }
 
-export function useCollectibleCountPerChain(): CollectibleCountPerChain {
-  const ethereum = useRootSelector(accountCollectiblesSelector).length;
-  return { ethereum };
-}
-
-export function calculateTotalCollectibleCount(collectibleCountPerChain: CollectibleCountPerChain): number {
-  const counts = recordValues(collectibleCountPerChain);
-  return counts.reduce((total, count) => count != null ? total + count : total, 0);
-}


### PR DESCRIPTION
Scope:
- [x] Fix wallet totals discrepancies by calculating them using memoized selector
- [x] Fix display side-chain assets in Assets screen 
- [x] Cleanup naming & file structure regarding total balances
- [x] Restructure `totalBalances` from account -> chain -> category to account -> category -> chain for easier usage
- [x] Various flow type improvements