### PR TITLE
history migration fix

### DIFF
--- a/src/services/dataMigration/history.js
+++ b/src/services/dataMigration/history.js
@@ -84,7 +84,7 @@ export default async function (storageData: Object, dispatch: Function, getState
         if (!chainsKeys.includes(chainKey)) return fixedChainsHistory;
 
         // $FlowFixMe
-        return {  ...fixedChainsHistory, [chainKey]: accountHistory[chainKey] };
+        return { ...fixedChainsHistory, [chainKey]: accountHistory[chainKey] };
       }, {});
 
       return { ...fixedHistory, [accountId]: fixedAccountHistory };

--- a/src/services/dataMigration/history.js
+++ b/src/services/dataMigration/history.js
@@ -76,7 +76,10 @@ export default async function (storageData: Object, dispatch: Function, getState
     history = Object.keys(history).reduce((fixedHistory, accountId) => {
       const accountHistory = history[accountId] ?? {};
 
-      const fixedAccountHistory = Object.keys(accountHistory).reduce((fixedChainsHistory, chainKey) => {
+      const fixedAccountHistory = Object.keys(accountHistory).reduce((
+        fixedChainsHistory,
+        chainKey,
+      ) => {
         // drop key if it's not chain
         if (!chainsKeys.includes(chainKey)) return fixedChainsHistory;
 

--- a/src/services/dataMigration/history.js
+++ b/src/services/dataMigration/history.js
@@ -17,7 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import { isEmpty, mapValues } from 'lodash';
+import { isEmpty } from 'lodash';
 
 // constants
 import { SET_HISTORY } from 'constants/historyConstants';
@@ -80,6 +80,7 @@ export default async function (storageData: Object, dispatch: Function, getState
         // drop key if it's not chain
         if (!chainsKeys.includes(chainKey)) return fixedChainsHistory;
 
+        // $FlowFixMe
         return {  ...fixedChainsHistory, [chainKey]: accountHistory[chainKey] };
       }, {});
 

--- a/src/services/dataMigration/history.js
+++ b/src/services/dataMigration/history.js
@@ -73,15 +73,18 @@ export default async function (storageData: Object, dispatch: Function, getState
     return Object.keys(accountHistory).some((chainKey) => !chainsKeys.includes(chainKey));
   });
   if (historyHasWrongKeys) {
-    history = mapValues(
-      history,
-      (accountHistory) => Object.keys(accountHistory ?? {}).reduce((fixedChainsHistory, chainKey) => {
+    history = Object.keys(history).reduce((fixedHistory, accountId) => {
+      const accountHistory = history[accountId] ?? {};
+
+      const fixedAccountHistory = Object.keys(accountHistory).reduce((fixedChainsHistory, chainKey) => {
         // drop key if it's not chain
         if (!chainsKeys.includes(chainKey)) return fixedChainsHistory;
 
         return {  ...fixedChainsHistory, [chainKey]: accountHistory[chainKey] };
-      })
-    );
+      }, {});
+
+      return { ...fixedHistory, [accountId]: fixedAccountHistory };
+    }, {});
     dispatch({ type: SET_HISTORY, payload: history });
     dispatch(saveDbAction('history', { history }, true));
   }

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -32,7 +32,6 @@ import {
 import { PAYMENT_NETWORK_TX_SETTLEMENT, PAYMENT_NETWORK_ACCOUNT_DEPLOYMENT } from 'constants/paymentNetworkConstants';
 import { ETH } from 'constants/assetsConstants';
 import { EVENT_TYPE, TRANSACTION_STATUS } from 'models/History';
-import { CHAIN } from 'constants/chainConstants';
 
 // types
 import type {
@@ -351,12 +350,4 @@ export const getCrossChainAccountCollectiblesHistory = (
 
 export const transactionStoreHasOldStructure = (
   transactionStore: TransactionsStore | CollectiblesHistoryStore,
-) => Object.keys(transactionStore).some((accountId) => {
-  const history = transactionStore[accountId] ?? {};
-
-  // checks if migration needed for history being transactions array and needed to be per chain based
-  if (Array.isArray(history)) return true;
-
-  // checks history if wrong was written during initial migration for per chain history
-  return Object.keys(history).some((chain) => !Object.values(CHAIN).includes(chain));
-});
+) => Object.values(transactionStore).some((history) => history && Array.isArray(history));

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -32,6 +32,7 @@ import {
 import { PAYMENT_NETWORK_TX_SETTLEMENT, PAYMENT_NETWORK_ACCOUNT_DEPLOYMENT } from 'constants/paymentNetworkConstants';
 import { ETH } from 'constants/assetsConstants';
 import { EVENT_TYPE, TRANSACTION_STATUS } from 'models/History';
+import { CHAIN } from 'constants/chainConstants';
 
 // types
 import type {
@@ -350,4 +351,12 @@ export const getCrossChainAccountCollectiblesHistory = (
 
 export const transactionStoreHasOldStructure = (
   transactionStore: TransactionsStore | CollectiblesHistoryStore,
-) => Object.values(transactionStore).some((history) => history && Array.isArray(history));
+) => Object.keys(transactionStore).some((accountId) => {
+  const history = transactionStore[accountId] ?? {};
+
+  // checks if migration needed for history being transactions array and needed to be per chain based
+  if (Array.isArray(history)) return true;
+
+  // checks history if wrong was written during initial migration for per chain history
+  return Object.keys(history).some((chain) => !Object.values(CHAIN).includes(chain));
+});


### PR DESCRIPTION
Transaction history migration had wrong flow because it was using existing method to update transactions history while this method also restructures existing history which at that point is still array and this results in history having not just added chain as key, but existing transactions array as keys (by each index starting with 0).

Basic example of what happened during initial transactions migration:
```
cont existingTransactions = [ { ... }, { .... } ... ];
const newHistory = { accountId: { chain: existingTransactions, ...existingTransactions } };
```