### PR TITLE
wc navigation dismiss fix

### DIFF
--- a/src/screens/SendToken/SendTokenTransaction.js
+++ b/src/screens/SendToken/SendTokenTransaction.js
@@ -137,11 +137,6 @@ class SendTokenTransaction extends React.Component<Props> {
 
     const { isSuccess, transactionPayload, goBackDismiss } = navigation.state.params;
 
-    if (goBackDismiss) {
-      navigation.goBack(null);
-      return;
-    }
-
     const txTag = transactionPayload?.tag || '';
     if (isSuccess && isPoolTogetherTag(txTag)) {
       const { extra: { symbol = DAI, amount, decimals = 18 } = {} } = transactionPayload;
@@ -223,7 +218,11 @@ class SendTokenTransaction extends React.Component<Props> {
       return;
     }
 
-    navigation.dismiss();
+    if (goBackDismiss) {
+      navigation.goBack(null);
+    } else {
+      navigation.dismiss();
+    }
 
     if (transactionPayload.usePPN && isSuccess) {
       const { amount, symbol } = transactionPayload;

--- a/src/screens/SendToken/SendTokenTransaction.js
+++ b/src/screens/SendToken/SendTokenTransaction.js
@@ -135,7 +135,12 @@ class SendTokenTransaction extends React.Component<Props> {
   handleDismissal = () => {
     const { navigation } = this.props;
 
-    const { isSuccess, transactionPayload } = navigation.state.params;
+    const { isSuccess, transactionPayload, goBackDismiss } = navigation.state.params;
+
+    if (goBackDismiss) {
+      navigation.goBack(null);
+      return;
+    }
 
     const txTag = transactionPayload?.tag || '';
     if (isSuccess && isPoolTogetherTag(txTag)) {

--- a/src/screens/WalletConnect/WalletConnectPinConfirm.js
+++ b/src/screens/WalletConnect/WalletConnectPinConfirm.js
@@ -70,7 +70,7 @@ type Props = {
   activeAccount: ?Account,
 };
 
-const WalletConnectPinConfirmScreen = ({
+const WalletConnectPinConfirmScreeen = ({
   resetIncorrectPassword,
   useBiometrics,
   sendAsset,
@@ -84,10 +84,10 @@ const WalletConnectPinConfirmScreen = ({
   const callRequest = navigation.getParam('callRequest');
   const transactionPayload = navigation.getParam('transactionPayload');
 
-  const onSuccess = (dismissNavigation: boolean = false) => {
+  const dismissScreen = () => {
     resetIncorrectPassword();
     setIsChecking(false);
-    if (dismissNavigation) navigation.dismiss();
+    navigation.dismiss();
   };
 
   const handleSendTransaction = (): void => {
@@ -98,11 +98,12 @@ const WalletConnectPinConfirmScreen = ({
         rejectCallRequest(callRequest);
       }
 
-      onSuccess();
+      dismissScreen();
 
       navigation.navigate(SEND_TOKEN_TRANSACTION, {
         ...transactionStatus,
         noRetry: true,
+        goBackDismiss: true,
         transactionPayload,
       });
     };
@@ -171,7 +172,7 @@ const WalletConnectPinConfirmScreen = ({
       });
     }
 
-    onSuccess(true);
+    dismissScreen();
   };
 
   const onNavigationBack = () => {
@@ -213,4 +214,4 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   resetIncorrectPassword: () => dispatch(resetIncorrectPasswordAction()),
 });
 
-export default connect(combinedMapStateToProps, mapDispatchToProps)(WalletConnectPinConfirmScreen);
+export default connect(combinedMapStateToProps, mapDispatchToProps)(WalletConnectPinConfirmScreeen);

--- a/src/screens/WalletConnect/WalletConnectPinConfirm.js
+++ b/src/screens/WalletConnect/WalletConnectPinConfirm.js
@@ -70,7 +70,7 @@ type Props = {
   activeAccount: ?Account,
 };
 
-const WalletConnectPinConfirmScreeen = ({
+const WalletConnectPinConfirmScreen = ({
   resetIncorrectPassword,
   useBiometrics,
   sendAsset,
@@ -84,10 +84,10 @@ const WalletConnectPinConfirmScreeen = ({
   const callRequest = navigation.getParam('callRequest');
   const transactionPayload = navigation.getParam('transactionPayload');
 
-  const dismissScreen = () => {
+  const onSuccess = (dismissNavigation: boolean = false) => {
     resetIncorrectPassword();
     setIsChecking(false);
-    navigation.dismiss();
+    if (dismissNavigation) navigation.dismiss();
   };
 
   const handleSendTransaction = (): void => {
@@ -98,7 +98,7 @@ const WalletConnectPinConfirmScreeen = ({
         rejectCallRequest(callRequest);
       }
 
-      dismissScreen();
+      onSuccess();
 
       navigation.navigate(SEND_TOKEN_TRANSACTION, {
         ...transactionStatus,
@@ -171,7 +171,7 @@ const WalletConnectPinConfirmScreeen = ({
       });
     }
 
-    dismissScreen();
+    onSuccess(true);
   };
 
   const onNavigationBack = () => {
@@ -213,4 +213,4 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   resetIncorrectPassword: () => dispatch(resetIncorrectPasswordAction()),
 });
 
-export default connect(combinedMapStateToProps, mapDispatchToProps)(WalletConnectPinConfirmScreeen);
+export default connect(combinedMapStateToProps, mapDispatchToProps)(WalletConnectPinConfirmScreen);


### PR DESCRIPTION
Fixes navigation to not be dismisses on Wallet Connect transaction send flow – it's dismissed in later screens in the asset send flow.