### PR TITLE
do not wait for history fetch during onboarding

### DIFF
--- a/src/actions/__tests__/onboardingActions.test.js
+++ b/src/actions/__tests__/onboardingActions.test.js
@@ -250,8 +250,8 @@ describe('Onboarding actions', () => {
       { payload: false, type: SET_FETCHING_TOTAL_BALANCES },
 
       { type: SET_FETCHING_HISTORY, payload: true },
-      { type: SET_FETCHING_HISTORY, payload: false },
       { type: SET_FETCHING_RATES, payload: true },
+      { type: SET_FETCHING_HISTORY, payload: false },
 
       { type: UPDATE_CHAIN_RATES, payload: { chain: CHAIN.ETHEREUM, rates: mockExchangeRates } },
       { type: SET_FETCHING_RATES, payload: false },
@@ -303,9 +303,8 @@ describe('Onboarding actions', () => {
       { payload: false, type: SET_FETCHING_TOTAL_BALANCES },
 
       { type: SET_FETCHING_HISTORY, payload: true },
-      { type: SET_HISTORY, payload: { [mockArchanovaAccount.id]: { ethereum: [] } } },
-      { type: SET_FETCHING_HISTORY, payload: false },
       { type: SET_FETCHING_RATES, payload: true },
+      { type: SET_HISTORY, payload: { [mockArchanovaAccount.id]: { ethereum: [] } } },
 
       { type: UPDATE_CHAIN_RATES, payload: { chain: CHAIN.ETHEREUM, rates: mockExchangeRates } },
       { type: SET_FETCHING_RATES, payload: false },

--- a/src/actions/onboardingActions.js
+++ b/src/actions/onboardingActions.js
@@ -255,7 +255,7 @@ export const setupAppServicesAction = (privateKey: ?string) => {
       'onboarding',
       'setupAppServicesAction: dispatching fetchTransactionsHistoryAction',
     );
-    await dispatch(fetchTransactionsHistoryAction());
+    dispatch(fetchTransactionsHistoryAction());
 
     logBreadcrumb('onboarding', 'setupAppServicesAction: dispatching rates action: fetchAssetsRatesAction');
     await dispatch(fetchAssetsRatesAction());


### PR DESCRIPTION
When we onboard users we wait until history is fetched which sometimes increases onboarding time by 30-40s (I think it has cold boot / throttle on the 3rd party API we’re using on Etherspot or else, will check with Etehrspot team and provide you an update).

Based on these changes we still dispatch history fetch action, but do not wait for result and let user go through onboarding, history will still appear once it’s fetched.