### PR TITLE
restore wallet backup notification

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -239,8 +239,6 @@ export const loginAction = (
         dispatch(fetchAllAccountsTotalBalancesAction());
       }
 
-      dispatch(checkForWalletBackupToastAction());
-
       // user is registered
       if (isOnline) {
         dispatch(fetchTransactionsHistoryAction());
@@ -285,6 +283,8 @@ export const loginAction = (
       }
 
       navigate(navigateToAppAction);
+
+      dispatch(checkForWalletBackupToastAction());
     } catch (e) {
       reportLog(`An error occurred whilst trying to complete auth actions: ${e.errorMessage}`, e);
       dispatch(updatePinAttemptsAction(true));

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -19,8 +19,6 @@
 */
 import { ethers } from 'ethers';
 import { NavigationActions } from 'react-navigation';
-import isEmpty from 'lodash.isempty';
-import get from 'lodash.get';
 import t from 'translations/translate';
 
 // components
@@ -37,7 +35,6 @@ import { WALLET_SETTINGS } from 'constants/navigationConstants';
 
 // utils
 import { getSaltedPin } from 'utils/wallet';
-import { findKeyBasedAccount, getAccountId } from 'utils/accounts';
 import { setKeychainDataObject } from 'utils/keychain';
 
 // services

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -131,17 +131,9 @@ export const checkForWalletBackupToastAction = () => {
   return (dispatch: Dispatch, getState: GetState) => {
     const {
       wallet: { backupStatus: { isImported, isBackedUp } },
-      accounts: { data: accounts },
-      assetsBalances: { data: balances },
     } = getState();
 
-    const keyBasedAccount = findKeyBasedAccount(accounts);
-    if (isImported || isBackedUp || !keyBasedAccount) return;
-
-    const keyBasedAccountBalances = balances[getAccountId(keyBasedAccount)];
-    const anyAssetHasPositiveBalance = !isEmpty(keyBasedAccountBalances)
-      && Object.values(keyBasedAccountBalances).some((asset) => !!Number(get(asset, 'balance', 0)));
-    if (!anyAssetHasPositiveBalance) return;
+    if (isImported || isBackedUp) return;
 
     Toast.show({
       message: t('toast.ensureBackup'),

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -345,7 +345,9 @@ class HeaderBlock extends React.Component<Props> {
         wrapperStyle.marginRight = -(20 - spacing.small);
       }
       if (type === RIGHT) {
-        wrapperStyle.marginRight = -20;
+        // not sure what's the full scope of this, but below causes close button to be moved too far right when in modal
+        // wrapperStyle.marginRight = -20;
+
         wrapperStyle.marginLeft = -(20 - spacing.small);
       }
 

--- a/storybook/__snapshots__/storyshots.test.js.snap
+++ b/storybook/__snapshots__/storyshots.test.js.snap
@@ -38890,7 +38890,6 @@ exports[`Storyshots HeaderBlock with close icon on the right 1`] = `
                   Array [
                     Object {
                       "marginLeft": -12,
-                      "marginRight": -20,
                     },
                     Object {
                       "marginBottom": -20,
@@ -46751,7 +46750,6 @@ exports[`Storyshots SlideModal default 1`] = `
                         Array [
                           Object {
                             "marginLeft": -12,
-                            "marginRight": -20,
                           },
                           Object {
                             "marginBottom": -20,


### PR DESCRIPTION
Includes:
- We no longer were showing notification to user to back up his wallet. This had key based wallet and its balance checks.
- Moved notification dispatch later after home screen navigation happens.
- Also fixed an issue where PIN confirm modal close button is padded too much to right. Wallet Settings modal is the only case we have it on the right as modal so that's probably why it wasn't noticed. Commented causing code just in case.