### PR TITLE
claim etherspot ens name tx

### DIFF
--- a/src/actions/ensRegistryActions.js
+++ b/src/actions/ensRegistryActions.js
@@ -36,7 +36,7 @@ import {
   reportErrorLog,
   resolveEnsName,
 } from 'utils/common';
-import { findFirstArchanovaAccount } from 'utils/accounts';
+import { findFirstArchanovaAccount, getAccountEnsName } from 'utils/accounts';
 
 // selectors
 import { accountsSelector } from 'selectors';
@@ -64,8 +64,9 @@ export const setEnsNameIfNeededAction = () => {
     const accounts = accountsSelector(getState());
     const legacySmartWallet = findFirstArchanovaAccount(accounts);
 
-    // perform clean Etherspot ENS reserve only for new accounts that does not have any Archanova account
-    if (legacySmartWallet) return;
+    // reserve Etherspot ENS only for new accounts that does not have ENS on Archanova account
+    const archanovaEnsName = getAccountEnsName(legacySmartWallet);
+    if (archanovaEnsName) return;
 
     dispatch(reserveEtherspotEnsNameAction(username));
   };

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -353,7 +353,7 @@ export class EtherspotService {
     const { account: etherspotAccount } = sdk.state;
     if (!etherspotAccount?.ensNode) {
       const ensNode = await this.getEnsNode(etherspotAccount.address);
-      if (ensNode?.state === ENSNodeStates.Reserved) {
+      if (ensNode && ensNode.state === ENSNodeStates.Reserved) {
         await sdk.batchClaimENSNode({ nameOrHashOrAddress: ensNode.name });
       }
     }


### PR DESCRIPTION
Puts Etherspot ENS claim transaction in any transaction batch that is estimated/sent.

Before put it's checked if the ENS is needed to claim.

~Few notes that needed to be fixed on Etherspot SDK/back-end before this gets merged:~
1. ~`validateENSName` should return invalid (throw exception) for reserved names (i.e. ardd.pillar.eth)~
2. ~`reserveENSName` should not let reserve on occupied ENS names~
3. ~after ENS name is claimed getENSNode returns updated ENS name state (from Reserved to Claimed) only after SDK is reinitiated~

Notes above are fixed. 3rd issue tends to be just a longer delay.