### PR TITLE
add native asset on supported empty list

### DIFF
--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -623,8 +623,8 @@ export class EtherspotService {
 
       supportedAssets = appendNativeAssetIfNeeded(chain, supportedAssets);
 
-      // rest of checks are Ethereum only
-      if (chain !== CHAIN.ETHEREUM) return supportedAssets;
+      // rest of checks are Ethereum mainnet (prod) only
+      if (chain !== CHAIN.ETHEREUM || !isProdEnv()) return supportedAssets;
 
       // add LP tokens from our own list, later this can be replaced with Etherspot list for LP tokens
       LIQUIDITY_POOLS().forEach(({

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -608,15 +608,15 @@ export class EtherspotService {
     }
 
     try {
-      const tokenListName = chain === CHAIN.ETHEREUM
+      const tokenListName = chain === CHAIN.ETHEREUM && isProdEnv()
         ? firebaseRemoteConfig.getString(REMOTE_CONFIG.FEATURE_TOKEN_LIST_ETHEREUM)
         : null;
 
-      const tokens: TokenListToken[] = await sdk.getTokenListTokens({ name: tokenListName });
+      let tokens: TokenListToken[] = await sdk.getTokenListTokens({ name: tokenListName });
 
       if (!tokens) {
         reportErrorLog('EtherspotService getSupportedAssets failed: no tokens returned', { tokenListName });
-        return null;
+        tokens = []; // let append native assets
       }
 
       let supportedAssets = tokens.map(parseTokenListToken);


### PR DESCRIPTION
Per title.

Returning `null` causes empty supported assets list which affects further flows such as fetching assets balances.