### PR TITLE
value input asset address fix, single rate fetch by address fix

### DIFF
--- a/src/actions/ratesActions.js
+++ b/src/actions/ratesActions.js
@@ -129,7 +129,7 @@ export const fetchAssetsRatesAction = () => {
 
 export const fetchSingleChainAssetRatesAction = (
   chain: Chain,
-  assetCode: string,
+  assetAddress: string,
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const {
@@ -144,10 +144,10 @@ export const fetchSingleChainAssetRatesAction = (
     const supportedAssetsPerChain = supportedAssetsPerChainSelector(getState());
     const chainSupportedAssets = supportedAssetsPerChain[chain] ?? [];
 
-    const asset = findAssetByAddress(chainSupportedAssets, assetCode);
+    const asset = findAssetByAddress(chainSupportedAssets, assetAddress);
     if (!asset) {
       dispatch(setIsFetchingRatesAction(false));
-      reportErrorLog('fetchSingleChainAssetRatesAction failed: cannot find asset', { assetCode });
+      reportErrorLog('fetchSingleChainAssetRatesAction failed: cannot find asset', { assetAddress });
       return;
     }
 

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -165,7 +165,10 @@ const ValueInputComponent = ({
   const [displayFiatAmount, setDisplayFiatAmount] = useState<boolean>(false);
   const [calculateBalanceSendPercent, setCalculateBalanceSendPercent] = useState<?number>(null);
 
-  const assetAddress = assetData?.contractAddress || '';
+  // TODO: fix AssetOption to contain contractAddress or address only, preference to address
+  // $FlowFixMe: address is not on Collectible type
+  const assetAddress = assetData?.contractAddress ?? assetData?.address ?? '';
+
   const assetSymbol = assetData?.symbol || '';
   const chain = assetData?.chain || CHAIN.ETHEREUM;
   const walletBalances = accountAssetsBalances?.[chain]?.wallet ?? {};

--- a/src/screens/SendSynthetic/SendSyntheticAmount.js
+++ b/src/screens/SendSynthetic/SendSyntheticAmount.js
@@ -60,7 +60,7 @@ import { activeSyntheticAssetsSelector } from 'selectors/synthetics';
 type Props = {
   navigation: NavigationScreenProp<any>,
   isOnline: boolean,
-  fetchSingleEthereumAssetRates: (assetCode: string) => void,
+  fetchSingleEthereumAssetRates: (assetAddress: string) => void,
   isFetchingSyntheticAssets: boolean,
   fetchAvailableSyntheticAssets: () => void,
   syntheticAssets: AssetOption[],
@@ -168,8 +168,8 @@ class SendSyntheticAmount extends React.Component<Props, State> {
     const { intentError } = this.state;
     const { fetchSingleEthereumAssetRates } = this.props;
     let updatedState = { value, assetData };
-    const symbol = assetData?.symbol;
-    if (value && symbol) fetchSingleEthereumAssetRates(symbol);
+    const assetAddress = assetData?.address ?? assetData?.contractAddress;
+    if (value && assetAddress) fetchSingleEthereumAssetRates(assetAddress);
 
     if (intentError) updatedState = { ...updatedState, intentError: null };
     this.setState(updatedState);
@@ -310,8 +310,8 @@ const combinedMapStateToProps = (state: RootReducerState): $Shape<Props> => ({
 
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
   fetchSingleEthereumAssetRates: (
-    assetCode: string,
-  ) => dispatch(fetchSingleChainAssetRatesAction(CHAIN.ETHEREUM, assetCode)),
+    assetAddress: string,
+  ) => dispatch(fetchSingleChainAssetRatesAction(CHAIN.ETHEREUM, assetAddress)),
   fetchAvailableSyntheticAssets: () => dispatch(fetchAvailableSyntheticAssetsAction()),
 });
 


### PR DESCRIPTION
Includes:
- Quick fix to get either `address` or `contractAddress` on `ValueInput` component.
- Small fix that found for fetching single asset rates.