### PR TITLE
PIL-1129: added few improvements to fix wc estimate loop

### DIFF
--- a/src/hooks/useWalletConnect.js
+++ b/src/hooks/useWalletConnect.js
@@ -17,7 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 // selectors
@@ -60,26 +60,48 @@ const useWalletConnect = (): UseWalletConnectResult => {
 
   const dispatch = useDispatch();
 
-  const connectToConnector = (uri: string) => dispatch(connectToWalletConnectConnectorAction(uri));
-  const disconnectSessionByUrl = (url: string) => dispatch(disconnectWalletConnectSessionByUrlAction(url));
+  const connectToConnector = useCallback(
+    (uri: string) => dispatch(connectToWalletConnectConnectorAction(uri)),
+    [dispatch],
+  );
 
-  const approveConnectorRequest = (peerId: string, chainId: number) =>
-    dispatch(approveWalletConnectConnectorRequestAction(peerId, chainId));
-  const rejectConnectorRequest = (peerId: string) => dispatch(rejectWalletConnectConnectorRequestAction(peerId));
+  const disconnectSessionByUrl = useCallback(
+    (url: string) => dispatch(disconnectWalletConnectSessionByUrlAction(url)),
+    [dispatch],
+  );
 
-  const approveCallRequest = (
-    callRequest: WalletConnectCallRequest,
-    result: string,
-  ) => dispatch(approveWalletConnectCallRequestAction(callRequest.callId, result));
+  const approveConnectorRequest = useCallback(
+    (peerId: string, chainId: number) => dispatch(approveWalletConnectConnectorRequestAction(peerId, chainId)),
+    [dispatch],
+  );
 
-  const rejectCallRequest = (
-    callRequest: WalletConnectCallRequest,
-    rejectReasonMessage?: string,
-  ) => dispatch(rejectWalletConnectCallRequestAction(callRequest.callId, rejectReasonMessage));
+  const rejectConnectorRequest = useCallback(
+    (peerId: string) => dispatch(rejectWalletConnectConnectorRequestAction(peerId)),
+    [dispatch],
+  );
 
-  const estimateCallRequestTransaction = (
-    callRequest: WalletConnectCallRequest,
-  ) => dispatch(estimateWalletConnectCallRequestTransactionAction(callRequest));
+  const approveCallRequest = useCallback(
+    (
+      callRequest: WalletConnectCallRequest,
+      result: string,
+    ) => dispatch(approveWalletConnectCallRequestAction(callRequest.callId, result)),
+    [dispatch],
+  );
+
+  const rejectCallRequest = useCallback(
+    (
+      callRequest: WalletConnectCallRequest,
+      rejectReasonMessage?: string,
+    ) => dispatch(rejectWalletConnectCallRequestAction(callRequest.callId, rejectReasonMessage)),
+    [dispatch],
+  );
+
+  const estimateCallRequestTransaction = useCallback(
+    (
+      callRequest: WalletConnectCallRequest,
+    ) => dispatch(estimateWalletConnectCallRequestTransactionAction(callRequest)),
+    [dispatch],
+  );
 
   return useMemo(() => ({
     activeConnectors,
@@ -91,10 +113,16 @@ const useWalletConnect = (): UseWalletConnectResult => {
     disconnectSessionByUrl,
     connectToConnector,
     estimateCallRequestTransaction,
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [
     activeConnectors,
     callRequests,
+    approveConnectorRequest,
+    rejectConnectorRequest,
+    approveCallRequest,
+    rejectCallRequest,
+    disconnectSessionByUrl,
+    connectToConnector,
+    estimateCallRequestTransaction,
   ]);
 };
 

--- a/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
+++ b/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
@@ -170,11 +170,31 @@ const useTransactionFee = (request: WalletConnectCallRequest) => {
   };
   const hasNotEnoughGas = !isEnoughBalanceForTransactionFee(walletBalances, balanceCheckTransaction, chain);
 
-  const { estimateCallRequestTransaction } = useWalletConnect();
+  const { estimateCallRequestTransaction, callRequests } = useWalletConnect();
 
-  React.useEffect(() => estimateCallRequestTransaction(request), [request, estimateCallRequestTransaction]);
+  React.useEffect(() => {
+    // perform additional check to avoid estimate on request dismiss
+    const requestExists = callRequests.some(({ callId }) => +callId === +request.callId);
+    if (!requestExists) return;
 
-  return { fee, gasSymbol, gasAddress, hasNotEnoughGas, isEstimating, estimationErrorMessage };
+    estimateCallRequestTransaction(request);
+  }, [request, estimateCallRequestTransaction, callRequests]);
+
+  return React.useMemo(() => ({
+    fee,
+    gasSymbol,
+    gasAddress,
+    hasNotEnoughGas,
+    isEstimating,
+    estimationErrorMessage,
+  }), [
+    fee,
+    gasSymbol,
+    gasAddress,
+    hasNotEnoughGas,
+    isEstimating,
+    estimationErrorMessage,
+  ]);
 };
 
 const useViewData = (request: WalletConnectCallRequest) => {

--- a/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
+++ b/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
@@ -174,7 +174,7 @@ const useTransactionFee = (request: WalletConnectCallRequest) => {
 
   React.useEffect(() => {
     // perform additional check to avoid estimate on request dismiss
-    const requestExists = callRequests.some(({ callId }) => +callId === +request.callId);
+    const requestExists = callRequests.some(({ callId }) => callId === request.callId);
     if (!requestExists) return;
 
     estimateCallRequestTransaction(request);

--- a/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
+++ b/src/screens/WalletConnect/CallRequest/TransactionRequestContent.js
@@ -180,21 +180,14 @@ const useTransactionFee = (request: WalletConnectCallRequest) => {
     estimateCallRequestTransaction(request);
   }, [request, estimateCallRequestTransaction, callRequests]);
 
-  return React.useMemo(() => ({
+  return {
     fee,
     gasSymbol,
     gasAddress,
     hasNotEnoughGas,
     isEstimating,
     estimationErrorMessage,
-  }), [
-    fee,
-    gasSymbol,
-    gasAddress,
-    hasNotEnoughGas,
-    isEstimating,
-    estimationErrorMessage,
-  ]);
+  };
 };
 
 const useViewData = (request: WalletConnectCallRequest) => {

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -186,20 +186,12 @@ const mapTransactionToTransactionPayload = (transaction: EthereumTransaction): T
 };
 
 export const getGasDecimals = (chain: Chain, gasToken: ?GasToken) => {
-  return gasToken?.decimals ?? nativeAssetPerChain[chain].decimals;
+  return gasToken?.decimals ?? nativeAssetPerChain[chain].decimals ?? 18;
 };
 
 export const getGasAddress = (chain: Chain, gasToken: ?GasToken) => {
-  return gasToken?.address ?? nativeAssetPerChain[chain].address;
+  return gasToken?.address ?? nativeAssetPerChain[chain].address ?? ADDRESS_ZERO;
 };
-
-// export const getGasDecimals = (chain: Chain, gasToken: ?GasToken) => {
-//   return gasToken?.decimals ?? nativeAssetPerChain[chain].decimals ?? 18;
-// };
-//
-// export const getGasAddress = (chain: Chain, gasToken: ?GasToken) => {
-//   return gasToken?.address ?? nativeAssetPerChain[chain].address ?? ADDRESS_ZERO;
-// };
 
 export const getGasSymbol = (chain: Chain, gasToken: ?GasToken) => {
   return gasToken?.symbol ?? nativeAssetPerChain[chain].symbol ?? ETH;

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -34,6 +34,7 @@ import { CHAIN } from 'constants/chainConstants';
 import { getBalance } from 'utils/assets';
 import { fromEthersBigNumber } from 'utils/bigNumber';
 import { nativeAssetPerChain } from 'utils/chains';
+import { reportErrorLog } from 'utils/common';
 
 // services
 import { buildERC721TransactionData, encodeContractMethod } from 'services/assets';
@@ -185,14 +186,38 @@ const mapTransactionToTransactionPayload = (transaction: EthereumTransaction): T
   return { to, amount, symbol: ETH, data, decimals: 18 };
 };
 
-export const getGasDecimals = (chain: Chain, gasToken: ?GasToken) => {
-  return gasToken?.decimals ?? nativeAssetPerChain[chain].decimals ?? 18;
+export const getGasDecimals = (chain: Chain, gasToken: ?GasToken): number => {
+  if (gasToken?.decimals) return gasToken.decimals;
+
+  const chainNativeAsset = nativeAssetPerChain[chain];
+  if (!chainNativeAsset) {
+    reportErrorLog('getGasDecimals failed: no native asset for chain', { chain });
+    return 18;
+  }
+
+  return chainNativeAsset.decimals;
 };
 
-export const getGasAddress = (chain: Chain, gasToken: ?GasToken) => {
-  return gasToken?.address ?? nativeAssetPerChain[chain].address ?? ADDRESS_ZERO;
+export const getGasAddress = (chain: Chain, gasToken: ?GasToken): string => {
+  if (gasToken?.address) return gasToken.address;
+
+  const chainNativeAsset = nativeAssetPerChain[chain];
+  if (!chainNativeAsset) {
+    reportErrorLog('getGasAddress failed: no native asset for chain', { chain });
+    return ADDRESS_ZERO;
+  }
+
+  return chainNativeAsset.address;
 };
 
-export const getGasSymbol = (chain: Chain, gasToken: ?GasToken) => {
-  return gasToken?.symbol ?? nativeAssetPerChain[chain].symbol ?? ETH;
+export const getGasSymbol = (chain: Chain, gasToken: ?GasToken): string => {
+  if (gasToken?.symbol) return gasToken.symbol;
+
+  const chainNativeAsset = nativeAssetPerChain[chain];
+  if (!chainNativeAsset) {
+    reportErrorLog('getGasSymbol failed: no native asset for chain', { chain });
+    return ETH;
+  }
+
+  return chainNativeAsset.symbol;
 };

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -23,7 +23,11 @@ import { BigNumber } from 'bignumber.js';
 import { BigNumber as EthersBigNumber, utils } from 'ethers';
 
 // constants
-import { COLLECTIBLES, ETH } from 'constants/assetsConstants';
+import {
+  ADDRESS_ZERO,
+  COLLECTIBLES,
+  ETH,
+} from 'constants/assetsConstants';
 import { CHAIN } from 'constants/chainConstants';
 
 // utils
@@ -188,6 +192,14 @@ export const getGasDecimals = (chain: Chain, gasToken: ?GasToken) => {
 export const getGasAddress = (chain: Chain, gasToken: ?GasToken) => {
   return gasToken?.address ?? nativeAssetPerChain[chain].address;
 };
+
+// export const getGasDecimals = (chain: Chain, gasToken: ?GasToken) => {
+//   return gasToken?.decimals ?? nativeAssetPerChain[chain].decimals ?? 18;
+// };
+//
+// export const getGasAddress = (chain: Chain, gasToken: ?GasToken) => {
+//   return gasToken?.address ?? nativeAssetPerChain[chain].address ?? ADDRESS_ZERO;
+// };
 
 export const getGasSymbol = (chain: Chain, gasToken: ?GasToken) => {
   return gasToken?.symbol ?? nativeAssetPerChain[chain].symbol ?? ETH;


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1129/check-continuous-estimation-triggered-on-walletconnect-transaction

This can only be replicated on production build and I was unable to do this locally. By inspecting code this is what I've found and improved:
1. I noticed that upon WC transaction reject it is still estimated, that happens because request that is passed from component is still there while at hook level for updated `callRequests` it's already removed. Adde additional check to follow this.
2. React `useEffect` return is a function that is executed on update, removed estimate action dispatch from that.
3. Added memoized return for `useTransactionFee`.
4. Added fallbacks to gas token address and decimals (we already had default symbol falling back to ETH).