### PR TITLE
PIL-1143: fixed no asset handling fr value input

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -502,7 +502,7 @@ class TextInput extends React.Component<Props, State> {
     const { fullWidth: fullWidthSelector } = selectorOptions;
 
     const showLeftAddon = (innerImageURI || fallbackSource) || !!leftSideText || !!leftSideSymbol;
-    const showRightAddon = !!iconProps || loading || rightPlaceholder;
+    const showRightAddon = !!iconProps || !!loading || !!rightPlaceholder;
 
     const selectorOptionsCount = this.getSelectorOptionsCount(selectorOptions);
 

--- a/src/components/ValueInput/ValueInput.js
+++ b/src/components/ValueInput/ValueInput.js
@@ -220,6 +220,8 @@ const ValueInputComponent = ({
   }, [txFeeInfo, calculateBalanceSendPercent]);
 
   const handleValueChange = (newValue: string) => {
+    if (!assetData) return;
+
     // ethers will crash with commas, TODO: we need a proper localisation
     newValue = newValue.replace(/,/g, '.');
     if (displayFiatAmount) {
@@ -338,12 +340,12 @@ const ValueInputComponent = ({
       setValueInFiat('0');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assetData.name]);
+  }, [assetData?.name]);
 
   const colors = getThemeColors(theme);
   const { towellie: genericCollectible } = images(theme);
 
-  const { tokenType = ASSET_TYPES.TOKEN } = assetData;
+  const { tokenType = ASSET_TYPES.TOKEN } = assetData ?? {};
 
   const toggleDisplayFiat = () => {
     // when switching at error state, reset values to avoid new errors

--- a/src/components/ValueInput/ValueInputHeader.js
+++ b/src/components/ValueInput/ValueInputHeader.js
@@ -21,14 +21,19 @@
 import * as React from 'react';
 import styled, { useTheme } from 'styled-components/native';
 
+// utils
 import { resolveAssetSource } from 'utils/textInput';
 import { images } from 'utils/images';
+import { fontStyles } from 'utils/variables';
+import { useTranslation } from 'translations/translate';
+
+// components
 import Icon from 'components/Icon';
 import Image from 'components/Image';
-import { fontStyles } from 'utils/variables';
 import { BaseText, MediumText } from 'components/Typography';
 import { Spacing } from 'components/Layout';
 
+// types
 import type { AssetOption } from 'models/Asset';
 import type { Collectible } from 'models/Collectible';
 
@@ -91,18 +96,22 @@ const ValueInputHeader = ({
   onAssetPress,
   disableAssetSelection,
 }: Props) => {
-  const { name, iconUrl, imageUrl } = asset;
-  const optionImageSource = resolveAssetSource(imageUrl || iconUrl);
+  const { t } = useTranslation();
 
   const theme = useTheme();
   const { genericToken } = images(theme);
+
+  const { name, iconUrl, imageUrl } = asset ?? {};
+
+  const optionImageSource = iconUrl || imageUrl
+    ? resolveAssetSource(imageUrl || iconUrl)
+    : genericToken;
 
   return (
     <Wrapper>
       <SideWrapper onPress={onAssetPress} disabled={disableAssetSelection || !onAssetPress}>
         <StyledImage
           source={optionImageSource}
-          fallbackSource={optionImageSource.uri !== undefined && genericToken}
           resizeMode="contain"
           style={{ height: 24, width: 24 }}
         />
@@ -117,7 +126,7 @@ const ValueInputHeader = ({
       </SideWrapper>
 
       <AssetName onPress={disableAssetSelection ? null : onAssetPress} numberOfLines={1}>
-        {name}
+        {name ?? t('label.pleaseSelect')}
       </AssetName>
 
       <Spacing w={8} />

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -260,7 +260,8 @@
     "archanovaToEtherspot": "Pillar V1 to Etherspot (Pillar V2)",
     "archanovaToEtherspotShort": "Pillar V1 to Etherspot",
     "deployed": "Deployed",
-    "walletDeployment": "Wallet deployment"
+    "walletDeployment": "Wallet deployment",
+    "pleaseSelect": "Please select"
   },
 
   "button": {

--- a/src/screens/Exchange/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange/Exchange.js
@@ -142,12 +142,6 @@ function Exchange() {
     [toOptions, toAddress, chain],
   );
 
-  // ValueInput crashes without asset.
-  const fallbackAsset = React.useMemo(
-    () => toOptions.find((a) => a.chain === chain && addressesEqual(a.address, nativeChainAssetAddress)),
-    [toOptions, chain, nativeChainAssetAddress],
-  );
-
   const offersQuery = useOffersQuery(chain, fromAsset, toAsset, fromAmount);
   const offers = sortOffers(offersQuery.data);
 
@@ -198,7 +192,8 @@ function Exchange() {
       <Content onScroll={() => Keyboard.dismiss()}>
         <FormWrapper>
           <ValueInput
-            assetData={fromAsset || fallbackAsset}
+            disabled={!fromAsset}
+            assetData={fromAsset}
             onAssetDataChange={(asset) => {
               if (asset.chain !== chain) setChain(asset.chain);
               setFromAddress(asset.address);
@@ -221,7 +216,7 @@ function Exchange() {
           <ValueInput
             disabled
             value={formattedToAmount}
-            assetData={toAsset || fallbackAsset}
+            assetData={toAsset}
             onAssetDataChange={(asset) => {
               if (asset.chain !== chain) setChain(asset.chain);
               setToAddress(asset.address);


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1143/improve-valueselector-component-to-allow-no-asset-state

Per title.

Side note: noticed that `fallbackSource` prop used for `FastImage` does not exist and likely is technical debt that needs to be fixed separately.