### PR TITLE
PIL-1144: added subsidized deployment fix

### DIFF
--- a/src/actions/transactionEstimateActions.js
+++ b/src/actions/transactionEstimateActions.js
@@ -69,7 +69,7 @@ export const setEstimatingTransactionAction = (isEstimating: boolean) => ({
 
 export const setTransactionsEstimateFeeAction = (feeInfo: ?TransactionFeeInfo) => {
   return (dispatch: Dispatch) => {
-    if (!feeInfo || (feeInfo.fee && !feeInfo.fee.gt(0))) {
+    if (!feeInfo || (feeInfo.fee && !feeInfo.fee.gte(0))) {
       dispatch(setTransactionsEstimateErrorAction(t('toast.transactionFeeEstimationFailed')));
       return;
     }

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -37,6 +37,7 @@ import {
   Transaction as EtherspotTransaction,
   Currencies as EtherspotCurrencies,
   ENSNodeStates,
+  AccountStates,
 } from 'etherspot';
 import { map } from 'rxjs/operators';
 import type { Subscription } from 'rxjs';
@@ -350,8 +351,12 @@ export class EtherspotService {
       throw new Error(t('error.unableToSetTransaction'));
     }
 
-    // check if ENS setup transaction needs to be included
     const { account: etherspotAccount } = sdk.state;
+    if (etherspotAccount.state === AccountStates.UnDeployed) {
+      await sdk.batchDeployAccount();
+    }
+
+    // check if ENS setup transaction needs to be included
     if (isProdEnv() && chain === CHAIN.ETHEREUM && !etherspotAccount?.ensNode) {
       const ensNode = await this.getEnsNode(etherspotAccount.address);
       if (ensNode && ensNode.state === ENSNodeStates.Reserved) {

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -353,6 +353,10 @@ export class EtherspotService {
 
     const { account: etherspotAccount } = sdk.state;
     if (etherspotAccount.state === AccountStates.UnDeployed) {
+      /**
+       * batchDeployAccount on back-end additionally checks if account is deployed
+       * regardless of our state check and either skips or adds deployment transaction.
+       */
       await sdk.batchDeployAccount();
     }
 


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1144/fix-subsidised-etherspot-smart-wallet-deployments-on-first-transaction

Adds manual deployment for every transaction which is the only way to get subsidised deployments on Etherspot back-end.

Side note: `batchDeployAccount` on back-end additionally checks if account is deployed regardless of our state check and either skips or adds deployment transaction.