### PR TITLE
fix double transaction status mapping

### DIFF
--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -261,7 +261,7 @@ export const getHistoryEventsFromTransactions = (
 ): Event[] => {
   let successfulOrPendingDeploymentEventAdded = false;
 
-  return orderBy(transactions, ['date'], ['desc']).reduce((
+  return orderBy(transactions, ['createdAt'], ['asc']).reduce((
     historyEvents,
     {
       _id,

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -297,7 +297,7 @@ export const getHistoryEventsFromTransactions = (
       date: new Date(+createdAt * 1000),
       fromAddress,
       toAddress,
-      status: TRANSACTION_STATUS[status],
+      status,
       batchHash,
       hash,
       fee,
@@ -330,7 +330,7 @@ export const getHistoryEventsFromTransactions = (
       successfulOrPendingDeploymentEventAdded = [
         TRANSACTION_STATUS.CONFIRMED,
         TRANSACTION_STATUS.PENDING,
-      ].includes(TRANSACTION_STATUS[historyEvent.status]);
+      ].includes(historyEvent.status);
 
       // $FlowFixMe: TODO: fix return for different event types
       return [...historyEvents, historyEvent, deploymentHistoryEvent];
@@ -366,7 +366,7 @@ export const getHistoryEventsFromCollectiblesTransactions = (
     date: new Date(+createdAt * 1000),
     fromAddress,
     toAddress,
-    status: TRANSACTION_STATUS[status],
+    status,
     batchHash,
     hash,
     imageUrl,


### PR DESCRIPTION
Includes:
1. Fixes wrong mapping into transaction statuses on Etherspot history parse util.
2. Fixes sorting before history item mapping to apply deployment events starting by oldest.
