### PR TITLE
target assets only matching source asset chain

### DIFF
--- a/src/screens/Exchange/Exchange/Exchange.js
+++ b/src/screens/Exchange/Exchange/Exchange.js
@@ -126,17 +126,14 @@ function Exchange() {
   );
 
   const toOptions = React.useMemo(
-    () => supportedChains.reduce((multiChainOptions, supportedChain) => {
-      const chainOptions = getExchangeToAssetOptions(
-        supportedAssetsPerChain,
-        walletBalancesPerChain,
-        fiatCurrency,
-        ratesPerChain,
-        supportedChain,
-      );
-      return [...multiChainOptions, ...chainOptions];
-    }, []),
-    [supportedChains, supportedAssetsPerChain, walletBalancesPerChain, fiatCurrency, ratesPerChain],
+    () => getExchangeToAssetOptions(
+      supportedAssetsPerChain,
+      walletBalancesPerChain,
+      fiatCurrency,
+      ratesPerChain,
+      chain,
+    ),
+    [chain, supportedAssetsPerChain, walletBalancesPerChain, fiatCurrency, ratesPerChain],
   );
 
   const fromAsset = React.useMemo(


### PR DESCRIPTION
Includes:
1. After recent discussion we decided to allow target exchange asset to be only selected from assets matching source asset chain.
2. Sushiswap Exchange provider added.