### PR TITLE
replace instabug boolean attribute to string

### DIFF
--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -242,9 +242,8 @@ export const setupSentryAction = (user: ?Object, wallet: Object) => {
     Instabug.setUserAttribute('activeAccountAddress', activeAccountAddress);
     Instabug.setUserAttribute('etherspotAccountAddress', etherspotAccountAddress);
     Instabug.setUserAttribute('archanovaAccountAddress', archanovaAccountAddress);
+    Instabug.setUserAttribute(IS_APP_VERSION_V3, 'true');
     /* eslint-enable i18next/no-literal-string */
-
-    Instabug.setUserAttribute(IS_APP_VERSION_V3, true);
 
     if (username) Instabug.setUserAttribute('ENS', username);
   };


### PR DESCRIPTION
Surprised that `true` as `boolean` actually never worked and it started failing because we removed `async` from action which was not discovered as not needed and action was just failing silently.