### PR TITLE
check undefined exchange options asset and log case

### DIFF
--- a/src/screens/Exchange/Exchange/utils.js
+++ b/src/screens/Exchange/Exchange/utils.js
@@ -29,6 +29,7 @@ import {
   addressesEqual,
 } from 'utils/assets';
 import { nativeAssetPerChain } from 'utils/chains';
+import { reportErrorLog } from 'utils/common';
 
 // Types
 import type {
@@ -63,7 +64,14 @@ export const getExchangeFromAssetOptions = (
   ) => chainSupportedAssets.some((supportedAsset) => addressesEqual(asset.address, supportedAsset.address));
 
   return sortAssets(chainAssets)
-    .filter((asset) => isMatching(asset) && isSupported(asset))
+    .filter((asset) => {
+      if (!asset) {
+        // debug and safe return for Sentry issue #2605322771
+        reportErrorLog('getExchangeFromAssetOptions failed: no asset', { asset, chainAssets });
+        return false;
+      }
+      return isMatching(asset) && isSupported(asset);
+    })
     .map((asset) => getAssetOption(asset, chainBalances, chainRates, currency, chain));
 };
 

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -332,10 +332,17 @@ export const isMatchingCollectible = (
 export const mapWalletAssetsBalancesIntoAssetsByAddress = (
   walletAssetsBalances: WalletAssetsBalances,
   chainSupportedAssets: Asset[],
-): AssetByAddress => mapValues(
-  walletAssetsBalances,
-  ({ address }: WalletAssetBalance) => findAssetByAddress(chainSupportedAssets, address),
-);
+): AssetByAddress => {
+  const walletAssets = Object.keys(walletAssetsBalances)
+    .map((assetAddress) => findAssetByAddress(chainSupportedAssets, assetAddress));
+
+  return walletAssets.reduce((assetsByAddress, asset) => {
+    // filter out no longer supported
+    if (!asset) return assetsByAddress;
+
+    return { ...assetsByAddress, [addressAsKey(asset.address)]: asset };
+  }, {});
+};
 
 export const sortSupportedAssets = (
   supportedChainAssets: AssetsPerChain,

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -53,6 +53,7 @@ import type { WalletAssetBalance, WalletAssetsBalances } from 'models/Balances';
 import type { Chain } from 'models/Chain';
 import type { Currency, RatesByAssetAddress } from 'models/Rates';
 import type { Value } from 'utils/common';
+import { omitNilProps } from 'utils/object';
 
 
 const sortAssetsFn = (a: Asset, b: Asset): number => {
@@ -333,15 +334,13 @@ export const mapWalletAssetsBalancesIntoAssetsByAddress = (
   walletAssetsBalances: WalletAssetsBalances,
   chainSupportedAssets: Asset[],
 ): AssetByAddress => {
-  const walletAssets = Object.keys(walletAssetsBalances)
-    .map((assetAddress) => findAssetByAddress(chainSupportedAssets, assetAddress));
+  const assetsByAddress = mapValues(
+    walletAssetsBalances,
+    ({ address }: WalletAssetBalance) => findAssetByAddress(chainSupportedAssets, address),
+  );
 
-  return walletAssets.reduce((assetsByAddress, asset) => {
-    // filter out no longer supported
-    if (!asset) return assetsByAddress;
-
-    return { ...assetsByAddress, [addressAsKey(asset.address)]: asset };
-  }, {});
+  // removes assets that were not found / no longer supported
+  return omitNilProps(assetsByAddress);
 };
 
 export const sortSupportedAssets = (


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1170/app-crash-on-swap-press

Based on Sentry issues for 3.5.3 (https://sentry.io/organizations/pillar-project-worldwide-ltd/releases/com.pillarproject.wallet%403.5.3%2B23475/?project=1294444&statsPeriod=14d&unselectedSeries=Healthy) it seems that app crash on Dashboard "Swap" press happens when options method gets `asset` as undefined.

While I was not able to replicate this I added additional check and log which we can move to internal build for our internal team to check that has crashes on this.