### PR TITLE
removed opensea deprecated query params

### DIFF
--- a/src/services/opensea.js
+++ b/src/services/opensea.js
@@ -69,11 +69,7 @@ export const fetchCollectibles = async (
 ): Promise<?OpenSeaAsset[]> => {
   if (!walletAddress) return null;
 
-  const url = `${getEnv().OPEN_SEA_API}/assets/` +
-    `?owner=${walletAddress}` +
-    '&exclude_currencies=true' +
-    '&order_by=listing_date' +
-    '&order_direction=asc';
+  const url = `${getEnv().OPEN_SEA_API}/assets/?owner=${walletAddress}`;
 
   return getOpenSeaAssets(url).catch((error) => {
     reportErrorLog('fetchCollectibles failed', { walletAddress, error });
@@ -87,7 +83,6 @@ export const fetchCollectiblesTransactionHistory = async (
   try {
     const url = `${getEnv().OPEN_SEA_API}/events/` +
       `?account_address=${walletAddress}` +
-      '&exclude_currencies=true' +
       '&event_type=transfer';
 
     const { data } = await httpRequest.get(url, requestConfig);


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PIL-1171/remove-deprecated-request-param-from-opensea-requests

Removed OpenSea deprecated param `exclude_currencies` and removed `order_by` because we had deprecated value for it and request was failing too allowing to sort only by sale params and I don't think we need to sort assets by sales.

This restores successful OpenSea requests.