### PR TITLE
Refactor: add chain field to Asset type

### DIFF
--- a/src/models/Asset.js
+++ b/src/models/Asset.js
@@ -53,9 +53,10 @@ export type TokenData = {|
 |};
 
 export type Asset = {
+  chain: Chain,
+  address: string,
   symbol: string,
   name: string,
-  address: string,
   iconUrl: string,
   decimals: number,
 };

--- a/src/reducers/__tests__/assetsReducer.test.js
+++ b/src/reducers/__tests__/assetsReducer.test.js
@@ -20,6 +20,7 @@
 
 // constants
 import { SET_SUPPORTED_ASSETS } from 'constants/assetsConstants';
+import { CHAIN } from 'constants/chainConstants';
 
 // reducers
 import reducer from 'reducers/assetsReducer';
@@ -31,6 +32,7 @@ import type { Asset } from 'models/Asset';
 describe('Assets reducer', () => {
   it('sorts supported assets', () => {
     const newAsset = (symbol: string): Asset => ({
+      chain: CHAIN.ETHEREUM,
       symbol,
       name: symbol,
       address: '0x0000',

--- a/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferEditAmount.js
+++ b/src/screens/KeyBasedAssetTransfer/KeyBasedAssetTransferEditAmount.js
@@ -97,7 +97,7 @@ function KeyBasedAssetTransferEditAmount() {
     navigation.goBack(null);
   };
 
-  const asset = assetData ? mapAssetDataToAsset(assetData) : null;
+  const asset = assetData ? mapAssetDataToAsset(assetData, CHAIN.ETHEREUM) : null;
 
   const buttonTitle = hasEnoughBalance ? t('button.confirm') : t('label.notEnoughBalance', { symbol: asset?.symbol });
 

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -639,7 +639,7 @@ export class EtherspotService {
         tokens = []; // let append native assets
       }
 
-      let supportedAssets = tokens.map(token => parseTokenListToken(token, chain));
+      let supportedAssets = tokens.map(token => parseTokenListToken(token));
 
       supportedAssets = appendNativeAssetIfNeeded(chain, supportedAssets);
 

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -639,7 +639,7 @@ export class EtherspotService {
         tokens = []; // let append native assets
       }
 
-      let supportedAssets = tokens.map(parseTokenListToken);
+      let supportedAssets = tokens.map(token => parseTokenListToken(token, chain));
 
       supportedAssets = appendNativeAssetIfNeeded(chain, supportedAssets);
 
@@ -656,6 +656,7 @@ export class EtherspotService {
         const existingAsset = findAssetByAddress(supportedAssets, address);
         if (!existingAsset) {
           supportedAssets.push({
+            chain,
             address,
             name,
             symbol,

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -288,8 +288,9 @@ export const isAssetOptionMatchedByQuery = (option: AssetOption, query: ?string)
   return caseInsensitiveIncludes(option.name, query) || caseInsensitiveIncludes(option.symbol, query);
 };
 
-export const mapAssetDataToAsset = (assetData: TokenData): Asset => {
+export const mapAssetDataToAsset = (assetData: TokenData, chain: Chain): Asset => {
   return {
+    chain,
     address: assetData.contractAddress,
     symbol: assetData.token,
     decimals: assetData.decimals,

--- a/src/utils/chains.js
+++ b/src/utils/chains.js
@@ -65,6 +65,7 @@ export function getSupportedChains(account: ?Account): Chain[] {
 /* eslint-disable i18next/no-literal-string */
 export const nativeAssetPerChain = {
   ethereum: {
+    chain: CHAIN.ETHEREUM,
     address: ADDRESS_ZERO,
     name: 'Ethereum',
     symbol: ETH,
@@ -72,6 +73,7 @@ export const nativeAssetPerChain = {
     iconUrl: 'https://tokens.1inch.exchange/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png',
   },
   polygon: {
+    chain: CHAIN.POLYGON,
     address: ADDRESS_ZERO,
     name: 'Matic',
     symbol: MATIC,
@@ -79,6 +81,7 @@ export const nativeAssetPerChain = {
     iconUrl: 'https://tokens.1inch.exchange/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0.png',
   },
   binance: {
+    chain: CHAIN.BINANCE,
     address: ADDRESS_ZERO,
     name: 'BNB',
     symbol: BNB,
@@ -86,6 +89,7 @@ export const nativeAssetPerChain = {
     iconUrl: 'https://tokens.1inch.exchange/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c.png',
   },
   xdai: {
+    chain: CHAIN.XDAI,
     address: ADDRESS_ZERO,
     name: 'xDAI',
     symbol: XDAI,

--- a/src/utils/etherspot.js
+++ b/src/utils/etherspot.js
@@ -48,7 +48,7 @@ import { firebaseRemoteConfig } from 'services/firebase';
 import { isEtherspotAccount } from 'utils/accounts';
 import { findAssetByAddress } from 'utils/assets';
 import { fromEthersBigNumber } from 'utils/bigNumber';
-import { nativeAssetPerChain } from 'utils/chains';
+import { chainFromChainId, nativeAssetPerChain } from 'utils/chains';
 import { buildHistoryTransaction } from 'utils/history';
 import { isProdEnv } from 'utils/environment';
 
@@ -180,14 +180,18 @@ export const parseEtherspotTransactionState = (state: GatewayBatchStates): ?stri
   }
 };
 
-export const parseTokenListToken = (
-  { address, name, symbol, decimals, logoURI }: TokenListToken,
-  chain: Chain,
-): Asset => {
+export const parseTokenListToken = ({
+  address,
+  name,
+  symbol,
+  decimals,
+  logoURI,
+  chainId,
+}: TokenListToken): Asset => {
   const hasValidIconUrl = logoURI?.startsWith('https://') || logoURI?.startsWith('http://');
 
   return {
-    chain,
+    chain: chainFromChainId[chainId],
     address,
     name,
     symbol,

--- a/src/utils/etherspot.js
+++ b/src/utils/etherspot.js
@@ -180,10 +180,14 @@ export const parseEtherspotTransactionState = (state: GatewayBatchStates): ?stri
   }
 };
 
-export const parseTokenListToken = ({ address, name, symbol, decimals, logoURI }: TokenListToken): Asset => {
+export const parseTokenListToken = (
+  { address, name, symbol, decimals, logoURI }: TokenListToken,
+  chain: Chain,
+): Asset => {
   const hasValidIconUrl = logoURI?.startsWith('https://') || logoURI?.startsWith('http://');
 
   return {
+    chain,
     address,
     name,
     symbol,


### PR DESCRIPTION
Motivation:
`Asset` object is usually meaningless with accompanying `chain` information. Currently this requires passing separately asset and chain to components. Similar entiries, `Collectible` and `AssetOption` already include chain field.

Scope:
- [x] Added `chain` to `Asset` type
- [x] Asset initialization to include `chain` field
- [x] Saved data migration 