### PR TITLE
PIL-1177 FastImage warning about `defaultSource`

### DIFF
--- a/src/components/AssetPattern/AssetPattern.js
+++ b/src/components/AssetPattern/AssetPattern.js
@@ -57,6 +57,7 @@ type Icon = string | { [uri: string]: ?string };
 
 
 const windowWidth = Dimensions.get('window').width;
+
 class AssetPattern extends React.Component<Props, State> {
   state = {
     errorLoading: false,

--- a/src/components/AssetPattern/AssetPattern.js
+++ b/src/components/AssetPattern/AssetPattern.js
@@ -23,10 +23,18 @@ import { Dimensions } from 'react-native';
 import styled, { withTheme } from 'styled-components/native';
 import { ColorMatrix, saturate } from 'react-native-color-matrix-image-filters';
 
+// Utils
 import { getColorByTheme, getThemeType } from 'utils/themes';
 import { images } from 'utils/images';
+
+// Constants
 import { LIGHT_THEME } from 'constants/appSettingsConstants';
+
+// Components
 import Image from 'components/Image';
+import CollectibleImage from 'components/CollectibleImage';
+
+// Types
 import type { Theme } from 'models/Theme';
 
 type Props = {
@@ -49,51 +57,6 @@ type Icon = string | { [uri: string]: ?string };
 
 
 const windowWidth = Dimensions.get('window').width;
-
-const Wrapper = styled.View`
-  width: 100%;
-  height: 250px;
-  justify-content: center;
-`;
-
-const PatternWrapper = styled.View`
-  width: 100%;
-  height: 220px;
-`;
-
-const NoIconWrapper = styled.View`
-  width: 100%;
-  height: 250px;
-  margin-top: 14px;
-  margin-bottom: 20px;
-  align-items: center;
-  justify-content: center;
-  opacity: ${props => props.isUnlisted ? 0.7 : 1};
-`;
-
-const IconWrapper = styled.View`
-  height: ${props => props.diameter}px;
-  width: ${props => props.diameter}px;
-  border: 2px solid ${({ theme }) => theme.colors.basic050};
-  position: absolute;
-  z-index: ${props => props.zIndex};
-  top: ${props => props.top}px;
-  left: ${props => props.left}px;
-  justify-content: center;
-  align-items: center;
-  elevation: ${props => props.addShadow ? props.elevation : 0};
-  shadow-color: ${getColorByTheme({ lightKey: 'basic010', darkCustom: 'transparent' })};
-  shadow-offset: ${props => props.addShadow ? '0px 3px' : 0};
-  shadow-opacity: ${props => props.addShadow ? props.shadowOpacity : 0};
-  shadow-radius: 6px;
-  background-color: ${({ theme }) => theme.colors.basic050};
-`;
-
-const NoIconImage = styled(Image)`
-  height: 192px;
-  width: 192px;
-`;
-
 class AssetPattern extends React.Component<Props, State> {
   state = {
     errorLoading: false,
@@ -247,13 +210,13 @@ class AssetPattern extends React.Component<Props, State> {
           <ColorMatrix
             matrix={saturate(saturation)}
           >
-            <Image
+            <CollectibleImage
               style={{
-                height: diameter - 4,
-                width: diameter - 4,
                 opacity,
                 borderRadius: (diameter - 4) / 2,
               }}
+              width={diameter - 4}
+              height={diameter - 4}
               source={icon}
               resizeMode="contain"
               onLoadEnd={() => { this.setState({ didLoad: true }); }}
@@ -296,3 +259,47 @@ class AssetPattern extends React.Component<Props, State> {
 }
 
 export default withTheme(AssetPattern);
+
+const Wrapper = styled.View`
+  width: 100%;
+  height: 250px;
+  justify-content: center;
+`;
+
+const PatternWrapper = styled.View`
+  width: 100%;
+  height: 220px;
+`;
+
+const NoIconWrapper = styled.View`
+  width: 100%;
+  height: 250px;
+  margin-top: 14px;
+  margin-bottom: 20px;
+  align-items: center;
+  justify-content: center;
+  opacity: ${props => props.isUnlisted ? 0.7 : 1};
+`;
+
+const IconWrapper = styled.View`
+  height: ${props => props.diameter}px;
+  width: ${props => props.diameter}px;
+  border: 2px solid ${({ theme }) => theme.colors.basic050};
+  position: absolute;
+  z-index: ${props => props.zIndex};
+  top: ${props => props.top}px;
+  left: ${props => props.left}px;
+  justify-content: center;
+  align-items: center;
+  elevation: ${props => props.addShadow ? props.elevation : 0};
+  shadow-color: ${getColorByTheme({ lightKey: 'basic010', darkCustom: 'transparent' })};
+  shadow-offset: ${props => props.addShadow ? '0px 3px' : 0};
+  shadow-opacity: ${props => props.addShadow ? props.shadowOpacity : 0};
+  shadow-radius: 6px;
+  background-color: ${({ theme }) => theme.colors.basic050};
+`;
+
+const NoIconImage = styled(Image)`
+  height: 192px;
+  width: 192px;
+`;

--- a/src/components/ProfileImage/ProfileImage.js
+++ b/src/components/ProfileImage/ProfileImage.js
@@ -58,7 +58,6 @@ const ProfileImage = (props: ProfileImageProps) => {
 
   const diameterWithBorder = diameter + (borderWidth * 2);
   const uri = getIdenticonImageUrl(userName, diameter);
-  // const uri = 'https://raw.githubusercontent.com/compound-finance/token-list/master/assets/asset_ZRX.svg';
   const { personIcon } = useThemedImages();
 
   const renderImage = () => (

--- a/src/components/ProfileImage/ProfileImage.js
+++ b/src/components/ProfileImage/ProfileImage.js
@@ -24,8 +24,78 @@ import styled, { css } from 'styled-components/native';
 import Image from 'components/Image';
 
 // Utils
-import { getIdenticonImageUrl } from 'utils/images';
+import { getIdenticonImageUrl, useThemedImages } from 'utils/images';
 import { getColorByTheme } from 'utils/themes';
+
+export type ProfileImageProps = {|
+  userName?: ?string,
+  containerStyle?: Object,
+  imageStyle?: Object,
+  onPress?: ?Function,
+  diameter?: number,
+  borderWidth?: number,
+  borderColor?: string,
+  style?: Object,
+  children?: React.Node,
+  cornerIcon?: Object,
+  cornerIconSize?: number,
+|};
+
+const ProfileImage = (props: ProfileImageProps) => {
+  const {
+    containerStyle,
+    imageStyle,
+    onPress,
+    style,
+    diameter = 50,
+    borderColor,
+    borderWidth = 0,
+    children,
+    userName,
+    cornerIcon,
+    cornerIconSize = 22,
+  } = props;
+
+  const diameterWithBorder = diameter + (borderWidth * 2);
+  const uri = getIdenticonImageUrl(userName, diameter);
+  // const uri = 'https://raw.githubusercontent.com/compound-finance/token-list/master/assets/asset_ZRX.svg';
+  const { personIcon } = useThemedImages();
+
+  const renderImage = () => (
+    <React.Fragment>
+      {children && <InnerBackground>{children}</InnerBackground>}
+
+      {!children && !!userName && (
+        <CircleImage
+          source={{ uri }}
+          diameter={diameter}
+          additionalImageStyle={imageStyle}
+          fallbackSource={personIcon}
+        />
+      )}
+    </React.Fragment>
+  );
+
+  return (
+    <ImageTouchable
+      additionalContainerStyle={containerStyle}
+      diameter={diameterWithBorder}
+      disabled={!onPress}
+      onPress={onPress}
+      transparent={uri}
+      style={style}
+      hasChildren={children}
+      borderWidth={borderWidth}
+      borderColor={borderColor}
+      needBackground={!uri}
+    >
+      {renderImage()}
+      {cornerIcon && <CornerIcon source={cornerIcon} size={cornerIconSize} />}
+    </ImageTouchable>
+  );
+};
+
+export default ProfileImage;
 
 const CircleImage = styled(Image)`
   width: ${props => (props.diameter ? props.diameter : '50')}px;
@@ -68,72 +138,3 @@ const CornerIcon = styled(Image)`
   right: 0;
 `;
 
-export type ProfileImageProps = {|
-  userName?: ?string,
-  containerStyle?: Object,
-  imageStyle?: Object,
-  onPress?: ?Function,
-  diameter?: number,
-  borderWidth?: number,
-  borderColor?: string,
-  style?: Object,
-  children?: React.Node,
-  cornerIcon?: Object,
-  cornerIconSize?: number,
-|};
-
-const IMAGE_LOAD_FAILED = 'image_load_failed';
-
-const ProfileImage = (props: ProfileImageProps) => {
-  const {
-    containerStyle,
-    imageStyle,
-    onPress,
-    style,
-    diameter = 50,
-    borderColor,
-    borderWidth = 0,
-    children,
-    userName,
-    cornerIcon,
-    cornerIconSize = 22,
-  } = props;
-
-  const diameterWithBorder = diameter + (borderWidth * 2);
-  const uri = getIdenticonImageUrl(userName, diameter);
-
-  const renderImage = () => (
-    <React.Fragment>
-      {children && <InnerBackground>{children}</InnerBackground>}
-
-      {!children && !!userName && (
-        <CircleImage
-          source={{ uri }}
-          diameter={diameter}
-          additionalImageStyle={imageStyle}
-          fallbackSource={IMAGE_LOAD_FAILED}
-        />
-      )}
-    </React.Fragment>
-  );
-
-  return (
-    <ImageTouchable
-      additionalContainerStyle={containerStyle}
-      diameter={diameterWithBorder}
-      disabled={!onPress}
-      onPress={onPress}
-      transparent={uri}
-      style={style}
-      hasChildren={children}
-      borderWidth={borderWidth}
-      borderColor={borderColor}
-      needBackground={!uri}
-    >
-      {renderImage()}
-      {cornerIcon && <CornerIcon source={cornerIcon} size={cornerIconSize} />}
-    </ImageTouchable>
-  );
-};
-
-export default ProfileImage;

--- a/src/components/display/TokenIcon.js
+++ b/src/components/display/TokenIcon.js
@@ -22,7 +22,7 @@ import * as React from 'react';
 import styled from 'styled-components/native';
 
 // Components
-import Image from 'components/Image';
+import CollectibleImage from 'components/CollectibleImage';
 
 // Utils
 import { useThemeColors } from 'utils/themes';
@@ -53,8 +53,6 @@ function TokenIcon({ url, size = 48, chain, style, imageStyle, chainIconStyle }:
 
   const source = url ? { uri: url } : genericToken;
   const imageSizeStyle = {
-    width: size,
-    height: size,
     borderRadius: size / 2,
   };
 
@@ -65,7 +63,13 @@ function TokenIcon({ url, size = 48, chain, style, imageStyle, chainIconStyle }:
 
   return (
     <Container style={style}>
-      <Image source={source} style={[imageSizeStyle, imageStyle]} />
+      <CollectibleImage
+        source={source}
+        resizeMode="contain"
+        width={size}
+        height={size}
+        style={[imageSizeStyle, imageStyle]}
+      />
 
       {!!ChainIcon && (
         <ChainIconWrapper style={[chainIconSizeStyle, chainIconStyle]}>


### PR DESCRIPTION
1. The warning is removed now. It was coming because in ProfileImage string value was set in fallbackSource(which we set the value of default source in Image component) and defaultSource prop accepts type ImageSource (object, array of objects, number).
2. Some of the token icon was not rendered as url was coming in svg and fast image does not support svg url. So I have modified the component. 

![Pil1177-1](https://user-images.githubusercontent.com/66996635/134487274-c4bbce00-b23d-4181-9e37-d81218d46d47.png)

