### PR TITLE
changed fetching balance from all tokens with fiat values

### DIFF
--- a/src/components/SendAsset/AssetSelector.js
+++ b/src/components/SendAsset/AssetSelector.js
@@ -55,6 +55,15 @@ type Props = {|
   txFeeInfo: ?TransactionFeeInfo,
 |};
 
+const getToken = (tokens, selectedToken) => {
+  return tokens.find(e => {
+    if (selectedToken?.chain === e.chain && selectedToken?.contractAddress === e.contractAddress) {
+      return true;
+    }
+    return false;
+  });
+};
+
 const AssetSelector = ({
   selectedToken,
   onSelectToken,
@@ -69,7 +78,11 @@ const AssetSelector = ({
   const tokens = useRootSelector(accountAssetsWithBalanceSelector);
   const collectibles = flattenCollectibles(useRootSelector(accountCollectiblesSelector));
 
-  const tokenBalance = useWalletAssetBalance(selectedToken?.chain, selectedToken?.address);
+  if (!!selectedToken && !tokens.includes(selectedToken)) {
+    selectedToken = getToken(tokens, selectedToken);
+  }
+
+  const tokenBalance = useWalletAssetBalance(selectedToken?.chain, selectedToken?.contractAddress);
   const tokenBalanceAfterFee = useTokenBalanceAfterFee(selectedToken, txFeeInfo);
 
   React.useEffect(() => {
@@ -119,7 +132,7 @@ const AssetSelector = ({
   }
 
   // Disable send max for native assets, as it's hard to get it right atm.
-  const disableMaxValue = isNativeAsset(selectedToken?.chain, selectedToken?.address);
+  const disableMaxValue = isNativeAsset(selectedToken?.chain, selectedToken?.contractAddress);
 
   return (
     <TokenFiatValueInputs


### PR DESCRIPTION
Balance didnt had fiatvalues while coming from asset screen to send flow was only passing asset details on nativagation parameters. So fetched from all tokens which were to be displayed on options to match the token details from the navigation params and got the balance along with fiat values

![PHOTO-2021-09-29-16-35-54](https://user-images.githubusercontent.com/82584664/135256802-c84d0e48-4d56-4452-8703-b39466361c4e.jpg)
![PHOTO-2021-09-29-16-43-27](https://user-images.githubusercontent.com/82584664/135257850-26178245-2670-4c29-9f70-c298e607fa86.jpg)

