### PR TITLE
fix/PIL-1195-ens-history-item-date-parse-fix

### DIFF
--- a/src/screens/History/MultiChainHistoryEtherspot.js
+++ b/src/screens/History/MultiChainHistoryEtherspot.js
@@ -214,7 +214,10 @@ function useEnsRegisteredEvent(chain: Chain): ?EnsNameRegisteredEvent {
     return {
       id: `ethereum-${EVENT_TYPE.ENS_NAME_REGISTERED}`,
       type: EVENT_TYPE.ENS_NAME_REGISTERED,
-      date: ensRegisteredDate ?? new Date(+createdAt - 1), // -1 to list it before smart wallet is created (per AC),
+      // As per acceptance criteria, the ENS history item needs to be
+      // visually after the wallet creation history item. Adding 1000ms
+      // achieves this.
+      date: ensRegisteredDate ?? new Date(Date.parse(createdAt) + 1000),
       ensName: getMigratedEnsName(accounts),
       hash: transactionHash,
       fee: transactionFee,


### PR DESCRIPTION
- Added fix to take into account new incoming date format for ENS history items. Not a perfect solution but fixes the issue for now.