### PR TITLE
PIL-1252 Issue on POAP NFT fee fetching

### DIFF
--- a/src/screens/SendCollectible/SendCollectibleConfirm.js
+++ b/src/screens/SendCollectible/SendCollectibleConfirm.js
@@ -42,7 +42,6 @@ import { Paragraph } from 'components/legacy/Typography';
 // Constants
 import { SEND_TOKEN_PIN_CONFIRM } from 'constants/navigationConstants';
 import { ETH } from 'constants/assetsConstants';
-import { CHAIN } from 'constants/chainConstants';
 
 // Utils
 import { isEnoughBalanceForTransactionFee } from 'utils/assets';
@@ -154,7 +153,7 @@ const SendCollectibleConfirm = ({
 
   useEffect(() => {
     resetEstimateTransaction();
-    estimateTransaction({ to: receiver, value: 0, assetData }, CHAIN.ETHEREUM);
+    estimateTransaction({ to: receiver, value: 0, assetData }, chain);
     if (isKovanNetwork) fetchRinkebyEth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
POAP NFT on xdai wasn't able to send since the default chain on sendCollectibleConfirm to estimate fee was ethereum which is why we got transaction reverted from backend
![b09037832c97612696447872ffff1a2dfa5f4c164716d80c46ddbfea1f89c0f6](https://user-images.githubusercontent.com/82584664/139806668-0367c28b-5af8-4069-a74a-0c81b9e41ef1.JPEG)
d 