### PR TITLE
fix/send-value-rounding-fee-estimation

### DIFF
--- a/src/actions/transactionEstimateActions.js
+++ b/src/actions/transactionEstimateActions.js
@@ -177,7 +177,7 @@ export const estimateTransactionsAction = (
         to,
         activeAccountAddress,
         data,
-        Number(value).toString(),
+        value,
         assetData?.token,
         assetData?.decimals,
         assetData?.tokenType,


### PR DESCRIPTION
- Removed `Number` as this causes decimal truncation and rounding, resulting in a possibly higher value being passed than what is available on-chain. This causes the Transaction Reverted error. Moral of the story is never to use `Number`'s in crypto.