### PR TITLE
PRO-442 Remove Copy button from 12 words screen

### DIFF
--- a/src/screens/BackupWallet/BackupPhraseValidate/BackupPhraseValidate.js
+++ b/src/screens/BackupWallet/BackupPhraseValidate/BackupPhraseValidate.js
@@ -96,13 +96,7 @@ const BackupPhraseValidate = ({ navigation, backupWallet }: Props) => {
           size="large"
         />
         {mnemonicPhrase ? (
-          <Button
-            title={t('button.copyToClipboard')}
-            variant="text"
-            style={styles.button}
-            size="large"
-            onPress={() => handleCopyToClipboard(mnemonicPhrase)}
-          />
+          null
         ) : (
           <Button
             title={t('button.copyToClipboard')}

--- a/src/screens/RevealBackupPhrase/RevealBackupPhrase.js
+++ b/src/screens/RevealBackupPhrase/RevealBackupPhrase.js
@@ -119,12 +119,6 @@ class RevealBackupPhrase extends React.Component<Props, State> {
               <Logo source={walletBackupImage} />
               <MnemonicPhrase phrase={mnemonicPhrase} />
             </Content>
-            <Button
-              title={t('button.copyToClipboard')}
-              style={styles.button}
-              size="large"
-              onPress={() => this.handleCopyToClipboard(mnemonicPhrase)}
-            />
           </NonScrollableContent>
         </Container>
       );


### PR DESCRIPTION
Remove copy button in two screens.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-09 at 20 06 51](https://user-images.githubusercontent.com/78720269/183677449-30b98e87-a352-48ba-b1f3-1f3e3b339d85.png)
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-09 at 20 04 46](https://user-images.githubusercontent.com/78720269/183677474-6a440503-a673-42b8-9294-b0b06bf4b68a.png)

