### PR TITLE
Fix - Tap areas increase for Settings and History

### DIFF
--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -296,11 +296,18 @@ class HeaderBlock extends React.Component<Props> {
     if (item.svgIcon) {
       const additionalIconStyle = {};
       const additionalIconProps = item.iconProps || {};
-      if (type === LEFT) additionalIconStyle.marginLeft = -10;
-      if (type === RIGHT) additionalIconStyle.marginRight = -10;
+      const buttonStyle = { paddingVertical: 2, paddingRight: 0, paddingLeft: 0 };
+      if (type === LEFT) {
+        additionalIconStyle.marginLeft = -10;
+        buttonStyle.paddingRight = 15;
+      }
+      if (type === RIGHT) {
+        additionalIconStyle.marginRight = -10;
+        buttonStyle.paddingLeft = 15;
+      }
       return (
         <View style={[commonStyle, itemStyle, additionalIconStyle]} key={item.svgIcon}>
-          <TouchableOpacity onPress={item.onPress} hitSlop={hitSlop20}>
+          <TouchableOpacity onPress={item.onPress} hitSlop={hitSlop20} style={buttonStyle}>
             <ActionSvgIcon
               name={item.svgIcon}
               color={


### PR DESCRIPTION
Increase tap area size.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 16 10 02](https://user-images.githubusercontent.com/78720269/185920498-ccbacce0-2f8f-4c03-b6a0-17cc9874711c.png)

