### PR TITLE
Fix - Splash screen (Android 12^)

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="main">#1a1a1a</color>
+    <color name="primary_dark">#000000</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
@@ -7,5 +7,10 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="colorControlNormal">#007AFF</item>
+        <item name="android:windowBackground">#000000</item>
+        <item name="android:windowSplashScreenBackground" tools:targetApi="s">#000000</item>
+        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">@android:color/transparent</item>
+        <item name="android:windowSplashScreenAnimationDuration" tools:targetApi="s">0</item>
+        <item name="android:windowIsTranslucent">true</item>
     </style>
 </resources>


### PR DESCRIPTION
* Set default black background splash screen for Android 12.

https://developer.android.com/develop/ui/views/launch/splash-screen

[splash.webm](https://user-images.githubusercontent.com/78720269/220934662-8f3e56e1-03dd-4ad6-b1a6-b05a99187b05.webm)
