### PR TITLE
Chore/new packages url

### DIFF
--- a/.circleci/announceURLs.sh
+++ b/.circleci/announceURLs.sh
@@ -25,4 +25,5 @@ cat <<EOM
 EOM
 )
 
-curl -X POST --data-urlencode payload="$payload" "$S3_URL_SLACK_WEBHOOK"
+# curl -X POST --data-urlencode payload="$payload" "$S3_URL_SLACK_WEBHOOK"
+curl -X POST --data-urlencode payload="$payload" "$S3_TEST_WEBHOOK"

--- a/.circleci/announceURLs.sh
+++ b/.circleci/announceURLs.sh
@@ -25,5 +25,4 @@ cat <<EOM
 EOM
 )
 
-# curl -X POST --data-urlencode payload="$payload" "$S3_URL_SLACK_WEBHOOK"
-curl -X POST --data-urlencode payload="$payload" "$S3_TEST_WEBHOOK"
+curl -X POST --data-urlencode payload="$payload" "$S3_URL_SLACK_WEBHOOK"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,12 +611,12 @@ jobs:
           command: |
             chmod +x .circleci/announceDeployment.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
-      - run:
-          name: Announce production iOS URL
-          command: |
-            cd ~/pillarwallet
-            chmod +x .circleci/announceURLs.sh
-            .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
+      # - run:
+      #     name: Announce production iOS URL
+      #     command: |
+      #       cd ~/pillarwallet
+      #       chmod +x .circleci/announceURLs.sh
+      #       .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive ipa file
           command: |
@@ -757,12 +757,12 @@ jobs:
           command: |
             chmod +x .circleci/announceDeployment.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
-      - run:
-          name: Announce Prod Android URL
-          command: |
-            cd ~/pillarwallet
-            chmod +x .circleci/announceURLs.sh
-            .circleci/announceURLs.sh "pillarwallet" "production" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/release/android-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
+      # - run:
+      #     name: Announce Prod Android URL
+      #     command: |
+      #       cd ~/pillarwallet
+      #       chmod +x .circleci/announceURLs.sh
+      #       .circleci/announceURLs.sh "pillarwallet" "production" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/release/android-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive apk file
           command: |
@@ -793,30 +793,41 @@ jobs:
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      - attach_workspace: &attach_workspace
-          at: /tmp/workspace
+      # - attach_workspace: &attach_workspace
+      #     at: /tmp/workspace
+      # - run:
+      #     name: Install github-release
+      #     command: |
+      #       go get github.com/github-release/github-release
+      # - run:
+      #     name: Set tag and publish releases to GitHub
+      #     command: |
+      #       chmod +x setReleaseInfo.sh
+      #       . ./setReleaseInfo.sh
+      #       TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+      #       APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
+      #       echo $SUPPORT_DESCRIPTION > support_description.txt
+      #       github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
+      #       sleep 10
+      #       github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
+      #       github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
       - run:
-          name: Install github-release
+          name: Announce production iOS and Android URL's
           command: |
-            go get github.com/github-release/github-release
-      - run:
-          name: Set tag and publish releases to GitHub
-          command: |
-            chmod +x setReleaseInfo.sh
-            . ./setReleaseInfo.sh
-            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
-            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
-            echo $SUPPORT_DESCRIPTION > support_description.txt
-            github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
-            sleep 10
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
-            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
-      - run:
-          name: Announce new RC to support channel
-          command: |
-            chmod +x .circleci/announceProdBuilds.sh
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
+            # cd ~/pillarwallet
+            # APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
+            APP_VERSION="3.21.3"
+            chmod +x .circleci/announceURLs.sh
+            IOS_URL="https://github.com/pillarwallet/pillarwallet/releases/download/v$APP_VERSION/pillarwallet-prod-ios-$APP_VERSION.ipa"
+            ANDROID_URL="https://github.com/pillarwallet/pillarwallet/releases/download/v$APP_VERSION/pillarwallet-prod-android-$APP_VERSION.apk"
+            .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$IOS_URL" "$APP_VERSION"
+            .circleci/announceURLs.sh "pillarwallet" "production" "android" "$ANDROID_URL" "$APP_VERSION"
+      # - run:
+      #     name: Announce new RC to support channel
+      #     command: |
+      #       chmod +x .circleci/announceProdBuilds.sh
+      #       .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
+      #       .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
 
 workflows:
   version: 2.1
@@ -830,6 +841,7 @@ workflows:
               ignore:
                 - develop
                 - master
+                - chore/new_packages_url
                 - /.*(u|U)(i|I)(-|_).*/
                 - /.*(-|_)(u|U)(i|I).*/
                 - /.*(u|U)(i|I)\/.*/
@@ -921,3 +933,12 @@ workflows:
           requires:
             - prod_android
             - prod_ios
+
+  test_announcement:
+    jobs:
+      - publish_releases_to_github:
+          context: docker-hub-creds
+          filters:
+            branches:
+              only:
+                - chore/new_packages_url

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,12 +611,6 @@ jobs:
           command: |
             chmod +x .circleci/announceDeployment.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
-      # - run:
-      #     name: Announce production iOS URL
-      #     command: |
-      #       cd ~/pillarwallet
-      #       chmod +x .circleci/announceURLs.sh
-      #       .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive ipa file
           command: |
@@ -757,12 +751,6 @@ jobs:
           command: |
             chmod +x .circleci/announceDeployment.sh
             .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
-      # - run:
-      #     name: Announce Prod Android URL
-      #     command: |
-      #       cd ~/pillarwallet
-      #       chmod +x .circleci/announceURLs.sh
-      #       .circleci/announceURLs.sh "pillarwallet" "production" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/release/android-s3-URL-prod.txt)" "$(cat /tmp/workspace/build-num/app_version.txt)"
       - run:
           name: prepare to archive apk file
           command: |
@@ -793,41 +781,39 @@ jobs:
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      # - attach_workspace: &attach_workspace
-      #     at: /tmp/workspace
-      # - run:
-      #     name: Install github-release
-      #     command: |
-      #       go get github.com/github-release/github-release
-      # - run:
-      #     name: Set tag and publish releases to GitHub
-      #     command: |
-      #       chmod +x setReleaseInfo.sh
-      #       . ./setReleaseInfo.sh
-      #       TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
-      #       APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
-      #       echo $SUPPORT_DESCRIPTION > support_description.txt
-      #       github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
-      #       sleep 10
-      #       github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
-      #       github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
+      - attach_workspace: &attach_workspace
+          at: /tmp/workspace
+      - run:
+          name: Install github-release
+          command: |
+            go get github.com/github-release/github-release
+      - run:
+          name: Set tag and publish releases to GitHub
+          command: |
+            chmod +x setReleaseInfo.sh
+            . ./setReleaseInfo.sh
+            TAG_VERSION="$(cat /tmp/workspace/build-num/gh_tag_version.txt)"
+            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
+            echo $SUPPORT_DESCRIPTION > support_description.txt
+            github-release release -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION  -n "$RELEASE_TITLE" --description "$RELEASE_DESCRIPTION"
+            sleep 10
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
+            github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
       - run:
           name: Announce production iOS and Android URL's
           command: |
-            # cd ~/pillarwallet
-            # APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
-            APP_VERSION="3.21.3"
+            APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
             chmod +x .circleci/announceURLs.sh
             IOS_URL="https://github.com/pillarwallet/pillarwallet/releases/download/v$APP_VERSION/pillarwallet-prod-ios-$APP_VERSION.ipa"
             ANDROID_URL="https://github.com/pillarwallet/pillarwallet/releases/download/v$APP_VERSION/pillarwallet-prod-android-$APP_VERSION.apk"
             .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$IOS_URL" "$APP_VERSION"
             .circleci/announceURLs.sh "pillarwallet" "production" "android" "$ANDROID_URL" "$APP_VERSION"
-      # - run:
-      #     name: Announce new RC to support channel
-      #     command: |
-      #       chmod +x .circleci/announceProdBuilds.sh
-      #       .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
-      #       .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
+      - run:
+          name: Announce new RC to support channel
+          command: |
+            chmod +x .circleci/announceProdBuilds.sh
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
 
 workflows:
   version: 2.1
@@ -841,7 +827,6 @@ workflows:
               ignore:
                 - develop
                 - master
-                - chore/new_packages_url
                 - /.*(u|U)(i|I)(-|_).*/
                 - /.*(-|_)(u|U)(i|I).*/
                 - /.*(u|U)(i|I)\/.*/
@@ -933,12 +918,3 @@ workflows:
           requires:
             - prod_android
             - prod_ios
-
-  test_announcement:
-    jobs:
-      - publish_releases_to_github:
-          context: docker-hub-creds
-          filters:
-            branches:
-              only:
-                - chore/new_packages_url


### PR DESCRIPTION
At the moment Slack messages for available apk/ipa package point to presigned s3 links that have expiration time and you can't download the package from these locations after expiration of assigned tokens.
This PR changes the way of Slack message's creation and now new available apk/ipa packages can be downloaded from GitHub releases location where assets are stored permanently.