### PR TITLE
PRO-1168: Added testID prop for elements in Onboarding flow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# ensure character set
+[*.{js,ts,tsx}]
+charset = utf-8
+
+# 2 space indentation using spaces, single quotes
+[*.{js,ts,tsx}]
+indent_style = space
+indent_size = 2
+quote_type = single
+max_line_length = 120
+
+[{package.json}]
+indent_style = space
+indent_size = 2

--- a/App.tsx
+++ b/App.tsx
@@ -438,6 +438,7 @@ const mapDispatchToProps = (dispatch: Dispatch): Partial<Props> => ({
   reduxFetchGasThresholds: () => dispatch(fetchGasThresholds()),
 });
 
+// @ts-ignore
 const AppWithNavigationState = connect(mapStateToProps, mapDispatchToProps)(withTranslation()(App));
 
 const AppRoot = () => (

--- a/src/components/BiometricModal/BiometricModal.js
+++ b/src/components/BiometricModal/BiometricModal.js
@@ -95,6 +95,7 @@ const BiometricModal = ({ onModalHide, biometricType, hasNoBiometrics = false }:
             titleColor={colors.buttonTextTitle}
             variant="text"
             onPress={() => proceedToBeginOnboarding()}
+            testID={`${TAG}-button-cancel`}
           />
           <VerticalDivider />
           <ButtonText
@@ -103,6 +104,7 @@ const BiometricModal = ({ onModalHide, biometricType, hasNoBiometrics = false }:
             style={styles.button}
             titleColor={colors.buttonTextTitle}
             onPress={() => proceedToBeginOnboarding(true)}
+            testID={`${TAG}-button-enable`}
           />
         </ButtonWrapper>
       </View>
@@ -149,3 +151,5 @@ const ButtonWrapper = styled.View`
 const ButtonText = styled(Button)`
   flex: 1;
 `;
+
+const TAG = 'BiometricModal';

--- a/src/components/ErrorMessage/ErrorMessage.js
+++ b/src/components/ErrorMessage/ErrorMessage.js
@@ -26,7 +26,8 @@ import { themedColors } from 'utils/themes';
 type Props = {
   children: React.Node,
   wrapperStyle?: Object,
-}
+  testID?: string,
+};
 
 const ErrorMessageBackground = styled.View`
   width: 100%;
@@ -41,14 +42,11 @@ const ErrorMessageText = styled(MediumText)`
 `;
 
 const ErrorMessage = (props: Props) => {
-  const { wrapperStyle } = props;
+  const { wrapperStyle, testID } = props;
   return (
     <ErrorMessageBackground style={wrapperStyle}>
-      <ErrorMessageText>
-        {props.children}
-      </ErrorMessageText>
+      <ErrorMessageText testID={testID}>{props.children}</ErrorMessageText>
     </ErrorMessageBackground>
-
   );
 };
 

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -53,6 +53,7 @@ type NavItem = {|
   style?: ViewStyleProp,
   color?: string,
   fontSize?: number,
+  testID?: string,
 |};
 
 export type OwnProps = {|
@@ -73,16 +74,19 @@ export type OwnProps = {|
   wrapperStyle?: Object,
   noHorizontalPadding?: boolean,
   forceInsetTop?: string,
+  testIdTag?: string,
 |};
 
 type Props = {|
   ...OwnProps,
   theme: Theme,
-|}
+|};
 
 const Wrapper = styled(Animated.View)`
   width: 100%;
-  ${({ floating }) => floating && `
+  ${({ floating }) =>
+    floating &&
+    `
     position: absolute;
     top: 0;
     left: 0;
@@ -98,7 +102,10 @@ const HeaderContentWrapper = styled.View`
 `;
 
 const SafeArea = styled(SafeAreaView)`
-  ${({ noPaddingTop, androidStatusbarHeight }) => !noPaddingTop && androidStatusbarHeight && `
+  ${({ noPaddingTop, androidStatusbarHeight }) =>
+    !noPaddingTop &&
+    androidStatusbarHeight &&
+    `
     margin-top: ${androidStatusbarHeight}px;
   `}
 `;
@@ -120,7 +127,7 @@ const CenterItems = styled.View`
 `;
 
 const LeftItems = styled.View`
-  flex: ${props => props.sideFlex ?? 1};
+  flex: ${(props) => props.sideFlex ?? 1};
   align-items: center;
   justify-content: flex-start;
   flex-direction: row;
@@ -128,7 +135,7 @@ const LeftItems = styled.View`
 `;
 
 const RightItems = styled.View`
-  flex: ${props => props.sideFlex ?? 1};
+  flex: ${(props) => props.sideFlex ?? 1};
   align-items: center;
   justify-content: flex-end;
   flex-direction: row;
@@ -142,7 +149,7 @@ const BackIcon = styled(IconButton)`
   width: 36px;
   height: 36px;
   border-radius: 36px;
-  background-color: ${getColorByTheme({ lightKey: 'basic060', darkKey: 'basic050' })}
+  background-color: ${getColorByTheme({ lightKey: 'basic060', darkKey: 'basic050' })};
 `;
 
 const ActionIcon = styled(IconButton)`
@@ -166,7 +173,7 @@ const CloseIcon = styled(IconButton)`
   align-self: center;
   padding: 15px;
   border-radius: 36px;
-  background-color: ${getColorByTheme({ lightKey: 'basic060', darkKey: 'basic050' })}
+  background-color: ${getColorByTheme({ lightKey: 'basic060', darkKey: 'basic050' })};
 `;
 
 const TextButton = styled.TouchableOpacity`
@@ -217,6 +224,7 @@ class HeaderBlock extends React.Component<Props> {
       customOnBack,
       theme,
       leftSideFlex,
+      testIdTag,
     } = this.props;
     const colors = getThemeColors(theme);
 
@@ -226,28 +234,24 @@ class HeaderBlock extends React.Component<Props> {
           sideFlex={sideFlex ?? leftSideFlex}
           style={!centerItems.length && !rightItems.length && !leftSideFlex ? { flexGrow: 2 } : {}}
         >
-          {(leftItems.length || !!noBack)
-            ? leftItems.map((item) => this.renderSideItems(item, LEFT))
-            : (
-              <BackIcon
-                icon="back"
-                color={colors.basic010}
-                onPress={customOnBack || (() => (navigation && navigation.goBack(null)))}
-                fontSize={fontSizes.big}
-              />
-            )
-          }
+          {leftItems.length || !!noBack ? (
+            leftItems.map((item) => this.renderSideItems(item, LEFT))
+          ) : (
+            <BackIcon
+              icon="back"
+              color={colors.basic010}
+              onPress={customOnBack || (() => navigation && navigation.goBack(null))}
+              fontSize={fontSizes.big}
+              testID={testIdTag && `${TAG}-${testIdTag}-button-left_back`}
+            />
+          )}
         </LeftItems>
-        {!!centerItems.length &&
-        <CenterItems>
-          {centerItems.map((item) => this.renderSideItems(item, CENTER))}
-        </CenterItems>
-        }
-        {(!!centerItems.length || !!rightItems.length) &&
-          <RightItems sideFlex={sideFlex}>
-            {rightItems.map((item) => this.renderSideItems(item, RIGHT))}
-          </RightItems>
-        }
+        {!!centerItems.length && (
+          <CenterItems>{centerItems.map((item) => this.renderSideItems(item, CENTER))}</CenterItems>
+        )}
+        {(!!centerItems.length || !!rightItems.length) && (
+          <RightItems sideFlex={sideFlex}>{rightItems.map((item) => this.renderSideItems(item, RIGHT))}</RightItems>
+        )}
       </HeaderRow>
     );
   };
@@ -259,14 +263,12 @@ class HeaderBlock extends React.Component<Props> {
     if (type === RIGHT && !item.noMargin) commonStyle.marginLeft = spacing.small;
     if (item.title) {
       return (
-        <View
-          style={[commonStyle, itemStyle]}
-          key={item.title}
-        >
+        <View style={[commonStyle, itemStyle]} key={item.title}>
           <HeaderTitleText
             style={item.color ? { color: item.color } : {}}
             onPress={item.onPress}
             centerText={type === CENTER}
+            testID={item.testID}
           >
             {item.title}
           </HeaderTitleText>
@@ -282,8 +284,9 @@ class HeaderBlock extends React.Component<Props> {
         <View style={[commonStyle, itemStyle, additionalIconStyle]} key={item.icon}>
           <ActionIcon
             icon={item.icon}
-            color={item.color
-              || getColorByThemeOutsideStyled(theme.current, { lightKey: 'basic010', darkKey: 'basic020' })}
+            color={
+              item.color || getColorByThemeOutsideStyled(theme.current, { lightKey: 'basic010', darkKey: 'basic020' })
+            }
             onPress={item.onPress}
             fontSize={item.fontSize || fontSizes.large}
             horizontalAlign="flex-start"
@@ -323,11 +326,7 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.iconSource) {
       return (
-        <TouchableOpacity
-          onPress={item.onPress}
-          key={item.key || item.iconSource}
-          style={[commonStyle, itemStyle]}
-        >
+        <TouchableOpacity onPress={item.onPress} key={item.key || item.iconSource} style={[commonStyle, itemStyle]}>
           <IconImage source={item.iconSource} />
           {!!item.indicator && <Indicator />}
         </TouchableOpacity>
@@ -335,11 +334,7 @@ class HeaderBlock extends React.Component<Props> {
     }
     if (item.link) {
       return (
-        <TextButton
-          onPress={item.onPress}
-          key={item.link}
-          style={[commonStyle, itemStyle]}
-        >
+        <TextButton onPress={item.onPress} key={item.link} style={[commonStyle, itemStyle]}>
           <ButtonLabel maxFontSizeMultiplier={1.1}>{item.link}</ButtonLabel>
           {item.addon}
         </TextButton>
@@ -385,7 +380,7 @@ class HeaderBlock extends React.Component<Props> {
       );
     }
     if (item.actionButton) {
-      return (<HeaderActionButton {...item.actionButton} wrapperStyle={[commonStyle, itemStyle]} />);
+      return <HeaderActionButton {...item.actionButton} wrapperStyle={[commonStyle, itemStyle]} />;
     }
     if (item.custom) {
       return (
@@ -418,10 +413,7 @@ class HeaderBlock extends React.Component<Props> {
 
     return (
       <ThemeProvider theme={updatedTheme}>
-        <Wrapper
-          floating={floating}
-          style={{ backgroundColor, ...wrapperStyle }}
-        >
+        <Wrapper floating={floating} style={{ backgroundColor, ...wrapperStyle }}>
           <SafeArea
             forceInset={{ bottom: 'never', top: forceInsetTop }}
             noPaddingTop={noPaddingTop}
@@ -438,3 +430,5 @@ class HeaderBlock extends React.Component<Props> {
 }
 
 export default (withTheme(HeaderBlock): React.AbstractComponent<OwnProps>);
+
+const TAG = 'HeaderBlock';

--- a/src/components/HeaderBlock/HeaderTitleText.js
+++ b/src/components/HeaderBlock/HeaderTitleText.js
@@ -26,6 +26,7 @@ type Props = {
   centerText?: boolean,
   color?: string,
   style?: Object,
+  testID?: string,
 };
 
 const StyledText = styled(MediumText)`

--- a/src/components/IconButton/IconButton.js
+++ b/src/components/IconButton/IconButton.js
@@ -44,11 +44,12 @@ export type Props = {
   theme: Theme,
   secondary?: boolean,
   hitSlop?: { top: number, left: number, bottom: number, right: number },
+  testID?: string,
 };
 
 const IconButtonWrapper = styled.TouchableOpacity`
   justify-content: center;
-  align-items: ${props => props.horizontalAlign ? props.horizontalAlign : 'center'};
+  align-items: ${(props) => (props.horizontalAlign ? props.horizontalAlign : 'center')};
   padding: 0;
 `;
 
@@ -73,6 +74,7 @@ const IconButton = (props: Props) => {
     secondary,
     theme,
     hitSlop,
+    testID,
   } = props;
   const colors = getThemeColors(theme);
   const iconColor = secondary ? colors.basic030 : color;
@@ -94,7 +96,13 @@ const IconButton = (props: Props) => {
     type,
   };
   return (
-    <IconButtonWrapper style={style} onPress={onPress} horizontalAlign={horizontalAlign} hitSlop={hitSlop}>
+    <IconButtonWrapper
+      style={style}
+      onPress={onPress}
+      horizontalAlign={horizontalAlign}
+      hitSlop={hitSlop}
+      testID={testID}
+    >
       <Icon {...iconParams} />
       {!!iconText && <ButtonText style={iconTextStyle}>{iconText}</ButtonText>}
     </IconButtonWrapper>

--- a/src/components/KeyPad/KeyPad.js
+++ b/src/components/KeyPad/KeyPad.js
@@ -59,15 +59,15 @@ const PinButton = styled.TouchableOpacity`
 `;
 
 const ButtonText = styled(BaseText)`
-  font-size: ${props => props.fontSize || fontSizes.large}px;
+  font-size: ${(props) => props.fontSize || fontSizes.large}px;
   align-self: center;
   line-height: 56px;
 `;
 
 const RippleSizer = styled.View`
-   height: 55px;
-   width: 100%;
-   align-self: center;
+  height: 55px;
+  width: 100%;
+  align-self: center;
 `;
 
 const ImageHolder = styled.View`
@@ -85,7 +85,6 @@ const Image = styled(RNImage)`
   height: 25px;
   align-self: center;
 `;
-
 
 const IMAGE = 'image';
 const STRING = 'string';
@@ -106,7 +105,8 @@ type Props = {
   style?: Object,
   inputColor?: string,
   theme: Theme,
-}
+  testIdTag?: string,
+};
 
 class KeyPad extends React.Component<Props> {
   static defaultProps = {
@@ -118,13 +118,7 @@ class KeyPad extends React.Component<Props> {
   };
 
   renderButton = (btn: KeyPadButton) => {
-    const {
-      label,
-      type,
-      image,
-      imageDarkTheme,
-      value,
-    } = btn;
+    const { label, type, image, imageDarkTheme, value } = btn;
     const { theme } = this.props;
     const { current: currentTheme = LIGHT_THEME } = theme;
     const colors = getThemeColors(theme);
@@ -142,30 +136,23 @@ class KeyPad extends React.Component<Props> {
       buttonFontSize = fontSizes.big;
     }
 
-    return (
-      <ButtonText fontSize={buttonFontSize}>
-        {label}
-      </ButtonText>
-    );
+    return <ButtonText fontSize={buttonFontSize}>{label}</ButtonText>;
   };
 
   renderKeys(buttons: any) {
     return buttons.map((btn: KeyPadButton) => {
-      const {
-        value,
-        label,
-      } = btn;
+      const { value, label } = btn;
+
+      const TAG = this.props.testIdTag;
 
       if (!label && label !== 0) {
-        return (
-          <KeyInput key={value} />
-        );
+        return <KeyInput key={value} />;
       }
 
       if (Platform.OS === 'ios') {
         return (
           <KeyInput key={value}>
-            <PinButton onPress={this.handleKeyPress(value)}>
+            <PinButton onPress={this.handleKeyPress(value)} testID={TAG && `${TAG}-button-keypad_${value}`}>
               {this.renderButton(btn)}
             </PinButton>
           </KeyInput>
@@ -176,10 +163,9 @@ class KeyPad extends React.Component<Props> {
           <TouchableNativeFeedback
             onPress={this.handleKeyPress(value)}
             background={TouchableNativeFeedback.SelectableBackgroundBorderless()}
+            testID={TAG && `$${TAG}-button-keypad_${value}`}
           >
-            <RippleSizer>
-              {this.renderButton(btn)}
-            </RippleSizer>
+            <RippleSizer>{this.renderButton(btn)}</RippleSizer>
           </TouchableNativeFeedback>
         </KeyInput>
       );
@@ -187,19 +173,12 @@ class KeyPad extends React.Component<Props> {
   }
 
   render() {
-    const {
-      style,
-      type,
-      customButtons,
-      options,
-    } = this.props;
+    const { style, type, customButtons, options } = this.props;
     const buttons = customButtons || (keyPadTypes[type] ? keyPadTypes[type](options) : keyPadTypes.numeric());
 
     return (
       <KeyPadWrapper style={style} ref={excludeFromMonitoring}>
-        <KeyPadInner>
-          {this.renderKeys(buttons)}
-        </KeyPadInner>
+        <KeyPadInner>{this.renderKeys(buttons)}</KeyPadInner>
       </KeyPadWrapper>
     );
   }

--- a/src/components/PinCode/PinCode.js
+++ b/src/components/PinCode/PinCode.js
@@ -38,7 +38,6 @@ import { maxPinCodeLengthSelector } from 'selectors/appSettings';
 // types
 import type { ViewStyleProp } from 'utils/types/react-native';
 
-
 type Props = {
   onPinEntered: Function,
   onPinChanged?: Function,
@@ -49,6 +48,7 @@ type Props = {
   customStyle?: ViewStyleProp,
   isLoading?: boolean,
   maxPinCodeLength?: number,
+  testIdTag?: string,
 };
 
 const PinDotsWrapper = styled(Wrapper)`
@@ -60,7 +60,6 @@ const Container = styled.View`
   flex-grow: 1;
   justify-content: space-between;
 `;
-
 
 const PinDotsWrapperAnimated = Animated.createAnimatedComponent(PinDotsWrapper);
 
@@ -76,6 +75,7 @@ const PinCode = ({
   showForgotButton = true,
   flex = true,
   maxPinCodeLength: defaultMaxPinCodeLength,
+  testIdTag,
 }: Props) => {
   const [pinCode, setPinCode] = useState([]);
   const maxPinCodeLength = defaultMaxPinCodeLength ?? useRootSelector(maxPinCodeLengthSelector);
@@ -98,9 +98,7 @@ const PinCode = ({
       return;
     }
 
-    const newPinCode = value === KEYPAD_BUTTON_DELETE
-      ? pinCode.slice(0, -1)
-      : [...pinCode, value];
+    const newPinCode = value === KEYPAD_BUTTON_DELETE ? pinCode.slice(0, -1) : [...pinCode, value];
 
     const enteredPinCodeLength = newPinCode.length;
 
@@ -127,12 +125,14 @@ const PinCode = ({
         flex={flex ? 1 : null}
         style={[
           {
-            transform: [{
-              translateX: errorShakeAnimation.interpolate({
-                inputRange: [0, 0.08, 0.25, 0.41, 0.58, 0.75, 0.92, 1],
-                outputRange: ([0, -10, 10, -10, 10, -5, 5, 0]: number[]),
-              }),
-            }],
+            transform: [
+              {
+                translateX: errorShakeAnimation.interpolate({
+                  inputRange: [0, 0.08, 0.25, 0.41, 0.58, 0.75, 0.92, 1],
+                  outputRange: ([0, -10, 10, -10, 10, -5, 5, 0]: number[]),
+                }),
+              },
+            ],
           },
           customStyle,
         ]}
@@ -147,11 +147,7 @@ const PinCode = ({
           />
         )}
       </PinDotsWrapperAnimated>
-      <KeyPad
-        type="pincode"
-        options={{ showForgotButton }}
-        onKeyPress={handleButtonPressed}
-      />
+      <KeyPad type="pincode" options={{ showForgotButton }} onKeyPress={handleButtonPressed} testIdTag={testIdTag} />
     </Container>
   );
 };

--- a/src/components/Switcher/Switcher.js
+++ b/src/components/Switcher/Switcher.js
@@ -27,10 +27,11 @@ type Props = {
   isOn?: boolean,
   onToggle: ?(boolean) => mixed,
   disabled?: boolean,
+  testID?: string,
 };
 
 type State = {
-  offsetX: Animated.Value
+  offsetX: Animated.Value,
 };
 
 const TOGGLE_DIAMETER = 28;
@@ -41,10 +42,15 @@ const Toggle = styled.View`
   align-items: center;
   justify-content: center;
   position: absolute;
-  background-color: ${({ isOn }) => isOn
-    ? css`${getColorByTheme({ lightKey: 'basic070', darkKey: 'basic050' })}`
-    : css`${getColorByTheme({ lightKey: 'basic070', darkCustom: '#a7a7a7' })}`};
-  elevation: ${({ disabled }) => disabled ? 0 : 2};
+  background-color: ${({ isOn }) =>
+    isOn
+      ? css`
+          ${getColorByTheme({ lightKey: 'basic070', darkKey: 'basic050' })}
+        `
+      : css`
+          ${getColorByTheme({ lightKey: 'basic070', darkCustom: '#a7a7a7' })}
+        `};
+  elevation: ${({ disabled }) => (disabled ? 0 : 2)};
   ${({ theme }) => theme.current === LIGHT_THEME && 'box-shadow: 0px 2px 2px rgba(0,0,0,0.05);'}
   width: ${TOGGLE_DIAMETER}px;
   height: ${TOGGLE_DIAMETER}px;
@@ -56,12 +62,11 @@ const SwitcherTouchable = styled.TouchableOpacity`
   width: 50px;
   border-radius: ${(TOGGLE_DIAMETER / 2) + 3}px;
   height: ${TOGGLE_DIAMETER + 3}px;
-  background-color: ${({ isOn, theme }) => isOn ? theme.colors.basic020 : theme.colors.basic080};
+  background-color: ${({ isOn, theme }) => (isOn ? theme.colors.basic020 : theme.colors.basic080)};
   ${({ disabled }) => disabled && 'opacity: 0.4;'}
 `;
 
 const AnimatedToggle = Animated.createAnimatedComponent(Toggle);
-
 
 class Switcher extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -79,26 +84,17 @@ class Switcher extends React.Component<Props, State> {
   toggle = () => {
     const { isOn } = this.props;
     const { offsetX } = this.state;
-    const toValue = isOn
-      ? ON_POSITION
-      : OFF_POSITION;
+    const toValue = isOn ? ON_POSITION : OFF_POSITION;
 
-    Animated.timing(
-      offsetX,
-      {
-        toValue,
-        duration: 300,
-        useNativeDriver: true,
-      },
-    ).start();
+    Animated.timing(offsetX, {
+      toValue,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
   };
 
   render() {
-    const {
-      isOn,
-      onToggle,
-      disabled,
-    } = this.props;
+    const { isOn, onToggle, disabled, testID } = this.props;
     const { offsetX } = this.state;
 
     return (
@@ -107,6 +103,7 @@ class Switcher extends React.Component<Props, State> {
         onPress={() => onToggle?.(!isOn)}
         disabled={disabled}
         isOn={isOn}
+        testID={testID}
       >
         <AnimatedToggle
           isOn={isOn}

--- a/src/components/core/Button.tsx
+++ b/src/components/core/Button.tsx
@@ -49,6 +49,7 @@ type Props = {
   titleColor?: string;
   titleStyle?: TextStyleProp;
   leftIconStyle?: ViewStyleProp;
+  testID?: string;
 };
 
 function Button({
@@ -62,6 +63,7 @@ function Button({
   titleColor,
   titleStyle,
   leftIconStyle,
+  testID,
 }: Props) {
   const [localDisabled, setLocalDisabled] = React.useState(false);
   const colors = useThemeColors();
@@ -88,6 +90,7 @@ function Button({
       style={style}
       $variant={variant}
       $size={size}
+      testID={testID}
     >
       {leftIcon && <LeftIcon name={leftIcon} color={titleColor} style={leftIconStyle} />}
 

--- a/src/components/core/Text.tsx
+++ b/src/components/core/Text.tsx
@@ -32,9 +32,10 @@ export type TextVariant = keyof typeof objectFontStyles;
 type Props = TextProps & {
   variant?: TextVariant;
   color?: string;
+  testID?: string;
 };
 
-function Text({ variant, color, style, ...rest }: Props) {
+function Text({ variant, color, style, testID, ...rest }: Props) {
   const colors = useThemeColors();
   const propStyle = StyleSheet.flatten(style);
 
@@ -48,7 +49,7 @@ function Text({ variant, color, style, ...rest }: Props) {
     style,
   ];
 
-  return <RNText {...rest} style={resultStyle} />;
+  return <RNText {...rest} style={resultStyle} testID={testID} />;
 }
 
 const baseStyle: TextStyleProp = {

--- a/src/components/legacy/Button/Button.js
+++ b/src/components/legacy/Button/Button.js
@@ -60,6 +60,7 @@ export type Props = {|
   transparent?: boolean,
   primarySecond?: boolean,
   warning?: boolean,
+  testID?: string,
 |};
 
 type CombinedProps = {|
@@ -340,6 +341,7 @@ class Button extends React.Component<CombinedProps, State> {
         borderRadius={small ? 3 : 6}
         style={style}
         variant={variant}
+        testID={this.props.testID}
       >
         {this.renderButtonContent(variant)}
         {children}

--- a/src/components/legacy/Checkbox/Checkbox.js
+++ b/src/components/legacy/Checkbox/Checkbox.js
@@ -27,7 +27,6 @@ import { LIGHT_THEME } from 'constants/appSettingsConstants';
 import type { Theme } from 'models/Theme';
 import { getColorByTheme, getThemeColors } from 'utils/themes';
 
-
 type Props = {
   text?: string,
   onPress?: () => void,
@@ -40,34 +39,41 @@ type Props = {
   small?: boolean,
   theme: Theme,
   positive?: boolean,
+  testID?: string,
 };
 
 const CheckboxBox = styled.View`
   width: 24px;
   height: 24px;
   margin-right: ${spacing.mediumLarge}px;
-  border-radius: ${({ rounded }) => rounded ? 12 : 2}px;
+  border-radius: ${({ rounded }) => (rounded ? 12 : 2)}px;
   flex: 0 0 24px;
   border-width: 1px;
-  border-color: ${({ active }) => active
-    ? css`${getColorByTheme({ lightKey: 'primaryAccent130', darkKey: 'basic090' })}`
-    : css`${getColorByTheme({ lightKey: 'basic080', darkKey: 'basic090' })}`};
+  border-color: ${({ active }) =>
+    active
+      ? css`
+          ${getColorByTheme({ lightKey: 'primaryAccent130', darkKey: 'basic090' })}
+        `
+      : css`
+          ${getColorByTheme({ lightKey: 'basic080', darkKey: 'basic090' })}
+        `};
   justify-content: center;
   align-items: center;
   background-color: ${getColorByTheme({ lightKey: 'basic070', darkKey: 'basic090' })};
-  ${({ rounded, clickable, theme }) => rounded && clickable && theme.current === LIGHT_THEME
-    ? `
+  ${({ rounded, clickable, theme }) =>
+    rounded && clickable && theme.current === LIGHT_THEME
+      ? `
       shadow-color: #000000;
       shadow-radius: 3px;
       shadow-opacity: 0.15;
       shadow-offset: 0px 2px;
       elevation: 4;`
-    : ''}
+      : ''}
 `;
 
 const CheckboxText = styled(BaseText)`
-  ${props => props.small ? fontStyles.regular : fontStyles.medium};
-  color: ${({ light, theme }) => light ? theme.colors.basic020 : theme.colors.basic010};
+  ${(props) => (props.small ? fontStyles.regular : fontStyles.medium)};
+  color: ${({ light, theme }) => (light ? theme.colors.basic020 : theme.colors.basic010)};
   flex-wrap: wrap;
 `;
 
@@ -81,7 +87,7 @@ const CheckboxWrapper = styled.View`
   flex-direction: row;
   align-items: flex-start;
   width: 100%;
-  opacity: ${props => props.disabled ? 0.5 : 1};
+  opacity: ${(props) => (props.disabled ? 0.5 : 1)};
 `;
 
 /**
@@ -102,33 +108,37 @@ const Checkbox = (props: Props) => {
     checked,
     onPress,
     positive,
+    testID,
   } = props;
 
   const colors = getThemeColors(theme);
 
   return (
-    <TouchableOpacity
-      onPress={!disabled ? onPress : null}
-      style={wrapperStyle}
-      disabled={!onPress}
-    >
+    <TouchableOpacity onPress={!disabled ? onPress : null} style={wrapperStyle} disabled={!onPress} testID={testID}>
       <CheckboxWrapper disabled={disabled}>
         <CheckboxBox active={checked} rounded={rounded} positive={positive} clickable={!disabled}>
-          {!!checked &&
-          <Icon
-            name="check"
-            style={{
-              color: positive ? colors.positive : colors.primary,
-              fontSize: fontSizes.tiny,
-            }}
-          />
-          }
+          {!!checked && (
+            <Icon
+              name="check"
+              style={{
+                color: positive ? colors.positive : colors.primary,
+                fontSize: fontSizes.tiny,
+              }}
+            />
+          )}
         </CheckboxBox>
-        {!!text && <CheckboxText small={small} light={lightText}>{text}</CheckboxText>}
-        {!!children &&
-        <TextWrapper>
-          <CheckboxText small={small} light={lightText}>{children}</CheckboxText>
-        </TextWrapper>}
+        {!!text && (
+          <CheckboxText small={small} light={lightText}>
+            {text}
+          </CheckboxText>
+        )}
+        {!!children && (
+          <TextWrapper>
+            <CheckboxText small={small} light={lightText}>
+              {children}
+            </CheckboxText>
+          </TextWrapper>
+        )}
       </CheckboxWrapper>
     </TouchableOpacity>
   );

--- a/src/components/legacy/Tabs/Tabs.js
+++ b/src/components/legacy/Tabs/Tabs.js
@@ -26,6 +26,7 @@ type Tab = {
   id: string,
   name: string,
   onPress: () => void,
+  testID?: string,
 };
 
 type TabProps = Tab & {
@@ -56,10 +57,10 @@ const TabContainer = styled.TouchableOpacity`
   align-items: center;
 `;
 
-const TabComponent = ({ name, onPress, active }: TabProps) => {
+const TabComponent = ({ name, onPress, active, testID }: TabProps) => {
   if (active) {
     return (
-      <TabContainer onPress={onPress}>
+      <TabContainer onPress={onPress} testID={testID}>
         <View>
           <BaseText regular>{name}</BaseText>
           <Underline />
@@ -69,7 +70,9 @@ const TabComponent = ({ name, onPress, active }: TabProps) => {
   }
   return (
     <TabContainer onPress={onPress}>
-      <BaseText regular secondary>{name}</BaseText>
+      <BaseText regular secondary>
+        {name}
+      </BaseText>
     </TabContainer>
   );
 };
@@ -82,7 +85,9 @@ const TabComponent = ({ name, onPress, active }: TabProps) => {
 const Tabs = ({ tabs, activeTab, wrapperStyle }: Props) => {
   return (
     <TabsContainer style={wrapperStyle}>
-      {tabs.map(tab => <TabComponent {...tab} active={activeTab === tab.id} key={tab.id} />)}
+      {tabs.map((tab) => (
+        <TabComponent {...tab} active={activeTab === tab.id} key={tab.id} />
+      ))}
     </TabsContainer>
   );
 };

--- a/src/components/legacy/TextInput/TextInput.js
+++ b/src/components/legacy/TextInput/TextInput.js
@@ -71,7 +71,8 @@ type Props = {
   leftSideSymbol?: string,
   inputError?: boolean,
   avoidAutoFocus?: boolean,
-  disableSelection?: boolean
+  disableSelection?: boolean,
+  testID?: string,
 };
 
 type State = {
@@ -261,6 +262,7 @@ class TextInput extends React.Component<Props, State> {
       inputError = false,
       avoidAutoFocus = false,
       disableSelection,
+      testID,
     } = this.props;
     let { fallbackSource, hasError } = this.props;
 
@@ -344,6 +346,7 @@ class TextInput extends React.Component<Props, State> {
                       smallPadding={!!onRightAddonPress}
                       autoFocus={!avoidAutoFocus}
                       selection={disableSelection ? undefined : selectionStart}
+                      testID={testID}
                     />
                   </View>
                 </TouchableWithoutFeedback>
@@ -372,6 +375,7 @@ class TextInput extends React.Component<Props, State> {
                     this.rnInput = ref;
                   }}
                   onFocus={this.handleRNFocus}
+                  testID={testID}
                 />
               )}
             </ItemHolder>

--- a/src/components/lists/CollectibleListItem.js
+++ b/src/components/lists/CollectibleListItem.js
@@ -39,14 +39,15 @@ type Props = {|
   onPress?: () => mixed,
   leftAddOn?: React.Node,
   style?: ViewStyleProp,
+  testID?: string,
 |};
 
 /**
  * Standard collectible list item displaying icon, name and optionally subtitle and left add-on (e.g. checkbox).
  */
-function CollectibleListItem({ collectible, subtitle, onPress, leftAddOn, style }: Props) {
+function CollectibleListItem({ collectible, subtitle, onPress, leftAddOn, style, testID }: Props) {
   return (
-    <Container onPress={onPress} disabled={!onPress} style={style}>
+    <Container onPress={onPress} disabled={!onPress} style={style} testID={testID}>
       {!!leftAddOn && <LeftAddOn>{leftAddOn}</LeftAddOn>}
 
       <CollectibleImage source={{ uri: collectible.iconUrl }} width={48} height={48} style={styles.icon} />

--- a/src/screens/AppAppearence/AppAppearence.js
+++ b/src/screens/AppAppearence/AppAppearence.js
@@ -95,7 +95,7 @@ const AppAppearence = () => {
 
   return (
     <Container>
-      <HeaderBlock leftItems={[{ close: true }]} onClose={onBackPress} noPaddingTop />
+      <HeaderBlock leftItems={[{ close: true }]} onClose={onBackPress} noPaddingTop testIdTag={TAG} />
       <Center flex={1} padding={spacing.rhythm}>
         <Title>{t('auth:title.appAppearence')}</Title>
         <Text color={colors.tertiaryText} variant="medium" style={appearenceStyles.textStyle}>
@@ -105,6 +105,7 @@ const AppAppearence = () => {
           <Themes
             onPress={onPressLightTheme}
             style={isLightThemePressed && [selectedThemeStyle, { borderColor: colors.buttonPrimaryBackground }]}
+            testID={`${TAG}-button-light_theme`}
           >
             <ThemeImage source={lightTheme} />
             <Text variant="small" style={appearenceStyles.textStyle}>
@@ -114,6 +115,7 @@ const AppAppearence = () => {
           <Themes
             onPress={onPressDarkTheme}
             style={isDarkThemePressed && [selectedThemeStyle, { borderColor: colors.buttonPrimaryBackground }]}
+            testID={`${TAG}-button-dark_theme`}
           >
             <ThemeImage source={darkTheme} />
             <Text variant="small" style={appearenceStyles.textStyle}>
@@ -126,6 +128,7 @@ const AppAppearence = () => {
           size="large"
           style={appearenceStyles.confirmButton}
           onPress={onConfirm}
+          testID={`${TAG}-button-confirm`}
         />
       </Center>
     </Container>
@@ -176,3 +179,5 @@ const ThemeImage = styled(Image)`
 `;
 
 export default AppAppearence;
+
+const TAG = 'AppAppearance';

--- a/src/screens/BiometricsPrompt/BiometricsPrompt.js
+++ b/src/screens/BiometricsPrompt/BiometricsPrompt.js
@@ -44,7 +44,6 @@ import { themedColors } from 'utils/themes';
 // types
 import type { Dispatch } from 'reducers/rootReducer';
 
-
 type Props = {
   navigation: NavigationScreenProp<*>,
   beginOnboarding: (enableBiometrics: boolean) => void,
@@ -76,7 +75,7 @@ const ButtonsWrapper = styled.View`
 const TouchIdImage = styled(Image)`
   width: 164px;
   height: 164px;
-  tintColor: ${themedColors.positive};
+  tintcolor: ${themedColors.positive};
 `;
 
 const getBiometryImage = (biometryType: string) => {
@@ -98,7 +97,9 @@ const showFaceIDFailed = () => {
     emoji: 'pensive',
     supportLink: true,
     link: t('label.faceIDSettings'),
-    onLinkPress: () => { Linking.openURL('app-settings:'); },
+    onLinkPress: () => {
+      Linking.openURL('app-settings:');
+    },
     autoClose: true,
   });
 };
@@ -116,9 +117,7 @@ class BiometricsPrompt extends React.Component<Props> {
      * is given to the app and not the user (obvious, but just making a note if questions rise)
      */
     const biometryType = navigation.getParam('biometryType');
-    if (setBiometrics
-      && Platform.OS === 'ios'
-      && biometryType === Keychain.BIOMETRY_TYPE.FACE_ID) {
+    if (setBiometrics && Platform.OS === 'ios' && biometryType === Keychain.BIOMETRY_TYPE.FACE_ID) {
       requestPermission(PERMISSIONS.IOS.FACE_ID)
         .then((status) => beginOnboarding(status === RESULTS.GRANTED))
         .catch(showFaceIDFailed);
@@ -144,11 +143,13 @@ class BiometricsPrompt extends React.Component<Props> {
                 title={t('auth:button.yesPlease')}
                 onPress={() => this.proceedToBeginOnboarding(true)}
                 marginBottom={4}
+                testID={`${TAG}-button-yes`}
               />
               <Button
                 transparent
                 title={t('auth:button.okToUsePinCodeOnly')}
                 onPress={() => this.proceedToBeginOnboarding(false)}
+                testID={`${TAG}-pin_only`}
               />
             </ButtonsWrapper>
           </ContentInnerWrapper>
@@ -163,3 +164,5 @@ const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
 });
 
 export default connect(null, mapDispatchToProps)(BiometricsPrompt);
+
+const TAG = 'BiometricsPrompt';

--- a/src/screens/ForgotPin/ForgotPin.js
+++ b/src/screens/ForgotPin/ForgotPin.js
@@ -38,12 +38,11 @@ import { spacing } from 'utils/variables';
 // types
 import type { OnValidPinCallback } from 'models/Wallet';
 
-
 type Props = {
   checkPin: (pin: string, onValidPin: ?OnValidPinCallback) => Function,
   wallet: Object,
   navigation: NavigationScreenProp<*>,
-}
+};
 
 const FooterParagraph = styled(Paragraph)`
   margin-bottom: ${spacing.rhythm}px;
@@ -68,27 +67,31 @@ class ForgotPin extends React.Component<Props, {}> {
   render() {
     return (
       <ContainerWithHeader
-        headerProps={({
+        headerProps={{
           centerItems: [{ title: t('auth:title.forgotPin') }],
           rightItems: [{ close: true }],
           noBack: true,
           onClose: this.goBackToPin,
-        })}
-        footer={(
+        }}
+        footer={
           <FooterWrapper>
-            <FooterParagraph>
-              {t('auth:paragraph.restoreWalletWarning')}
-            </FooterParagraph>
+            <FooterParagraph>{t('auth:paragraph.restoreWalletWarning')}</FooterParagraph>
             <Button
               leftIconName="down-arrow"
               danger
               marginBottom={4}
               onPress={this.toImportWallet}
               title={t('auth:title.importWallet')}
+              testID={`${TAG}-button-import_wallet`}
             />
-            <Button onPress={this.goBackToPin} transparent title={t('auth:button.backToPin')} />
+            <Button
+              onPress={this.goBackToPin}
+              transparent
+              title={t('auth:button.backToPin')}
+              testID={`${TAG}-button-back`}
+            />
           </FooterWrapper>
-        )}
+        }
       >
         <Wrapper regularPadding style={{ marginTop: spacing.layoutSides }}>
           <Paragraph>{t('auth:paragraph.restoreWalletInstructions')}</Paragraph>
@@ -102,3 +105,5 @@ class ForgotPin extends React.Component<Props, {}> {
 const mapStateToProps = ({ wallet: { data: wallet } }) => ({ wallet });
 
 export default connect(mapStateToProps)(ForgotPin);
+
+const TAG = 'ForgotPin';

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -222,17 +222,30 @@ function Home() {
       <>
         <Container>
           <HeaderBlock
-            leftItems={[{ svgIcon: 'menu', color: colors.basic020, onPress: () => navigation.navigate(MENU) }]}
+            leftItems={[
+              {
+                svgIcon: 'menu',
+                color: colors.basic020,
+                onPress: () => navigation.navigate(MENU),
+                testID: `${TAG}-button-header_menu`, // eslint-disable-line i18next/no-literal-string
+              },
+            ]}
             centerItems={[
               {
                 custom: <UserNameAndImage user={user?.username} address={accountAddress} />,
               },
             ]}
             rightItems={[
-              { svgIcon: 'history', color: colors.basic020, onPress: () => navigation.navigate(HOME_HISTORY) },
+              {
+                svgIcon: 'history',
+                color: colors.basic020,
+                onPress: () => navigation.navigate(HOME_HISTORY),
+                testID: `${TAG}-button-header_history`, // eslint-disable-line i18next/no-literal-string
+              },
             ]}
             navigation={navigation}
             noPaddingTop
+            testIdTag={TAG}
           />
 
           {/* this should stay first element, avoid putting it inside UserNameAndImage */}
@@ -301,3 +314,5 @@ function Home() {
 }
 
 export default Home;
+
+const TAG = 'Home';

--- a/src/screens/ImportWallet/ImportWallet.js
+++ b/src/screens/ImportWallet/ImportWallet.js
@@ -46,7 +46,6 @@ import { excludeFromMonitoring } from 'utils/monitoring';
 // types
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 
-
 type Props = {
   importWalletFromMnemonic: (mnemonic: string) => void,
   wallet: Object,
@@ -145,7 +144,9 @@ class ImportWallet extends React.Component<Props, State> {
     if (activeTab === DEV) {
       return (
         <TextInput
-          getInputRef={(ref) => { this.devPhraseInput = ref; }}
+          getInputRef={(ref) => {
+            this.devPhraseInput = ref;
+          }}
           inputProps={{
             ...inputProps,
             multiline: true,
@@ -156,6 +157,7 @@ class ImportWallet extends React.Component<Props, State> {
             if (!this.devPhraseInput) return;
             this.devPhraseInput.focus();
           }}
+          testID={`${TAG}-input-phrase_word`}
         />
       );
     }
@@ -164,12 +166,18 @@ class ImportWallet extends React.Component<Props, State> {
       <React.Fragment>
         <Row>
           {Object.keys(backupPhrase).map((key) => {
-            return (<BackupWordText key={key}>{`${key}. ${backupPhrase[key]}`}</BackupWordText>);
+            return (
+              <BackupWordText key={key} testID={`${TAG}-text-seed_word_${key}`}>
+                {`${key}. ${backupPhrase[key]}`}
+              </BackupWordText>
+            );
           })}
         </Row>
-        <Label>{t('auth:seedWord', { wordNumber: currentWordIndex })}</Label>
+        <Label testID={`${TAG}-text-seed_word_index`}>{t('auth:seedWord', { wordNumber: currentWordIndex })}</Label>
         <TextInput
-          getInputRef={(ref) => { this.backupPhraseInput = ref; }}
+          getInputRef={(ref) => {
+            this.backupPhraseInput = ref;
+          }}
           inputProps={{
             ...inputProps,
             returnKeyType: 'next',
@@ -182,18 +190,14 @@ class ImportWallet extends React.Component<Props, State> {
             if (!this.backupPhraseInput) return;
             this.backupPhraseInput.focus();
           }}
+          testID={`${TAG}-input-phrase_word`}
         />
       </React.Fragment>
     );
   };
 
   renderFooterButtons = (tabsInfo) => {
-    const {
-      activeTab,
-      currentBPWord,
-      currentWordIndex,
-      importError,
-    } = this.state;
+    const { activeTab, currentBPWord, currentWordIndex, importError } = this.state;
     const { isImportingWallet } = this.props;
 
     if (activeTab === TWORDSPHRASE) {
@@ -214,6 +218,7 @@ class ImportWallet extends React.Component<Props, State> {
               disabled={isImportingWallet}
               secondary
               block={false}
+              testID={`${TAG}-button-prev_word`}
             />
           )}
           <StyledButton
@@ -224,6 +229,7 @@ class ImportWallet extends React.Component<Props, State> {
             disabled={!currentBPWord || isImportingWallet}
             isLoading={isImportingWallet}
             block={false}
+            testID={`${TAG}-button-next_word`}
           />
         </ButtonsWrapper>
       );
@@ -235,6 +241,7 @@ class ImportWallet extends React.Component<Props, State> {
         title={t('auth:button.reimport')}
         onPress={this.handleImportSubmit}
         isLoading={isImportingWallet}
+        testID={`${TAG}-button-reimport_wallet`}
       />
     );
   };
@@ -272,25 +279,23 @@ class ImportWallet extends React.Component<Props, State> {
   };
 
   render() {
-    const {
-      tWordsPhrase,
-      currentBPWord,
-      activeTab,
-    } = this.state;
+    const { tWordsPhrase, currentBPWord, activeTab } = this.state;
 
     const restoreWalletTabs = [
       {
         id: TWORDSPHRASE,
         name: t('auth:title.backupPhrase'),
         onPress: () => this.setActiveTab(TWORDSPHRASE),
+        testID: `${TAG}-button-tab.${TWORDSPHRASE}`, // eslint-disable-line i18next/no-literal-string
       },
     ];
 
     if (__DEV__) {
       restoreWalletTabs.push({
         id: DEV,
-        name: 'Dev\'s phrase', // eslint-disable-line i18next/no-literal-string
+        name: "Dev's phrase", // eslint-disable-line i18next/no-literal-string
         onPress: () => this.setActiveTab(DEV),
+        testID: `${TAG}-button-tab.${DEV}`, // eslint-disable-line i18next/no-literal-string
       });
     }
 
@@ -333,11 +338,7 @@ class ImportWallet extends React.Component<Props, State> {
 }
 
 const mapStateToProps = ({
-  onboarding: {
-    wallet,
-    errorMessage,
-    isImportingWallet,
-  },
+  onboarding: { wallet, errorMessage, isImportingWallet },
 }: RootReducerState): $Shape<Props> => ({
   wallet,
   errorMessage,
@@ -368,7 +369,7 @@ const FooterWrapper = styled.View`
 const ButtonsWrapper = styled.View`
   justify-content: center;
   align-items: center;
-  flex-direction: ${props => props.isRow ? 'row' : 'column'};
+  flex-direction: ${(props) => (props.isRow ? 'row' : 'column')};
 `;
 
 const StyledButton = styled(Button)`
@@ -399,3 +400,5 @@ const BackupWordText = styled(BaseText)`
   align-items: flex-start;
   color: ${themedColors.secondaryText};
 `;
+
+const TAG = 'ImportWallet';

--- a/src/screens/ImportWallet/ImportWalletLegals.js
+++ b/src/screens/ImportWallet/ImportWalletLegals.js
@@ -120,6 +120,7 @@ class ImportWalletLegals extends React.Component<Props, State> {
               lightText
               wrapperStyle={{ marginBottom: 16 }}
               checked={hasAgreedToTerms}
+              testID={`${TAG}-checkbox-agree_to_terms`}
             >
               <CheckboxText>
                 {t('auth:withLink.readUnderstandAgreeTo', {
@@ -135,6 +136,7 @@ class ImportWalletLegals extends React.Component<Props, State> {
               small
               lightText
               checked={hasAgreedToPolicy}
+              testID={`${TAG}-checkbox-agree_to_policy`}
             >
               <CheckboxText>
                 {t('auth:withLink.readUnderstandAgreeTo', {
@@ -149,6 +151,7 @@ class ImportWalletLegals extends React.Component<Props, State> {
               disabled={!canGoNext}
               title={t('auth:button.proceed')}
               onPress={() => navigation.navigate(IMPORT_WALLET)}
+              testID={`${TAG}-button-proceed`}
             />
           </ButtonWrapper>
         </Wrapper>
@@ -182,3 +185,5 @@ const CheckboxText = styled(BaseText)`
 const StyledButton = styled(Button)`
   margin: 0 6px;
 `;
+
+const TAG = 'ImportWalletLegals';

--- a/src/screens/LegalScreen/LegalScreen.js
+++ b/src/screens/LegalScreen/LegalScreen.js
@@ -78,7 +78,7 @@ const LegalScreen = () => {
         navigation={navigation}
         noPaddingTop
       />
-      {!isPrismicHTMLFetched && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      {!isPrismicHTMLFetched && <ErrorMessage testID={`${TAG}-error-no_prismic_html`}>{errorMessage}</ErrorMessage>}
       <Content>
         {isLoading && <Spinner size={30} />}
         {!!isPrismicHTMLFetched && !isLoading && (
@@ -87,8 +87,13 @@ const LegalScreen = () => {
       </Content>
       {!!onBoardingFlow && (
         <Footer>
-          <Button title={t('auth:button.accept')} size="large" style={styles.buttonStyle} />
-          <Button title={t('auth:button.reject')} size="large" variant="text" />
+          <Button
+            title={t('auth:button.accept')}
+            size="large"
+            style={styles.buttonStyle}
+            testID={`${TAG}-button-accept`}
+          />
+          <Button title={t('auth:button.reject')} size="large" variant="text" testID={`${TAG}-button-reject`} />
         </Footer>
       )}
     </Container>
@@ -96,7 +101,6 @@ const LegalScreen = () => {
 };
 
 export default LegalScreen;
-
 
 const styles = {
   buttonStyle: {
@@ -109,3 +113,5 @@ const ErrorMessage = styled(Text)`
   text-align: center;
   color: ${({ theme }) => theme.colors.negative};
 `;
+
+const TAG = 'LegalScreen';

--- a/src/screens/Menu/Menu/Menu.js
+++ b/src/screens/Menu/Menu/Menu.js
@@ -80,7 +80,7 @@ const Menu = () => {
 
   const [repliesFlag, setRepliesFlag] = useState(false);
 
-  Replies.hasChats(previousChat => {
+  Replies.hasChats((previousChat) => {
     if (previousChat) {
       setRepliesFlag(true);
     }
@@ -121,6 +121,7 @@ const Menu = () => {
           value={!isBackedUp ? tRoot('menu.settings.backupNotFinishedWarning') : ''}
           valueColor={colors.negative}
           onPress={goToSettings}
+          testID={`${TAG}-button-settings`}
         />
         <MenuItem title={t('item.addressBook')} icon="contacts" onPress={goToInviteFriends} />
         <MenuItem
@@ -128,12 +129,30 @@ const Menu = () => {
           subtitle={!enoughPlrBalance ? t('item.liveChatActivate') : ''}
           icon="message"
           onPress={goToEmailSupport}
+          testID={`${TAG}-button-email_support`}
         />
         {repliesFlag && enoughPlrBalance ? (
-          <MenuItem title={t('item.supportConversations')} icon="message" onPress={goToSupportConversations} />
+          <MenuItem
+            title={t('item.supportConversations')}
+            icon="message"
+            onPress={goToSupportConversations}
+            testID={`${TAG}-button-support_conversations`}
+          />
         ) : null}
-        <MenuItem title={t('item.knowledgebase')} icon="info" onPress={goToKnowledgebase} />
-        {__DEV__ && <MenuItem title={t('item.storybook')} icon="lifebuoy" onPress={goToStorybook} />}
+        <MenuItem
+          title={t('item.knowledgebase')}
+          icon="info"
+          onPress={goToKnowledgebase}
+          testID={`${TAG}-button-knowledge_base`}
+        />
+        {__DEV__ && (
+          <MenuItem
+            title={t('item.storybook')}
+            icon="lifebuoy"
+            onPress={goToStorybook}
+            testID={`${TAG}-button-storybook`}
+          />
+        )}
 
         <SocialMediaLinks />
 
@@ -167,3 +186,5 @@ const BannersContainer = styled.View`
 const FlexSpacer = styled.View`
   flex-grow: 1;
 `;
+
+const TAG = 'Menu';

--- a/src/screens/Menu/Menu/components/MenuFooter.js
+++ b/src/screens/Menu/Menu/components/MenuFooter.js
@@ -29,11 +29,7 @@ import { useTranslationWithPrefix } from 'translations/translate';
 import Button from 'components/core/Button';
 
 // Constants
-import {
-  MENU_SYSTEM_INFORMATION,
-  BACKUP_WALLET_IN_SETTINGS_FLOW,
-  LEGAL_SCREEN,
-} from 'constants/navigationConstants';
+import { MENU_SYSTEM_INFORMATION, BACKUP_WALLET_IN_SETTINGS_FLOW, LEGAL_SCREEN } from 'constants/navigationConstants';
 import { REMOTE_CONFIG } from 'constants/remoteConfigConstants';
 
 // Selectors
@@ -48,7 +44,6 @@ import { firebaseRemoteConfig } from 'services/firebase';
 // Utils
 import { useThemeColors } from 'utils/themes';
 import { objectFontStyles, spacing } from 'utils/variables';
-
 
 const MenuFooter = () => {
   const { t, tRoot } = useTranslationWithPrefix('menu.footer');
@@ -99,6 +94,7 @@ const MenuFooter = () => {
           style={styles.button}
           titleStyle={styles.buttonTitle}
           titleColor={colors.secondaryText}
+          testID={`${TAG}-button-privacy_policy`}
         />
         <Button
           title={t('termsOfService')}
@@ -108,6 +104,7 @@ const MenuFooter = () => {
           style={styles.button}
           titleStyle={styles.buttonTitle}
           titleColor={colors.secondaryText}
+          testID={`${TAG}-button-terms_of_service`}
         />
         <Button
           title={t('systemInformation')}
@@ -117,6 +114,7 @@ const MenuFooter = () => {
           style={styles.button}
           titleStyle={styles.buttonTitle}
           titleColor={colors.secondaryText}
+          testID={`${TAG}-button-system_information`}
         />
       </LeftColumn>
 
@@ -129,6 +127,7 @@ const MenuFooter = () => {
           size="compact"
           style={styles.button}
           titleStyle={styles.buttonTitle}
+          testID={`${TAG}-button-logout`}
         />
       </RightColumn>
     </Container>
@@ -160,3 +159,5 @@ const RightColumn = styled.View`
   flex: 1;
   align-items: flex-end;
 `;
+
+const TAG = 'MenuFooter';

--- a/src/screens/Menu/Menu/components/MenuItem.js
+++ b/src/screens/Menu/Menu/components/MenuItem.js
@@ -28,20 +28,20 @@ import Text from 'components/core/Text';
 // Utils
 import { fontStyles, spacing } from 'utils/variables';
 
-
 type Props = {|
   title: string,
   icon: IconName,
   onPress: () => mixed,
   value?: string,
   valueColor?: string,
-  subtitle?: string
+  subtitle?: string,
+  testID?: string,
 |};
 
-const MenuItem = ({ title, icon, onPress, value, valueColor, subtitle }: Props) => {
+const MenuItem = ({ title, icon, onPress, value, valueColor, subtitle, testID }: Props) => {
   return (
     <Container>
-      <TouchableContainer onPress={onPress}>
+      <TouchableContainer onPress={onPress} testID={testID}>
         <ItemIcon name={icon} width={16} height={16} />
         <Title>{title}</Title>
         {!!value && <Value $color={valueColor}>{value}</Value>}

--- a/src/screens/Menu/Menu/components/SocialMediaLinks.js
+++ b/src/screens/Menu/Menu/components/SocialMediaLinks.js
@@ -37,7 +37,6 @@ import LogoDiscord from 'assets/images/logo-discord.svg';
 import LogoTwitter from 'assets/images/logo-twitter.svg';
 import LogoYouTube from 'assets/images/logo-youtube.svg';
 
-
 const SocialMediaLinks = () => {
   const isDarkTheme = useIsDarkTheme();
 
@@ -49,13 +48,13 @@ const SocialMediaLinks = () => {
 
   return (
     <Container>
-      <TouchableWrapper onPress={() => openUrl(discordUrl)}>
+      <TouchableWrapper onPress={() => openUrl(discordUrl)} testID={`${TAG}-button-discord`}>
         <LogoDiscord fill={isDarkTheme ? discordColors.dark : discordColors.light} style={styles.discord} />
       </TouchableWrapper>
-      <TouchableWrapper onPress={() => openUrl(twitterUrl)}>
+      <TouchableWrapper onPress={() => openUrl(twitterUrl)} testID={`${TAG}-button-twitter`}>
         <LogoTwitter />
       </TouchableWrapper>
-      <TouchableWrapper onPress={() => openUrl(youTubeUrl)}>
+      <TouchableWrapper onPress={() => openUrl(youTubeUrl)} testID={`${TAG}-button-youtube`}>
         <LogoYouTube />
       </TouchableWrapper>
     </Container>
@@ -85,3 +84,5 @@ const Container = styled.View`
 const TouchableWrapper = styled.TouchableOpacity`
   margin: ${spacing.medium}px;
 `;
+
+const TAG = 'SocialMediaLinks';

--- a/src/screens/Menu/Settings/components/BiometricLoginSetting.js
+++ b/src/screens/Menu/Settings/components/BiometricLoginSetting.js
@@ -72,9 +72,8 @@ function BiometricLoginSetting({ pin, wallet }: Props) {
   const handleBiometricPress = async () => {
     if (!pin || !wallet) return;
 
-    const shouldRequestPermission = !useBiometrics
-      && Platform.OS === 'ios'
-      && supportedBiometryType === Keychain.BIOMETRY_TYPE.FACE_ID;
+    const shouldRequestPermission =
+      !useBiometrics && Platform.OS === 'ios' && supportedBiometryType === Keychain.BIOMETRY_TYPE.FACE_ID;
     if (!shouldRequestPermission) {
       dispatch(changeUseBiometricsAction(!useBiometrics, { ...wallet, pin }));
       return;
@@ -104,6 +103,7 @@ function BiometricLoginSetting({ pin, wallet }: Props) {
       title={t('biometricLogin')}
       value={!!useBiometrics}
       onChangeValue={handleBiometricPress}
+      testID={`${TAG}-button-toggle`}
     />
   );
 }
@@ -121,3 +121,5 @@ function useSupportedBiometryType() {
 
   return supportedBiometryType;
 }
+
+const TAG = 'BiometricLoginSetting';

--- a/src/screens/Menu/Settings/components/SettingsToggle.js
+++ b/src/screens/Menu/Settings/components/SettingsToggle.js
@@ -34,14 +34,15 @@ type Props = {|
   icon: IconName,
   value: boolean,
   onChangeValue: (value: boolean) => mixed,
+  testID?: string,
 |};
 
-const SettingsToggle = ({ title, icon, value, onChangeValue }: Props) => {
+const SettingsToggle = ({ title, icon, value, onChangeValue, testID }: Props) => {
   return (
     <Container>
       <Icon name={icon} width={16} height={16} style={styles.icon} />
       <Title>{title}</Title>
-      <Switcher isOn={value} onToggle={onChangeValue} />
+      <Switcher isOn={value} onToggle={onChangeValue} testID={testID} />
     </Container>
   );
 };

--- a/src/screens/Permissions/Permissions.js
+++ b/src/screens/Permissions/Permissions.js
@@ -42,7 +42,6 @@ import { SET_WALLET_PIN_CODE } from 'constants/navigationConstants';
 import type { Theme } from 'models/Theme';
 import Button from 'components/legacy/Button';
 
-
 type Props = {
   navigation: NavigationScreenProp<*>,
   theme: Theme,
@@ -98,10 +97,7 @@ const FooterWrapper = styled.View`
   padding: ${spacing.layoutSides}px;
 `;
 
-const Permissions = ({
-  navigation,
-  theme,
-}: Props) => {
+const Permissions = ({ navigation, theme }: Props) => {
   const [openCollapseKey, setOpenCollapseKey] = useState(null);
   const [openInnerCollapseKey, setOpenInnerCollapseKey] = useState(null);
   const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false);
@@ -225,20 +221,15 @@ const Permissions = ({
   const colors = getThemeColors(theme);
 
   const renderSectionContent = ({ item: sectionContent }: Object) => {
-    const {
-      key,
-      title,
-      paragraph,
-      custom,
-    } = sectionContent;
+    const { key, title, paragraph, custom } = sectionContent;
     if (paragraph) {
       return (
         <CollapsibleListItem
-          customToggle={(
+          customToggle={
             <InnerSectionToggle>
               <InnerSectionTitle>{title}</InnerSectionTitle>
             </InnerSectionToggle>
-          )}
+          }
           open={openInnerCollapseKey === key}
           onPress={() => toggleInnerCollapse(key)}
           toggleWrapperStyle={{
@@ -251,56 +242,50 @@ const Permissions = ({
             borderBottomWidth: 0.5,
           }}
           collapseContent={
-            <View style={{
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              flex: 1,
-              marginRight: 30,
-              marginLeft: -6,
-            }}
+            <View
+              style={{
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                flex: 1,
+                marginRight: 30,
+                marginLeft: -6,
+              }}
             >
               <Paragraph light small>
                 {paragraph}
               </Paragraph>
             </View>
           }
+          testID={`${TAG}-button-sub_permission_dropdown.${key}`}
         />
       );
     }
     if (custom) {
-      return (
-        <View style={{ marginHorizontal: 15 }}>
-          {custom}
-        </View>
-      );
+      return <View style={{ marginHorizontal: 15 }}>{custom}</View>;
     }
     return (
-      <SectionTitle key={key} style={{ margin: 30, fontSize: fontSizes.medium }}>{title}</SectionTitle>
+      <SectionTitle key={key} style={{ margin: 30, fontSize: fontSizes.medium }}>
+        {title}
+      </SectionTitle>
     );
   };
 
   const renderCollapseContent = (sectionKey: string) => {
     const section = sections.find((thisSection) => thisSection.key === sectionKey) || {};
     const { content } = section;
-    return (
-      <FlatList
-        keyExtractor={item => item.key}
-        data={content}
-        renderItem={renderSectionContent}
-      />
-    );
+    return <FlatList keyExtractor={(item) => item.key} data={content} renderItem={renderSectionContent} />;
   };
 
   const renderSection = ({ item: { title, key } }: Object) => (
     <CollapsibleListItem
-      customToggle={(
+      customToggle={
         <SectionToggle>
           <SectionTitle>{title}</SectionTitle>
           <IconHolder>
             <TickIcon name="check" />
           </IconHolder>
         </SectionToggle>
-      )}
+      }
       open={openCollapseKey === key}
       onPress={() => toggleCollapse(key)}
       toggleWrapperStyle={{
@@ -316,13 +301,12 @@ const Permissions = ({
       }}
       collapseContent={renderCollapseContent(key)}
       noPadding
+      testID={`${TAG}-button-permission_dropdown.${key}`}
     />
   );
 
   return (
-    <ContainerWithHeader
-      headerProps={{ centerItems: [{ title: t('auth:title.permissions') }] }}
-    >
+    <ContainerWithHeader headerProps={{ centerItems: [{ title: t('auth:title.permissions') }] }}>
       <ScrollView
         contentContainerStyle={{
           flexGrow: 1,
@@ -330,7 +314,7 @@ const Permissions = ({
         }}
       >
         <StyledFlatList
-          keyExtractor={item => item.key}
+          keyExtractor={(item) => item.key}
           data={sections}
           renderItem={renderSection}
           contentContainerStyle={{
@@ -345,6 +329,7 @@ const Permissions = ({
             lightText
             checked={hasAgreedToTerms}
             wrapperStyle={{ marginBottom: 16 }}
+            testID={`${TAG}-checkbox-agree_to_terms`}
           >
             {t('auth:withLink.readUnderstandAgreeTo', { linkedText: t('auth:termsOfUse') })}
           </Checkbox>
@@ -352,6 +337,7 @@ const Permissions = ({
             title={t('auth:button.proceed')}
             onPress={handleAgree}
             disabled={!hasAgreedToTerms}
+            testID={`${TAG}-button-submit`}
           />
         </FooterWrapper>
       </ScrollView>
@@ -360,3 +346,5 @@ const Permissions = ({
 };
 
 export default withTheme(Permissions);
+
+const TAG = 'Permissions';

--- a/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
+++ b/src/screens/PinCodeConfirmation/PinCodeConfirmation.js
@@ -87,6 +87,7 @@ const PinCodeConfirmation = ({ setOnboardingPinCode, navigation }) => {
           showForgotButton={false}
           pinError={!!errorMessage}
           flex={false}
+          testIdTag={TAG}
         />
       </ContentWrapper>
     </ContainerWithHeader>
@@ -109,3 +110,5 @@ const HeaderText = styled(MediumText)`
   text-align: center;
   margin: ${spacing.large}px 0;
 `;
+
+const TAG = 'PinCodeConfirmation';

--- a/src/screens/PinCodeUnlock/PinCodeUnlock.js
+++ b/src/screens/PinCodeUnlock/PinCodeUnlock.js
@@ -56,7 +56,6 @@ import type { InitArchanovaProps } from 'models/ArchanovaWalletAccount';
 import type { Dispatch, RootReducerState } from 'reducers/rootReducer';
 import type { OnValidPinCallback } from 'models/Wallet';
 
-
 const ACTIVE_APP_STATE = 'active';
 const BACKGROUND_APP_STATE = 'background';
 
@@ -64,7 +63,7 @@ type HandleUnlockActionProps = {
   pin?: string,
   privateKey?: string,
   defaultAction: () => void,
-}
+};
 
 type Props = {
   loginWithPin: (pin: string, callback: ?OnValidPinCallback, useBiometrics: ?boolean) => void,
@@ -122,7 +121,7 @@ class PinCodeUnlock extends React.Component<Props, State> {
 
     if (navigation.getParam('omitPin')) {
       getKeychainDataObject()
-        .then(data => {
+        .then((data) => {
           this.loginWithPrivateKey(data);
         })
         .catch(() => {
@@ -151,7 +150,9 @@ class PinCodeUnlock extends React.Component<Props, State> {
     const { useBiometrics } = this.props;
     if (useBiometrics) {
       this.showBiometricLogin();
-    } else { this.setState({ showPin: true }); }
+    } else {
+      this.setState({ showPin: true });
+    }
   };
 
   handleUnlockAction = async ({ pin, privateKey, defaultAction }: HandleUnlockActionProps) => {
@@ -187,10 +188,7 @@ class PinCodeUnlock extends React.Component<Props, State> {
 
   handleAppStateChange = (nextAppState: string) => {
     const { lastAppState } = this.state;
-    if (nextAppState === ACTIVE_APP_STATE
-      && lastAppState === BACKGROUND_APP_STATE
-      && !this.errorMessage
-    ) {
+    if (nextAppState === ACTIVE_APP_STATE && lastAppState === BACKGROUND_APP_STATE && !this.errorMessage) {
       this.triggerAuthentication();
     }
     this.setState({ lastAppState: nextAppState });
@@ -210,7 +208,7 @@ class PinCodeUnlock extends React.Component<Props, State> {
 
     this.setState({ biometricsShown: true }, () => {
       getKeychainDataObject()
-        .then(data => {
+        .then((data) => {
           this.setState({ biometricsShown: false });
           this.loginWithPrivateKey(data);
         })
@@ -272,26 +270,27 @@ class PinCodeUnlock extends React.Component<Props, State> {
     } = this.props;
     const { waitingTime, showPin } = this.state;
     const pinError = walletErrorMessage || this.errorMessage || null;
-    const showError = pinError ? <ErrorMessage>{pinError}</ErrorMessage> : null;
+    const showError = pinError ? <ErrorMessage testID={`${TAG}-error-pin_error`}>{pinError}</ErrorMessage> : null;
 
     if (showPin) {
       return (
         <Container>
           <Header centerTitle title={t('auth:enterPincode')} />
           {showError}
-          {waitingTime > 0 &&
-            <ErrorMessage>
+          {waitingTime > 0 && (
+            <ErrorMessage testID={`${TAG}-error-max_attempts`}>
               {t('auth:error.tooManyAttemptsTryAgain', { waitDuration: waitingTime.toFixed(0) })}
             </ErrorMessage>
-          }
-          {waitingTime <= 0 &&
+          )}
+          {waitingTime <= 0 && (
             <PinCode
               onPinEntered={this.handlePinSubmit}
               onForgotPin={this.handleForgotPasscode}
               pinError={!!pinError}
               isLoading={isAuthorizing}
+              testIdTag={TAG}
             />
-          }
+          )}
         </Container>
       );
     }
@@ -302,8 +301,12 @@ class PinCodeUnlock extends React.Component<Props, State> {
 
 const mapStateToProps = ({
   wallet,
-  appSettings: { data: { useBiometrics } },
-  session: { data: { isAuthorizing } },
+  appSettings: {
+    data: { useBiometrics },
+  },
+  session: {
+    data: { isAuthorizing },
+  },
 }: RootReducerState): $Shape<Props> => ({
   wallet,
   useBiometrics,
@@ -311,19 +314,15 @@ const mapStateToProps = ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): $Shape<Props> => ({
-  loginWithPin: (
-    pin: string,
-    callback: ?OnValidPinCallback,
-  ) => dispatch(loginAction(pin, null, callback)),
-  loginWithPrivateKey: (
-    privateKey: string,
-    callback: ?OnValidPinCallback,
-  ) => dispatch(loginAction(null, privateKey, callback)),
-  initSmartWalletSdkWithPrivateKeyOrPin: (
-    initProps: InitArchanovaProps,
-  ) => dispatch(initArchanovaSdkWithPrivateKeyOrPinAction(initProps)),
+  loginWithPin: (pin: string, callback: ?OnValidPinCallback) => dispatch(loginAction(pin, null, callback)),
+  loginWithPrivateKey: (privateKey: string, callback: ?OnValidPinCallback) =>
+    dispatch(loginAction(null, privateKey, callback)),
+  initSmartWalletSdkWithPrivateKeyOrPin: (initProps: InitArchanovaProps) =>
+    dispatch(initArchanovaSdkWithPrivateKeyOrPinAction(initProps)),
   switchAccount: (accountId: string) => dispatch(switchAccountAction(accountId)),
   removePrivateKeyFromMemory: () => dispatch(removePrivateKeyFromMemoryAction()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PinCodeUnlock);
+
+const TAG = 'PinCodeUnlock';

--- a/src/screens/SetWalletPinCode/SetWalletPinCode.js
+++ b/src/screens/SetWalletPinCode/SetWalletPinCode.js
@@ -94,6 +94,7 @@ const SetWalletPinCode = ({ navigation, wallet }: Props) => {
           showForgotButton={false}
           pinError={!!errorMessage}
           flex={false}
+          testIdTag={TAG}
         />
       </ContentWrapper>
     </ContainerWithHeader>
@@ -116,3 +117,5 @@ const HeaderText = styled(MediumText)`
   margin-top: ${spacing.large}px;
   margin-bottom: 9px;
 `;
+
+const TAG = 'SetWalletPinCode';

--- a/src/screens/WelcomeBack/WelcomeBack.js
+++ b/src/screens/WelcomeBack/WelcomeBack.js
@@ -75,7 +75,12 @@ const WelcomeBack = () => {
       <Paragraph small light center style={{ marginBottom: 40, paddingLeft: 40, paddingRight: 40 }}>
         {t('auth:paragraph.successfullyRestoredWallet')}
       </Paragraph>
-      <Button marginBottom={20} onPress={proceedToNextScreen} title={t('auth:button.next')} />
+      <Button
+        marginBottom={20}
+        onPress={proceedToNextScreen}
+        title={t('auth:button.next')}
+        testID={`${TAG}-button-next`}
+      />
     </Wrapper>
   );
 
@@ -134,3 +139,5 @@ const Text = styled(MediumText)`
 const ContentWrapper = styled.View`
   flex: 1;
 `;
+
+const TAG = 'WelcomeBack';


### PR DESCRIPTION
I've added `testID`s for various interactable elements during the Onboarding flow + Home screen -> Re-import Wallet flow.

The IDs are in this format: `[TAG]-[TYPE]-[NAME_WITH_UNDERSCORES].[OPTIONAL_PROP].[ETC]`

Where:
- TAG is the name of the file
- TYPE is the type of the element (currently only 5 types: `button`, `checkbox`, `input`, `text`, `error`)
- And after that there will be a name in snake_case. If the testIDs are generated through an array then there may be extra keys joined by `.`

You may need to look at the code to see what exactly the IDs are, but here are some example IDs:
- Normal button `BiometricModal-button-enable`
- Normal checkbox `ImportWalletLegals-checkbox-agree_to_policy`
- Checkboxes generated through an array/object `Permissions-button-permission_dropdown.PUSH_NOTIFICATIONS`