### PR TITLE
PRO-349: Fixed crash on Receive Modal

### DIFF
--- a/src/screens/Asset/ReceiveModal.tsx
+++ b/src/screens/Asset/ReceiveModal.tsx
@@ -176,7 +176,7 @@ const ReceiveModal: FC<IReceiveModal> = ({ address, onModalHide, theme }) => {
                       width={18}
                       style={IconContainer}
                       name={'checkmark-circle-green'}
-                      color={theme.colors.black}
+                      color={colors.black}
                     />
                   )}
                 </ChainIconWrapper>


### PR DESCRIPTION
Prop `theme.colors` was causing a crash, so switched to just `colors`.