### PR TITLE
Modify pipeline slack url notifications

### DIFF
--- a/.circleci/announceDeployment.sh
+++ b/.circleci/announceDeployment.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 applicationName=$1
 targetEnvironment=$2
 appBuildNumber=$3
+packageLink=$4
 
 payload=$(
 cat <<EOM
@@ -14,7 +15,7 @@ cat <<EOM
             "color": "#33CC66",
             "pretext": "$applicationName deployed to $targetEnvironment.",
             "title": "$CIRCLE_PROJECT_REPONAME",
-            "title_link": "https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_WORKSPACE_ID",
+            "title_link": "$packageLink",
             "text": "build number: $appBuildNumber",
             "ts": $(date '+%s')
         }

--- a/.circleci/announceProdBuilds.sh
+++ b/.circleci/announceProdBuilds.sh
@@ -5,6 +5,7 @@ applicationName=$1
 targetEnvironment=$2
 appBuildNumber=$3
 pr_description=$4
+packageLink=$5
 
 payload=$(
 cat <<EOM
@@ -15,7 +16,7 @@ cat <<EOM
             "color": "#33CC66",
             "pretext": "<!here> - $applicationName deployed to $targetEnvironment.",
             "title": "build number: $appBuildNumber",
-            "title_link": "https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_WORKSPACE_ID",
+            "title_link": "$packageLink",
             "text": "What's new: \n \n $pr_description",
             "ts": $(date '+%s')
         }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,8 +351,6 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
-              chmod +x .circleci/announceDeployment.sh
-              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "x.xxx.xx" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)"
             fi
       - slack/status:
           fail_only: true
@@ -473,8 +471,6 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
-              chmod +x .circleci/announceDeployment.sh
-              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "x.xxx.xx" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)"
             fi
       - slack/status:
           fail_only: true
@@ -813,8 +809,8 @@ jobs:
             .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$IOS_URL" "$APP_VERSION"
             .circleci/announceURLs.sh "pillarwallet" "production" "android" "$ANDROID_URL" "$APP_VERSION"
             chmod +x .circleci/announceProdBuilds.sh
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)" "$ANDROID_URL"
             .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)" "$IOS_URL"
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)" "$ANDROID_URL"            
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,8 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
-              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "x.xxx.xx" "$(cat /home/circleci/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)"
+              chmod +x .circleci/announceDeployment.sh
+              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "x.xxx.xx" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)"
             fi
       - slack/status:
           fail_only: true
@@ -472,6 +473,7 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
+              chmod +x .circleci/announceDeployment.sh
               .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "x.xxx.xx" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)"
             fi
       - slack/status:
@@ -612,7 +614,7 @@ jobs:
           name: Announce Deployment
           command: |
             chmod +x .circleci/announceDeployment.sh
-            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat /home/circleci/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)"
+            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)"
       - run:
           name: prepare to archive ipa file
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,7 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "ios" "$(cat ~/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
+              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "x.xxx.xx" "$(cat /home/circleci/pillarwallet/ios/output/gym/ios-s3-URL-feature.txt)"
             fi
       - slack/status:
           fail_only: true
@@ -471,6 +472,7 @@ jobs:
               cd ~/pillarwallet
               chmod +x .circleci/announceURLs.sh
               .circleci/announceURLs.sh "pillarwallet" "$CIRCLE_BRANCH" "android" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)" "$(cat ~/pillarwallet/buildNumber.txt)"
+              .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "x.xxx.xx" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/staging/android-s3-URL-feature.txt)"
             fi
       - slack/status:
           fail_only: true
@@ -610,7 +612,7 @@ jobs:
           name: Announce Deployment
           command: |
             chmod +x .circleci/announceDeployment.sh
-            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
+            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* iOS internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat /home/circleci/pillarwallet/ios/output/gym/ios-s3-URL-prod.txt)"
       - run:
           name: prepare to archive ipa file
           command: |
@@ -750,7 +752,7 @@ jobs:
           name: Announce Deployment
           command: |
             chmod +x .circleci/announceDeployment.sh
-            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)"
+            .circleci/announceDeployment.sh "Pillar Wallet" "*Prod* Android internal track - Tests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat /home/circleci/pillarwallet/android/app/build/outputs/apk/release/android-s3-URL-prod.txt)"
       - run:
           name: prepare to archive apk file
           command: |
@@ -800,7 +802,7 @@ jobs:
             github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-android-$APP_VERSION.apk" -f /tmp/workspace/android-release/*.apk
             github-release upload -s $GITHUB_TOKEN -u "pillarwallet" -r "pillarwallet" -t $TAG_VERSION -n "pillarwallet-prod-ios-$APP_VERSION.ipa" -f /tmp/workspace/ios-release/*.ipa
       - run:
-          name: Announce production iOS and Android URL's
+          name: Announce production iOS and Android URL's to s3-urls channel and Announce new RC to support channel
           command: |
             APP_VERSION="$(cat /tmp/workspace/build-num/app_version.txt)"
             chmod +x .circleci/announceURLs.sh
@@ -808,12 +810,9 @@ jobs:
             ANDROID_URL="https://github.com/pillarwallet/pillarwallet/releases/download/v$APP_VERSION/pillarwallet-prod-android-$APP_VERSION.apk"
             .circleci/announceURLs.sh "pillarwallet" "production" "ios" "$IOS_URL" "$APP_VERSION"
             .circleci/announceURLs.sh "pillarwallet" "production" "android" "$ANDROID_URL" "$APP_VERSION"
-      - run:
-          name: Announce new RC to support channel
-          command: |
             chmod +x .circleci/announceProdBuilds.sh
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
-            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)"
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* Android internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)" "$ANDROID_URL"
+            .circleci/announceProdBuilds.sh "Pillar Wallet" "*Prod* iOS internal track - Тests pending" "$(cat /tmp/workspace/build-num/app_version.txt)" "$(cat ~/pillarwallet/support_description.txt)" "$IOS_URL"
 
 workflows:
   version: 2.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Build links in Slack messages that we send to support team are changed and now they point to GitHub releases links. 
-  Frontend CircleCI links point to pre-signed urls with a short lifetime. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Current links point to CircleCI workflows and are not beneficial for all users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested from _ui feature branch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)