### PR TITLE
PRO-1253: Token icons missing for native tokens and entire BSC list

### DIFF
--- a/src/components/ReviewSummary/TokenReviewSummary.js
+++ b/src/components/ReviewSummary/TokenReviewSummary.js
@@ -23,7 +23,7 @@ import styled from 'styled-components/native';
 // components
 import { BaseText, MediumText } from 'components/legacy/Typography';
 import { Spacing } from 'components/legacy/Layout';
-import Image from 'components/Image';
+import CollectibleImage from 'components/CollectibleImage';
 
 // utils
 import { formatFiat, formatTokenAmount } from 'utils/common';
@@ -57,10 +57,6 @@ const Container = styled.View`
   align-items: center;
 `;
 
-const TokenImage = styled(Image)`
-  width: 64px;
-  height: 64px;
-`;
 
 export const TokenReviewSummaryComponent = ({
   assetSymbol,
@@ -91,7 +87,12 @@ export const TokenReviewSummaryComponent = ({
 
   return (
     <Container>
-      <TokenImage source={assetIcon} fallbackSource={!!asset && genericToken} />
+      <CollectibleImage
+        source={assetIcon}
+        width={64}
+        height={64}
+        fallbackSource={!!asset && genericToken}
+      />
       <Spacing h={32} />
       <BaseText regular>{text}</BaseText>
       <Spacing h={4} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-1253/token-icons-missing-for-native-tokens-and-entire-bsc-list

## Description
<!--- Describe your changes in detail -->
- Replaced Review screen in component CollectibleImage from Image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://sentry.io/organizations/pillar-project-worldwide-ltd/issues/4015609445/?project=1294444&query=is%3Aunresolved+release.version%3A3.22.2&referrer=issue-stream&statsPeriod=14d&stream_index=0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on Simulator 12 

## Screenshots (if appropriate):
https://user-images.githubusercontent.com/82652040/231126094-07d48b25-49d6-4366-b9f5-4ce3ca9a590c.mp4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)