### PR TITLE
PRO-1262:  Formatted Fiat Value for gas estimates lower then 0.01$

### DIFF
--- a/src/components/FeeLabelToggle/FeeLabelToggle.tsx
+++ b/src/components/FeeLabelToggle/FeeLabelToggle.tsx
@@ -97,7 +97,7 @@ const FeeLabelToggle: FC<IFeeLabelToggle> = ({
 
   const feeInFiat = getTxFeeInFiat(chain, txFeeInWei, gasToken, chainRates, fiatCurrency);
   const feeInFiatDisplayValue =
-    feeInFiat < 0.01 && feeInFiat > 0 ? `<${currencySymbol}0.01` : `${currencySymbol}${feeInFiat.toFixed(2)}`;
+    feeInFiat < 0.01 && feeInFiat > 0 ? `< ${currencySymbol}0.01` : `${currencySymbol}${feeInFiat.toFixed(2)}`;
   const labelValue = isFiatValueVisible ? feeInFiatDisplayValue : feeDisplayValue;
 
   showRelayerMigration =

--- a/src/components/FeeLabelToggle/FeeLabelToggle.tsx
+++ b/src/components/FeeLabelToggle/FeeLabelToggle.tsx
@@ -96,7 +96,8 @@ const FeeLabelToggle: FC<IFeeLabelToggle> = ({
   const currencySymbol = getCurrencySymbol(fiatCurrency);
 
   const feeInFiat = getTxFeeInFiat(chain, txFeeInWei, gasToken, chainRates, fiatCurrency);
-  const feeInFiatDisplayValue = `${currencySymbol}${feeInFiat.toFixed(2)}`;
+  const feeInFiatDisplayValue =
+    feeInFiat < 0.01 && feeInFiat > 0 ? `<${currencySymbol}0.01` : `${currencySymbol}${feeInFiat.toFixed(2)}`;
   const labelValue = isFiatValueVisible ? feeInFiatDisplayValue : feeDisplayValue;
 
   showRelayerMigration =

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -316,7 +316,9 @@ export const formatFiatValue = (value: Value, options?: { skipCents?: boolean })
 
 export const formatFiat = (value: Value, baseFiatCurrency?: ?string, options?: { skipCents?: boolean }): string => {
   const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
-  return `${getCurrencySymbol(fiatCurrency)}${formatFiatValue(value, options)}`;
+  return parseFloat(value) < 0.01 && parseFloat(value) > 0
+    ? `<${getCurrencySymbol(fiatCurrency)}0.01`
+    : `${getCurrencySymbol(fiatCurrency)}${formatFiatValue(value, options)}`;
 };
 
 export const partial = (fn: Function, ...fixedArgs: any) => {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -317,7 +317,7 @@ export const formatFiatValue = (value: Value, options?: { skipCents?: boolean })
 export const formatFiat = (value: Value, baseFiatCurrency?: ?string, options?: { skipCents?: boolean }): string => {
   const fiatCurrency = baseFiatCurrency || defaultFiatCurrency;
   return parseFloat(value) < 0.01 && parseFloat(value) > 0
-    ? `<${getCurrencySymbol(fiatCurrency)}0.01`
+    ? `< ${getCurrencySymbol(fiatCurrency)}0.01`
     : `${getCurrencySymbol(fiatCurrency)}${formatFiatValue(value, options)}`;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-1262/formatted-fiat-value-for-gas-estimates-lower-then-001dollar

## Description
<!--- Describe your changes in detail -->
- Show <$0.01 for less than 0.01 fiat value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on Simulator 12

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/82652040/231667715-ee6f7545-3da3-4001-a6ec-4071df46500e.mp4


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)