### PR TITLE
PRO-1510 Token Analytics Refinements

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.8",
     "ethers": "5.0.19",
-    "etherspot": "1.43.5",
+    "etherspot": "1.43.7",
     "events": "^1.0.0",
     "fast-text-encoding": "^1.0.6",
     "https-browserify": "~0.0.0",

--- a/patches/react-native-gifted-charts+1.2.42.patch
+++ b/patches/react-native-gifted-charts+1.2.42.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-gifted-charts/src/LineChart/index.tsx b/node_modules/react-native-gifted-charts/src/LineChart/index.tsx
-index 8ef5ecc..56a0ac6 100644
+index 8ef5ecc..4d11a61 100644
 --- a/node_modules/react-native-gifted-charts/src/LineChart/index.tsx
 +++ b/node_modules/react-native-gifted-charts/src/LineChart/index.tsx
 @@ -441,6 +441,7 @@ export const LineChart = (props: propTypes) => {
@@ -28,6 +28,41 @@ index 8ef5ecc..56a0ac6 100644
            </View>
          )}
        </View>
+@@ -3516,7 +3519,7 @@ export const LineChart = (props: propTypes) => {
+         onMoveShouldSetResponder={evt => (pointerConfig ? true : false)}
+         onResponderGrant={evt => {
+           if (!pointerConfig) return;
+-          setResponderStartTime(evt.timeStamp);
++          // setResponderStartTime(evt.timeStamp);
+           if (activatePointersOnLongPress) {
+             return;
+           }
+@@ -3546,6 +3549,7 @@ export const LineChart = (props: propTypes) => {
+             10;
+           setPointerY(y);
+           setPointerItem(item);
++          setResponderActive(true);
+           if (data2 && data2.length) {
+             item = data2[factor];
+             if (item) {
+@@ -3688,7 +3692,7 @@ export const LineChart = (props: propTypes) => {
+           setResponderStartTime(0);
+           setPointerIndex(-1);
+           setResponderActive(false);
+-          setTimeout(() => setPointerX(0), pointerVanishDelay);
++          setTimeout(() =>  setPointerX(0), pointerVanishDelay);
+         }}
+         onResponderTerminationRequest={evt => false}
+         // onResponderTerminate={evt => {
+@@ -4029,7 +4033,7 @@ export const LineChart = (props: propTypes) => {
+               height:
+                 containerHeight + 10 + horizSectionsBelow.length * stepHeight,
+               bottom: 60 + labelsExtraHeight,
+-              width: totalWidth,
++              // width: totalWidth,
+               zIndex: 20,
+             }}>
+             {!stripOverPointer && renderStripAndLabel()}
 diff --git a/node_modules/react-native-gifted-charts/src/LineChart/styles.tsx b/node_modules/react-native-gifted-charts/src/LineChart/styles.tsx
 index f6af90e..ba13ef7 100644
 --- a/node_modules/react-native-gifted-charts/src/LineChart/styles.tsx

--- a/src/assets/icons/svg/24-card-in-light.svg
+++ b/src/assets/icons/svg/24-card-in-light.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd" opacity=".5">
+        <path d="M15.5 5H18a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V8c0-1.311.841-2.426 2.013-2.834M3 10h2m10 0h6" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <g fill-rule="nonzero">
+            <path fill="#FF5F00" d="M14.98 13.395h1.44v2.587h-1.44z"/>
+            <path d="M15.071 14.688c0-.525.247-.992.627-1.293a1.645 1.645 0 1 0 0 2.587 1.643 1.643 0 0 1-.627-1.294z" fill="#EB001B"/>
+            <path d="M18.363 14.688a1.645 1.645 0 0 1-2.66 1.294 1.65 1.65 0 0 0 0-2.587c.278-.22.63-.352 1.014-.352.91 0 1.646.74 1.646 1.645z" fill="#F79E1B"/>
+        </g>
+        <path d="m7 7 3 3 3-3m-3 3V2.5" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+</svg>

--- a/src/assets/icons/svg/24-card-out-light.svg
+++ b/src/assets/icons/svg/24-card-out-light.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd" opacity=".5">
+        <path d="M16.5 5H18a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V8c0-.853.356-1.623.928-2.17M3 10h4m6 0h8" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <g fill-rule="nonzero">
+            <path fill="#FF5F00" d="M14.98 13.395h1.44v2.587h-1.44z"/>
+            <path d="M15.071 14.688c0-.525.247-.992.627-1.293a1.645 1.645 0 1 0 0 2.587 1.643 1.643 0 0 1-.627-1.294z" fill="#EB001B"/>
+            <path d="M18.363 14.688a1.645 1.645 0 0 1-2.66 1.294 1.65 1.65 0 0 0 0-2.587c.278-.22.63-.352 1.014-.352.91 0 1.646.74 1.646 1.645z" fill="#F79E1B"/>
+        </g>
+        <path d="m7 5.5 3-3 3 3m-3-3V10" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+</svg>

--- a/src/components/AnimatedGraph/index.tsx
+++ b/src/components/AnimatedGraph/index.tsx
@@ -37,7 +37,7 @@ import { ONE_DAY } from 'constants/assetsConstants';
 import Icon from 'components/core/Icon';
 
 // Types
-import type { HistoricalTokenPrices, MarketDetails } from 'models/Asset';
+import type { HistoricalTokenPrices, MarketDetails, TokenDetails } from 'models/Asset';
 import PointerLevel from './PointerLevel';
 
 export const { width: SIZE } = Dimensions.get('window');
@@ -46,6 +46,7 @@ interface Props {
   period: string;
   marketData: MarketDetails;
   historicData: HistoricProps;
+  tokenDetailsData: TokenDetails;
   onChangePointer: (items: any, isActive: boolean) => void;
 }
 
@@ -55,7 +56,7 @@ interface HistoricProps {
   isLoading: boolean;
 }
 
-const AnimatedGraph = ({ period, marketData, historicData, onChangePointer }: Props) => {
+const AnimatedGraph = ({ period, marketData, historicData, onChangePointer, tokenDetailsData }: Props) => {
   const colors = useThemeColors();
 
   const { data, status, isLoading } = historicData;
@@ -75,7 +76,7 @@ const AnimatedGraph = ({ period, marketData, historicData, onChangePointer }: Pr
 
   const currentPricePercentage = useMemo(() => {
     if (isEmpty(marketData)) return 0;
-    const pricePercentage = getPriceChangePercentage(period, marketData);
+    const pricePercentage = getPriceChangePercentage(period, marketData, tokenDetailsData);
     return pricePercentage;
   }, [marketData, period]);
 
@@ -156,7 +157,6 @@ const AnimatedGraph = ({ period, marketData, historicData, onChangePointer }: Pr
           shiftPointerLabelX: -15,
           pointerVanishDelay: 0,
           activatePointersDelay: 0,
-          activatePointersOnLongPress: true,
           autoAdjustPointerLabelPosition: false,
           pointerLabelComponent: (items, isActive) => (
             <PointerLevel items={items} isActive={isActive} onChangePointer={onChangePointer} />

--- a/src/components/HeaderBlock/HeaderBlock.js
+++ b/src/components/HeaderBlock/HeaderBlock.js
@@ -61,6 +61,7 @@ export type OwnProps = {|
   rightItems?: NavItem[],
   leftItems?: NavItem[],
   centerItems?: NavItem[],
+  centerItemsStyle?: Object,
   sideFlex?: number,
   navigation?: NavigationScreenProp<*>,
   background?: string,
@@ -119,7 +120,6 @@ const HeaderRow = styled.View`
 `;
 
 const CenterItems = styled.View`
-  flex: 4;
   padding: 0 ${spacing.medium}px;
   align-items: center;
   justify-content: center;
@@ -226,6 +226,7 @@ class HeaderBlock extends React.Component<Props> {
       theme,
       leftSideFlex,
       testIdTag,
+      centerItemsStyle,
     } = this.props;
     const colors = getThemeColors(theme);
 
@@ -249,7 +250,9 @@ class HeaderBlock extends React.Component<Props> {
           )}
         </LeftItems>
         {!!centerItems.length && (
-          <CenterItems>{centerItems.map((item) => this.renderSideItems(item, CENTER))}</CenterItems>
+          <CenterItems style={centerItemsStyle || { flex: 4 }}>
+            {centerItems.map((item) => this.renderSideItems(item, CENTER))}
+          </CenterItems>
         )}
         {(!!centerItems.length || !!rightItems.length) && (
           <RightItems sideFlex={sideFlex}>{rightItems.map((item) => this.renderSideItems(item, RIGHT))}</RightItems>

--- a/src/components/core/Icon.tsx
+++ b/src/components/core/Icon.tsx
@@ -138,6 +138,8 @@ import PlrTransparentIcon from 'assets/icons/svg/tokens-48-plr-transparent.svg';
 import DashboardLiquidity from 'assets/icons/svg/24-dashboard-liquidity.svg';
 import BuyIcon from 'assets/icons/svg/24-card-in.svg';
 import SellIcon from 'assets/icons/svg/24-card-out.svg';
+import BuyIconLight from 'assets/icons/svg/24-card-in-light.svg';
+import SellIconLight from 'assets/icons/svg/24-card-out-light.svg';
 import PlusIcon from 'assets/icons/svg/24-add.svg';
 import MinusIcon from 'assets/icons/svg/24-minus.svg';
 import GreenUpIcon from 'assets/icons/svg/icon-up-green.svg';
@@ -301,6 +303,8 @@ const components = {
   'plr-transparent': PlrTransparentIcon,
   buy: BuyIcon,
   sell: SellIcon,
+  'buy-light': BuyIconLight,
+  'sell-light': SellIconLight,
   'green-plus': PlusIcon,
   'red-minus': MinusIcon,
 

--- a/src/constants/assetsConstants.js
+++ b/src/constants/assetsConstants.js
@@ -174,6 +174,6 @@ export const ETHERSPOT_POPULAR_MULTICHAIN = 'EtherspotPopularMultichain';
 
 // Token analytics period types
 export const ONE_DAY = '1d';
-export const ONE_WEEK = '1week';
+export const ONE_WEEK = '1w';
 export const ONE_MONTH = '1m';
 export const ONE_YEAR = '1y';

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -467,6 +467,10 @@
     "seven_day": "7 D",
     "one_month": "1 M",
     "one_year": "1 Y",
+    "today": "Today",
+    "last_week": "Last Week",
+    "last_month": "Last Month",
+    "last_year": "Last Year",
     "token_analytics": "Token Analytics"
   },
 

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -444,6 +444,10 @@
     "seven_day": "7天",
     "one_month": "1米",
     "one_year": "1 岁",
+    "today": "今天",
+    "last_week": "上星期",
+    "last_month": "上个月",
+    "last_year": "去年",
     "token_analytics": "代币分析"
   },
   "paragraph": {

--- a/src/models/Asset.js
+++ b/src/models/Asset.js
@@ -179,4 +179,9 @@ export type TokenDetails = {
   usdPrice: number,
   liquidityUSD: number,
   tradingVolume: number,
+  tradingVolumeChangePercentage: number,
+  liquidityUSDChangePercentage24h: number,
+  holders: number,
+  supply: number,
+  priceChangePercentage24h: number,
 };

--- a/src/screens/Asset/AnimatedFloatingActions.tsx
+++ b/src/screens/Asset/AnimatedFloatingActions.tsx
@@ -22,6 +22,7 @@ import t from 'translations/translate';
 import { useNavigation } from 'react-navigation-hooks';
 import { Animated, StyleSheet, View } from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
+import { useIsDarkTheme } from 'utils/themes';
 
 // Constants
 import { BRIDGE_TAB, SEND_TOKEN_FROM_ASSET_FLOW } from 'constants/navigationConstants';
@@ -46,6 +47,7 @@ import { getActiveAccount, isEtherspotAccount } from 'utils/accounts';
 
 const AnimatedFloatingActions = ({ assetData }) => {
   const navigation = useNavigation();
+  const isDarkTheme = useIsDarkTheme();
 
   const isExchangeAvailable = useIsExchangeAvailable();
   const [disableFront, setDisableFront] = useState(false);
@@ -138,7 +140,7 @@ const AnimatedFloatingActions = ({ assetData }) => {
   const buttons = [
     (isPelerinSupported || isRampSupported) && {
       title: t('label.buy'),
-      iconName: 'buy',
+      iconName: isDarkTheme ? 'buy' : 'buy-light',
       onPress: isPelerinSupported ? buyOnPelerin : buyOnRamp,
     },
     isExchangeAvailable && {
@@ -156,7 +158,7 @@ const AnimatedFloatingActions = ({ assetData }) => {
     },
     isPelerinSupported && {
       title: t('label.sell'),
-      iconName: 'sell',
+      iconName: isDarkTheme ? 'sell' : 'sell-light',
       onPress: sellOnPelerin,
     },
   ];

--- a/src/screens/Asset/Asset.tsx
+++ b/src/screens/Asset/Asset.tsx
@@ -19,6 +19,7 @@
 */
 import React, { useMemo, useState } from 'react';
 import t from 'translations/translate';
+import { Dimensions } from 'react-native';
 import { useNavigation, useNavigationParam } from 'react-navigation-hooks';
 
 // Components
@@ -61,6 +62,8 @@ const AssetScreen = () => {
   const assetData: AssetDataNavigationParam = useNavigationParam('assetData');
   const { chain, imageUrl, contractAddress, token } = assetData;
 
+  const { width: screenWidth } = Dimensions.get('window');
+
   const chainRates = useChainRates(chain);
   const config = useChainConfig(chain);
 
@@ -80,7 +83,7 @@ const AssetScreen = () => {
   }
   if (marketDetailsQuery?.data) {
     const { symbol } = marketDetailsQuery?.data;
-    if (symbol !== token) {
+    if (symbol.toUpperCase() !== token) {
       marketDetailsQuery.data = null;
     }
   }
@@ -110,15 +113,22 @@ const AssetScreen = () => {
           {
             custom: <TokenIcon url={imageUrl} chain={chain} size={24} />,
           },
-          { title: ` ${assetData.name} ${t('label.on_network', { network: networkName })}` },
+          {
+            title: ` ${assetData.name} ${t('label.on_network', { network: networkName })}`,
+          },
+        ]}
+        centerItemsStyle={[
+          { maxWidth: screenWidth * 0.8 },
+          networkName.length > 10 && { marginLeft: screenWidth * 0.05 },
         ]}
         customOnBack={() => navigation.dismiss()}
         noPaddingTop
       />
-      <Content bounces={false} paddingHorizontal={0} paddingVertical={0}>
+      <Content scrollEnabled={!pointerVisible} bounces={false} paddingHorizontal={0} paddingVertical={0}>
         <Container style={{ alignItems: 'center' }}>
           <Spacing h={20} />
           <HeaderContent
+            chain={chain}
             period={selectedPeriod}
             tokenRate={pointerVisible ? convertDecimalNumber(pointerTokenValue) : tokenRateCMC || tokenRate}
             marketDetails={marketDetailsQuery}
@@ -128,6 +138,7 @@ const AssetScreen = () => {
 
           <AnimatedGraph
             period={selectedPeriod}
+            tokenDetailsData={tokenDetailsQuery.data}
             marketData={marketDetailsQuery.data}
             historicData={historicalTokenPricesQuery}
             onChangePointer={(item, isActive) => {

--- a/src/screens/Asset/components/ActivityHeaderContent.tsx
+++ b/src/screens/Asset/components/ActivityHeaderContent.tsx
@@ -17,10 +17,14 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'translations/translate';
+import styled from 'styled-components/native';
 
 // Utils
 import { fiatTokenValue } from 'utils/rates';
+import { wrapBigNumberOrNil } from 'utils/bigNumber';
+import { useThemeColors } from 'utils/themes';
 
 // Components
 import Text from 'components/core/Text';
@@ -46,23 +50,67 @@ type TokenDetailsProps = {
 
 const ActivityHeaderContent = ({ chain, tokenDetails, isPoolActivity }: Props) => {
   const currency = useFiatCurrency();
+  const colors = useThemeColors();
   const ratesPerChain = useRatesPerChain();
+  const { t } = useTranslation();
 
   const { data: tokenDetailsData } = tokenDetails;
+
+  const priceChangePercentage = isPoolActivity
+    ? tokenDetailsData?.liquidityUSDChangePercentage24h
+    : tokenDetailsData?.tradingVolumeChangePercentage;
+
+  const isPositive = priceChangePercentage === 0 || wrapBigNumberOrNil(priceChangePercentage).gt(0);
 
   const liquidityValue = tokenDetailsData?.liquidityUSD
     ? fiatTokenValue(tokenDetailsData?.liquidityUSD, ratesPerChain[chain], currency)
     : null;
 
-  const tradingvolume = tokenDetailsData?.tradingVolume ? fiatTokenValue(tokenDetailsData?.tradingVolume, ratesPerChain[chain], currency) : null;
+  const tradingvolume = tokenDetailsData?.tradingVolume
+    ? fiatTokenValue(tokenDetailsData?.tradingVolume, ratesPerChain[chain], currency)
+    : null;
+
+  const valueFromPercentage = useMemo(() => {
+    if (isPoolActivity && !tokenDetailsData?.liquidityUSD) return null;
+    if (!isPoolActivity && !tokenDetailsData?.tradingVolume) return null;
+
+    const tokenValue = isPoolActivity ? tokenDetailsData?.liquidityUSD : tokenDetailsData?.tradingVolume;
+
+    const changedPriceValue = (tokenValue * priceChangePercentage) / 100;
+
+    return fiatTokenValue(isPositive ? changedPriceValue : changedPriceValue * -1, ratesPerChain[chain], currency);
+  }, [priceChangePercentage]);
 
   return (
     <>
-      {liquidityValue && isPoolActivity && <Text variant="large">{liquidityValue}</Text>}
+      {liquidityValue && isPoolActivity && (
+        <Text variant="large" color={colors.basic000}>
+          {liquidityValue}
+        </Text>
+      )}
       {tradingvolume && !isPoolActivity && <Text variant="large">{tradingvolume}</Text>}
       <Spacing h={6} />
+      {priceChangePercentage !== 0 && (
+        <RowContainer>
+          <Text variant="small" color={colors.tertiaryText}>
+            {t('button.today')}
+          </Text>
+          <Spacing w={4} />
+          <Text variant="regular" color={isPositive ? colors.positive : colors.negative}>
+            {isPositive && '+'}
+            {priceChangePercentage?.toFixed(2)}% {valueFromPercentage && `(${valueFromPercentage})`}
+          </Text>
+        </RowContainer>
+      )}
     </>
   );
 };
+
+const RowContainer = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 90%;
+`;
 
 export default ActivityHeaderContent;

--- a/src/screens/Asset/components/Loaders.tsx
+++ b/src/screens/Asset/components/Loaders.tsx
@@ -25,7 +25,7 @@ import ContentLoader from 'react-native-content-loader';
 import { Rect } from 'react-native-svg';
 
 // Utils
-import { useIsDarkTheme } from 'utils/themes';
+import { useIsDarkTheme, useThemeColors } from 'utils/themes';
 
 // Components
 import Icon from 'components/core/Icon';
@@ -64,17 +64,20 @@ export const GraphLoader = () => {
   );
 };
 
-export const TokenAnalyticsLoader = () => (
-  <ContentLoader
-    primaryColor={'rgba(59, 0, 110, 0.33)'}
-    secondaryColor={'rgba(74, 0, 138, 0.4)'}
-    duration={1000}
-    width={66}
-    height={23}
-  >
-    <Rect x="0" y="0" rx="4" ry="4" width="66" height="15" />
-  </ContentLoader>
-);
+export const TokenAnalyticsLoader = () => {
+  const colors = useThemeColors();
+  return (
+    <ContentLoader
+      primaryColor={colors.purpleHeatPrimary}
+      secondaryColor={colors.purpleHeatSecondary}
+      duration={1000}
+      width={66}
+      height={23}
+    >
+      <Rect x="0" y="0" rx="4" ry="4" width="66" height="15" />
+    </ContentLoader>
+  );
+};
 
 export const BalanceLoader = () => {
   const isDarkTheme = useIsDarkTheme();

--- a/src/screens/Asset/components/TokenAnalyticsListItem.tsx
+++ b/src/screens/Asset/components/TokenAnalyticsListItem.tsx
@@ -22,19 +22,23 @@ import { FlatList } from 'react-native';
 import styled from 'styled-components/native';
 import { useTranslation } from 'translations/translate';
 import { useNavigation, useNavigationParam } from 'react-navigation-hooks';
+import moment from 'moment';
 
 // Utils
 import { fontStyles } from 'utils/variables';
 import { useThemeColors, useIsDarkTheme } from 'utils/themes';
-import { getCurrencySymbol, nFormatter, convertDecimalNumber } from 'utils/common';
+import { nFormatter, convertDecimalNumber } from 'utils/common';
+import { fiatTokenValue } from 'utils/rates';
 
 // Components
 import Text from 'components/core/Text';
 import Icon from 'components/core/Icon';
 import { Spacing } from 'components/legacy/Layout';
 
+// Selectors
+import { useRatesPerChain, useFiatCurrency } from 'selectors';
+
 // Constants
-import { USD } from 'constants/assetsConstants';
 import { POOLS_ACTIVITY, TRADING_ACTIVITY } from 'constants/navigationConstants';
 
 // Models
@@ -46,24 +50,28 @@ import { AllTimeLoader, TokenAnalyticsLoader } from './Loaders';
 const TokenAnalyticsListItem = ({ tokenRate, tokenDetails, marketDetails }) => {
   const { t } = useTranslation();
   const colors = useThemeColors();
-  const currencySymbol = getCurrencySymbol(USD);
   const isDarkTheme = useIsDarkTheme();
   const navigation = useNavigation();
+  const ratesPerChain = useRatesPerChain();
+  const currency = useFiatCurrency();
 
   const assetData: AssetDataNavigationParam = useNavigationParam('assetData');
 
   const { data, isLoading } = marketDetails;
   const { data: tokenDetailsData, isLoading: tokenDetailsLoading } = tokenDetails;
+  const { chain } = assetData;
 
   const analyticsList = [
     {
       label: t('label.marketCap'),
-      value: data?.marketCap ? `${currencySymbol + nFormatter(data.marketCap)}` : t('label.notApplicable'),
+      value: data?.marketCap
+        ? fiatTokenValue(data.marketCap, ratesPerChain[chain], currency, nFormatter)
+        : t('label.notApplicable'),
     },
     {
       label: t('label.fdv'),
       value: data?.fullyDilutedValuation
-        ? `${currencySymbol + nFormatter(data.fullyDilutedValuation)}`
+        ? fiatTokenValue(data.fullyDilutedValuation, ratesPerChain[chain], currency, nFormatter)
         : t('label.notApplicable'),
       icon: 'info',
       iconPress: null,
@@ -71,29 +79,42 @@ const TokenAnalyticsListItem = ({ tokenRate, tokenDetails, marketDetails }) => {
     {
       label: t('label.totalLiquidity'),
       value: tokenDetailsData?.liquidityUSD
-        ? `${currencySymbol + nFormatter(tokenDetailsData.liquidityUSD)}`
+        ? fiatTokenValue(tokenDetailsData.liquidityUSD, ratesPerChain[chain], currency, nFormatter)
         : t('label.notApplicable'),
       icon: 'history',
+      percentageDifference: tokenDetailsData?.liquidityUSD ? tokenDetailsData?.liquidityUSDChangePercentage24h : null,
       iconPress: tokenDetailsLoading ? null : () => navigation.navigate(POOLS_ACTIVITY, { assetData, tokenDetails }),
     },
-    { label: t('label.supply'), value: t('label.notApplicable') },
-    { label: t('label.holders'), value: t('label.notApplicable') },
+    {
+      label: t('label.supply'),
+      value: tokenDetailsData?.supply ? nFormatter(tokenDetailsData.supply) : t('label.notApplicable'),
+    },
+    {
+      label: t('label.holders'),
+      value: tokenDetailsData?.holders ? nFormatter(tokenDetailsData.holders) : t('label.notApplicable'),
+    },
     {
       label: t('label.trandingVol'),
-      value: tokenDetailsData?.tradingVolume ? nFormatter(tokenDetailsData.tradingVolume) : t('label.notApplicable'),
+      value: tokenDetailsData?.tradingVolume
+        ? fiatTokenValue(tokenDetailsData.tradingVolume, ratesPerChain[chain], currency, nFormatter)
+        : t('label.notApplicable'),
       icon: 'history',
+      percentageDifference: tokenDetailsData?.tradingVolume ? tokenDetailsData?.tradingVolumeChangePercentage : null,
       iconPress: tokenDetailsLoading ? null : () => navigation.navigate(TRADING_ACTIVITY, { assetData, tokenDetails }),
     },
   ];
 
   const renderItem = ({ item, index }) => {
+    const loading = index === 1 || index === 0 ? isLoading : tokenDetailsLoading;
     return (
       <ItemContainer
         key={item.label}
         isDark={isDarkTheme}
+        disabled={index !== 2 && index !== 5}
+        onPress={item?.iconPress}
         style={(index === 2 || index === 5) && [{ marginRight: 0, width: '39%' }]}
       >
-        {isLoading ? (
+        {loading ? (
           <TokenAnalyticsLoader />
         ) : (
           <RowContainer style={{ justifyContent: 'flex-start' }}>
@@ -101,9 +122,14 @@ const TokenAnalyticsListItem = ({ tokenRate, tokenDetails, marketDetails }) => {
               {item.value}
             </Text>
             <Spacing w={4} />
-            {item?.percentageDifference && (
-              <Text variant="small" color={index === 5 ? colors.negative : colors.positive} style={{ lineHeight: 22 }}>
-                {item.percentageDifference}
+            {!!item?.percentageDifference && (
+              <Text
+                variant="small"
+                color={item.percentageDifference < 0 ? colors.negative : colors.positive}
+                style={{ lineHeight: 22 }}
+              >
+                {item.percentageDifference > 0 && '+'}
+                {item.percentageDifference?.toFixed(2)}%
               </Text>
             )}
           </RowContainer>
@@ -122,6 +148,13 @@ const TokenAnalyticsListItem = ({ tokenRate, tokenDetails, marketDetails }) => {
     );
   };
 
+  const allTimeHigh = data?.allTimeHigh
+    ? fiatTokenValue(data.allTimeHigh, ratesPerChain[chain], currency, convertDecimalNumber)
+    : t('label.notApplicable');
+  const allTimeLow = data?.allTimeLow
+    ? fiatTokenValue(data.allTimeLow, ratesPerChain[chain], currency, convertDecimalNumber)
+    : t('label.notApplicable');
+
   const allTimeHighPercentage =
     data?.allTimeHigh && !!tokenRate ? ((parseFloat(tokenRate) - data.allTimeHigh) * 100) / data.allTimeHigh : null;
   const allTimeLowPercentage =
@@ -139,51 +172,58 @@ const TokenAnalyticsListItem = ({ tokenRate, tokenDetails, marketDetails }) => {
       <Spacing h={18} />
       <RowContainer>
         <LabelText>{t('label.allTimeHigh')}</LabelText>
-        {isLoading ? (
-          <AllTimeLoader />
-        ) : (
-          <LabelText color={colors.basic000}>
-            {data?.allTimeHigh
-              ? `${currencySymbol + convertDecimalNumber(data.allTimeHigh)}`
-              : t('label.notApplicable')}
-          </LabelText>
-        )}
+        {isLoading ? <AllTimeLoader /> : <LabelText>{allTimeHigh}</LabelText>}
       </RowContainer>
-      {allTimeHighPercentage && (
+      {
         <RowContainer>
-          <LabelText />
           {isLoading ? (
             <AllTimeLoader />
           ) : (
-            <Text variant="tiny" color={data.allTimeHigh > tokenRate ? colors.negative : colors.positive}>
-              {allTimeHighPercentage?.toFixed(2)}%
-            </Text>
+            data?.allTimeHighTimestamp && (
+              <Text variant="tiny" color={colors.basic020}>
+                {moment(data.allTimeHighTimestamp).format('YYYY, MMM DD HH:mm')}
+              </Text>
+            )
+          )}
+          {isLoading ? (
+            <AllTimeLoader />
+          ) : (
+            allTimeHighPercentage && (
+              <Text variant="tiny" color={data.allTimeHigh > tokenRate ? colors.negative : colors.positive}>
+                {allTimeHighPercentage?.toFixed(2)}%
+              </Text>
+            )
           )}
         </RowContainer>
-      )}
+      }
       <Spacing h={10} />
       <RowContainer>
         <LabelText>{t('label.allTimeLow')}</LabelText>
-        {isLoading ? (
-          <AllTimeLoader />
-        ) : (
-          <LabelText color={colors.basic000}>
-            {data?.allTimeLow ? `${currencySymbol + convertDecimalNumber(data.allTimeLow)}` : t('label.notApplicable')}
-          </LabelText>
-        )}
+        {isLoading ? <AllTimeLoader /> : <LabelText>{allTimeLow}</LabelText>}
       </RowContainer>
-      {allTimeLowPercentage && (
+      {
         <RowContainer>
-          <LabelText />
           {isLoading ? (
             <AllTimeLoader />
           ) : (
-            <Text variant="tiny" color={data.allTimeLow < tokenRate ? colors.positive : colors.negative}>
-              +{allTimeLowPercentage?.toFixed(2)}%
-            </Text>
+            data?.allTimeLowTimestamp &&
+            !!data?.allTimeLow && (
+              <Text variant="tiny" color={colors.basic020}>
+                {moment(data.allTimeLowTimestamp).format('YYYY, MMM DD HH:mm')}
+              </Text>
+            )
+          )}
+          {isLoading ? (
+            <AllTimeLoader />
+          ) : (
+            allTimeLowPercentage && (
+              <Text variant="tiny" color={data.allTimeLow < tokenRate ? colors.positive : colors.negative}>
+                +{allTimeLowPercentage?.toFixed(2)}%
+              </Text>
+            )
           )}
         </RowContainer>
-      )}
+      }
       <Spacing h={4} />
     </>
   );
@@ -199,10 +239,10 @@ const RowContainer = styled.View`
 
 const LabelText = styled(Text)`
   ${fontStyles.small};
-  color: ${({ theme, color }) => (color ? color : theme.colors.basic010)};
+  color: ${({ theme, color }) => (color ? color : theme.colors.basic000)};
 `;
 
-const ItemContainer = styled.View`
+const ItemContainer = styled.TouchableOpacity`
   width: 27%;
   margin-right: 12px;
   margin-vertical: 6px;

--- a/src/services/etherspot.js
+++ b/src/services/etherspot.js
@@ -691,10 +691,14 @@ export class EtherspotService {
       return null;
     }
 
+    const nativeAddress = nativeAssetPerChain[chain].address;
+
     try {
       const tokenDetails = await sdk.getTokenDetails({
         tokenAddress: contractAddress,
         chainId: mapChainToChainId(chain),
+        // eslint-disable-next-line i18next/no-literal-string
+        provider: nativeAddress && 'dex-guru',
       });
       return tokenDetails;
     } catch (error) {

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -66,6 +66,7 @@ import type {
   AssetsPerChain,
   TokenData,
   MarketDetails,
+  TokenDetails,
 } from 'models/Asset';
 import type { GasToken } from 'models/Transaction';
 import type { WalletAssetBalance, WalletAssetsBalances } from 'models/Balances';
@@ -446,18 +447,22 @@ export const getGraphPeriod = (period?: string) => {
     {
       id: ONE_DAY,
       label: t('button.twentyfour_hour'),
+      balanceLabel: t('button.today'),
     },
     {
       id: ONE_WEEK,
       label: t('button.seven_day'),
+      balanceLabel: t('button.last_week'),
     },
     {
       id: ONE_MONTH,
       label: t('button.one_month'),
+      balanceLabel: t('button.last_month'),
     },
     {
       id: ONE_YEAR,
       label: t('button.one_year'),
+      balanceLabel: t('button.last_year'),
     },
   ];
 
@@ -465,11 +470,15 @@ export const getGraphPeriod = (period?: string) => {
   return durationList.find((periodInfo) => periodInfo.id === period);
 };
 
-export const getPriceChangePercentage = (period: string, marketData: MarketDetails) => {
+export const getPriceChangePercentage = (
+  period: string,
+  marketData: MarketDetails,
+  tokenDetailsData?: TokenDetails,
+) => {
   const zeroValue = 0;
 
   if (period === ONE_DAY) {
-    return marketData?.priceChangePercentage24h || zeroValue;
+    return marketData?.priceChangePercentage24h || tokenDetailsData?.priceChangePercentage24h || zeroValue;
   }
   if (period === ONE_WEEK) {
     return marketData?.priceChangePercentage7d || zeroValue;

--- a/src/utils/rates.js
+++ b/src/utils/rates.js
@@ -109,7 +109,7 @@ export const fiatInvestmentBalance = (balance: BigNumber, rates: RatesPerChain, 
   return fiatAmount?.toFixed(2);
 };
 
-export const fiatTokenValue = (tokenValue: number, rates: RatesPerChain, currency: Currency) => {
+export const fiatTokenValue = (tokenValue: number, rates: RatesPerChain, currency: Currency, formatter: any) => {
   if (isNaN(tokenValue)) return '';
   const nativeAssetRate = rates[nativeAssetPerChain[CHAIN.ETHEREUM].address];
   const currencySymbol = getCurrencySymbol(currency);
@@ -118,7 +118,7 @@ export const fiatTokenValue = (tokenValue: number, rates: RatesPerChain, currenc
 
   const decimalsFiatValue = fiatAmount?.toFixed(fiatAmount > 1 ? 2 : 4);
 
-  const formattedNumber = numberWithCommas(decimalsFiatValue) ?? 0;
+  const formattedNumber = formatter ? formatter(fiatAmount) : numberWithCommas(decimalsFiatValue) ?? 0;
 
   return `${currencySymbol + formattedNumber.toString()}`;
 };

--- a/src/utils/themes.tsx
+++ b/src/utils/themes.tsx
@@ -114,6 +114,8 @@ export const semanticLightThemeColors = {
   toastTextColor: lightThemeColors.basic090,
   bannerTextColor: baseColors.white,
   basic60: '#ebf0f6',
+  purpleHeatPrimary: 'rgba(216, 171, 255, 0.33)',
+  purpleHeatSecondary: 'rgba(227, 200, 250, 0.4)',
 };
 
 export const semanticDarkThemeColors = {
@@ -178,6 +180,8 @@ export const semanticDarkThemeColors = {
   toastTextColor: darkThemeColors.basic010,
   bannerTextColor: baseColors.black,
   basic60: '#141414',
+  purpleHeatPrimary: 'rgba(59, 0, 110, 0.33)',
+  purpleHeatSecondary: 'rgba(74, 0, 138, 0.4)',
 };
 
 export const themedColors = {

--- a/src/utils/tokens/tokens.json
+++ b/src/utils/tokens/tokens.json
@@ -129,7 +129,7 @@
   },
   {
     "chain": "xdai",
-    "address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+    "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
     "name": "Gnosis",
     "symbol": "GNO",
     "decimals": 18,

--- a/storybook/__snapshots__/storyshots.test.js.snap
+++ b/storybook/__snapshots__/storyshots.test.js.snap
@@ -34080,16 +34080,16 @@ exports[`Storyshots HeaderBlock edge cases 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }
@@ -34384,16 +34384,16 @@ exports[`Storyshots HeaderBlock floating transparent 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }
@@ -34658,16 +34658,16 @@ exports[`Storyshots HeaderBlock with close icon on the left 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }
@@ -34811,16 +34811,16 @@ exports[`Storyshots HeaderBlock with close icon on the right 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }
@@ -35083,16 +35083,16 @@ exports[`Storyshots HeaderBlock with hamburger 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }
@@ -35282,16 +35282,16 @@ exports[`Storyshots HeaderBlock with items on all sides 1`] = `
                 Array [
                   Object {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 4,
-                    "flexShrink": 1,
                     "height": 40,
                     "justifyContent": "center",
                     "paddingBottom": 0,
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "paddingTop": 0,
+                  },
+                  Object {
+                    "flex": 4,
                   },
                 ]
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10181,10 +10181,10 @@ ethers@^5.7.2:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
-etherspot@1.43.5:
-  version "1.43.5"
-  resolved "https://registry.yarnpkg.com/etherspot/-/etherspot-1.43.5.tgz#a6f09b1764406cfa0dac848da123eb43f39b712f"
-  integrity sha512-wO6jV5dR9Ep3o3zQGBRPrns5LMtHXYGrm9N1LgxnqD5wPtHb4b0B+phDi6q+Dnp9c56D1+9mO85O759sLC47sA==
+etherspot@1.43.7:
+  version "1.43.7"
+  resolved "https://registry.yarnpkg.com/etherspot/-/etherspot-1.43.7.tgz#aa96b87953f6e9970d4f1d09e677fb65d7387aff"
+  integrity sha512-52lF4hqPf4CQL2/huCLRcY8gquStsji5zLt2AzlX3PR5+gq1+jch2UN90EhhcaZriPwHQ06MDaV3EkpNK+CT0w==
   dependencies:
     "@apollo/client" "3.4.0"
     "@etherspot/contracts" "1.9.9"
@@ -17603,6 +17603,13 @@ react-native-gesture-handler@^1.9.0:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-get-random-values@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz#6cb30511c406922e75fe73833dc1812a85bfb37e"
+  integrity sha512-+29IR2oxzxNVeaRwCqGZ9ABadzMI8SLTBidrIDXPOkKnm5+kEmLt34QKM4JV+d2usPErvKyS85le0OmGTHnyWQ==
+  dependencies:
+    fast-base64-decode "^1.0.0"
+
 react-native-gifted-charts@^1.2.42:
   version "1.2.42"
   resolved "https://registry.yarnpkg.com/react-native-gifted-charts/-/react-native-gifted-charts-1.2.42.tgz#ab44cb6e9df0ff5e00424f983d696a63f0822adc"
@@ -17616,13 +17623,6 @@ react-native-gifted-charts@^1.2.42:
     react-native-linear-gradient "^2.5.6"
     react-native-svg "^13.6.0"
     typescript "^4.2.4"
-
-react-native-get-random-values@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz#6cb30511c406922e75fe73833dc1812a85bfb37e"
-  integrity sha512-+29IR2oxzxNVeaRwCqGZ9ABadzMI8SLTBidrIDXPOkKnm5+kEmLt34QKM4JV+d2usPErvKyS85le0OmGTHnyWQ==
-  dependencies:
-    fast-base64-decode "^1.0.0"
 
 react-native-htmlview@^0.13.0:
   version "0.13.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-1510/pillar-wallet-token-analytics-refinements

## Description
<!--- Describe your changes in detail -->
- When balance is 0, do not show 24h percentage.
- Showing the line that displays the price point when triggered the user taps on the graph
- Volume to have a $ sign
- 24 H Replaced by Today, 7 D Replaced by Last Week, 1 M Replaced by Last Month, 1 Y Replaced by Last Year
- Added date and time for ATH and ATL,
- 7 days graph shows data last 7 days now
- Fit token name + chain name in single line
- Added missing percentage of trading and pool activity
- whole trading and pool activity button clickable
- Added supply and headers data
- Changed balance and ATH/ATL text color

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on Simulator 14 PRO
- Tested on Android device

## Screenshots (if appropriate):
https://github.com/pillarwallet/pillarwallet/assets/82652040/4cb300d9-d8c7-4a74-ae3c-1461a6dbc066



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)