### PR TITLE
PRO-1797: Upgrade Android API Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "react-native-tcp": "^3.3.2",
     "react-native-udp": "^2.6.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webview": "^10.1.0",
+    "react-native-webview": "^11.22.7",
     "react-navigation": "^4.4.3",
     "react-navigation-hooks": "^1.1.0",
     "react-navigation-redux-helpers": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17546,10 +17546,10 @@ react-native-vector-icons@^7.0.0:
     prop-types "^15.7.2"
     yargs "^15.0.2"
 
-react-native-webview@^10.1.0:
-  version "10.10.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.10.2.tgz#13208aef17c9ccfd28355363688f4cbe2143f10a"
-  integrity sha512-98Dh7q1gEflicFZ8KNL3nK5XRjx50OZXqw87jHofVjKfjbK0LKmvI5X8ymgUMGg61JVgI3AF+g8qpDvqjgQsfg==
+react-native-webview@^11.22.7:
+  version "11.26.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.26.1.tgz#658c09ed5162dc170b361e48c2dd26c9712879da"
+  integrity sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PRO-1409/upgrade-sign-modal

Updated react-native-webview from `10.1.0` to `11.22.7` library to work with API version 33.