### PR TITLE
PRO-1756: PLR Staking Unified PLR View

### DIFF
--- a/src/constants/plrStakingConstants.tsx
+++ b/src/constants/plrStakingConstants.tsx
@@ -25,6 +25,15 @@ export enum WalletType {
 
 export const plrSupportedChains = [CHAIN.ETHEREUM, CHAIN.POLYGON, CHAIN.BINANCE];
 
+export const defaultPlrToken = {
+  chain: CHAIN.ETHEREUM,
+  address: '',
+  name: 'PLR',
+  symbol: 'PLR',
+  decimals: 18,
+  iconUrl: PLR_ICON_URL,
+};
+
 export const stkPlrToken = {
   chain: CHAIN.ETHEREUM,
   address: '',

--- a/src/screens/PlrStaking/PlrStaking.tsx
+++ b/src/screens/PlrStaking/PlrStaking.tsx
@@ -245,7 +245,7 @@ const PlrStaking = () => {
     return () => clearInterval(timerCountdown);
   }, [stakingEndTime]);
 
-  const getPlrTotal = () => {
+  const getPlrTotal = (includeAllWallets?: boolean) => {
     if (!plrBalances?.length) return 0;
 
     let total = 0;
@@ -255,10 +255,15 @@ const PlrStaking = () => {
       total += parseFloat(bal?.assetBalance || 0);
     });
 
+    if (includeAllWallets) {
+      if (archanovaPlrBalance) total += parseFloat(ethers.utils.formatEther(archanovaPlrBalance));
+      if (keybasedPlrBalance) total += parseFloat(ethers.utils.formatEther(keybasedPlrBalance));
+    }
+
     return `${total.toFixed(2)} ${symbol}`;
   };
 
-  const getPlrFiatTotal = () => {
+  const getPlrFiatTotal = (includeAllWallets?: boolean) => {
     if (!plrBalances?.length) return 0;
 
     let total = 0;
@@ -268,7 +273,10 @@ const PlrStaking = () => {
       total += parseFloat(bal?.balance?.balanceInFiat || 0);
     });
 
-    if (!total) return 0;
+    if (includeAllWallets) {
+      if (archanovaPlrBalance) total += getFiatValue(archanovaPlrBalance, ethereumPlrAddress);
+      if (keybasedPlrBalance) total += getFiatValue(keybasedPlrBalance, ethereumPlrAddress);
+    }
 
     return symbol + total.toFixed(2);
   };
@@ -435,8 +443,8 @@ const PlrStaking = () => {
               </AvailablePlrTokenWrapper>
 
               <AvailablePlrBoxTextWrapper>
-                <AvailablePlrText>{getPlrTotal()}</AvailablePlrText>
-                <AvailablePlrFiatText>{getPlrFiatTotal()}</AvailablePlrFiatText>
+                <AvailablePlrText>{getPlrTotal(true)}</AvailablePlrText>
+                <AvailablePlrFiatText>{getPlrFiatTotal(true)}</AvailablePlrFiatText>
               </AvailablePlrBoxTextWrapper>
             </AvailablePlrBox>
 

--- a/src/screens/PlrStaking/PlrStaking.tsx
+++ b/src/screens/PlrStaking/PlrStaking.tsx
@@ -31,6 +31,7 @@ import {
   STAKING_LOCKED_PERIOD,
   STAKING_PERIOD,
   WalletType,
+  defaultPlrToken,
   plrSupportedChains,
   stkPlrToken,
 } from 'constants/plrStakingConstants';
@@ -41,7 +42,7 @@ import { useStableAssets, useNonStableAssets } from 'hooks/assets';
 // Utils
 import { fontStyles, spacing } from 'utils/variables';
 import { formatBigAmount, reportErrorLog } from 'utils/common';
-import { isArchanovaAccount, isKeyBasedAccount, getAccountAddress } from 'utils/accounts';
+import { isArchanovaAccount, isKeyBasedAccount, getAccountAddress, isEtherspotAccount } from 'utils/accounts';
 import { formatTokenValue, formatFiatValue, convertToBigNumberJs } from 'utils/format';
 import { getBalanceInFiat } from 'utils/assets';
 
@@ -87,6 +88,9 @@ const PlrStaking = () => {
   const currency = useFiatCurrency();
   const ethRates = useChainRates(CHAIN.ETHEREUM);
 
+  const ethereumPlrAddress = getPlrAddressForChain(CHAIN.ETHEREUM);
+  const { titleShort: ethereumTitle } = chainsConfig[CHAIN.ETHEREUM];
+
   const { tokens: stableTokens } = useStableAssets();
   const { tokens: nonStableTokens } = useNonStableAssets();
   const tokens = [...stableTokens, ...nonStableTokens];
@@ -97,6 +101,7 @@ const PlrStaking = () => {
   const [stakedPercentage, setStakedPercentage] = useState(null);
   const [stakers, setStakers] = useState(0);
   const [stakingApy, setStakingApy] = useState<string>(null);
+  const [minStakeAmount, setMinStakeAmount] = useState<BigNumber>(BigNumber.from(0));
 
   // Remote Config
   const [stakingEndTime, setStakingEndTime] = useState<Date>(null);
@@ -110,7 +115,10 @@ const PlrStaking = () => {
   const [hasEnoughPlr, setHasEnoughPlr] = useState(false);
 
   const [accountType, setAccountType] = useState(WalletType.ETHERSPOT);
+  const [selectedAccount, setSelectedAccount] = useState(WalletType.ETHERSPOT);
   const [selectedChain, setSelectedChain] = useState(null);
+  const [keybasedPlrBalance, setKeybasedPlrBalance] = useState<BigNumber>(null);
+  const [archanovaPlrBalance, setArchanovaPlrBalance] = useState<BigNumber>(null);
 
   const [stakedTokenAddress, setStakedTokenAddress] = useState<string>(null);
   const [stkPlrBal, setStkPlrBal] = useState<BigNumber>(null);
@@ -156,45 +164,46 @@ const PlrStaking = () => {
         setStakedAmount(formatBigAmount(ethers.utils.formatEther(totalStaked)));
         setStakedPercentage(percentage.toFixed(0).toString());
         setStakers(stakers);
+        setMinStakeAmount(stakingInfo.minStakeAmount);
       } catch (e) {
         reportErrorLog('PlrStaking - fetchStakingInfo error', e);
       }
+
+      const plrAddresses: string[] = [];
+      chains.map((chain) => {
+        const plrAddress = getPlrAddressForChain(chain);
+        if (!!plrAddress) plrAddresses.push(plrAddress.toLowerCase());
+      });
+
+      const filteredWithoutPlr = tokens.filter(
+        (token) =>
+          !plrAddresses.includes(token?.address?.toLowerCase()) &&
+          plrSupportedChains.includes(token.chain) &&
+          token.assetBalance > 0,
+      );
+
+      const filteredTokens = tokens
+        .filter((token) => plrAddresses.includes(token?.address?.toLowerCase()))
+        .sort((a, b) => b?.assetBalance - a?.assetBalance);
+
+      if (!filteredTokens?.length) {
+        setHasEnoughPlr(false);
+        return;
+      }
+
+      setSelectedChain(filteredTokens[0].chain);
+      setHasEnoughPlr(ethers.utils.parseUnits(filteredTokens?.[0]?.assetBalance || 0).gte(stakingInfo.minStakeAmount));
+      setPlrBalances(filteredTokens);
+      setBalancesWithoutPlr(filteredWithoutPlr);
     };
 
     fetchStakingInfo();
-
-    const plrAddresses: string[] = [];
-    chains.map((chain) => {
-      const plrAddress = getPlrAddressForChain(chain);
-      if (!!plrAddress) plrAddresses.push(plrAddress.toLowerCase());
-    });
-
-    const filteredWithoutPlr = tokens.filter(
-      (token) =>
-        !plrAddresses.includes(token?.address?.toLowerCase()) &&
-        plrSupportedChains.includes(token.chain) &&
-        token.assetBalance > 0,
-    );
-
-    const filteredTokens = tokens
-      .filter((token) => plrAddresses.includes(token?.address?.toLowerCase()))
-      .sort((a, b) => b?.assetBalance - a?.assetBalance);
-
-    if (!filteredTokens?.length) {
-      setHasEnoughPlr(false);
-      return;
-    }
-
-    setSelectedChain(filteredTokens[0].chain);
-    setHasEnoughPlr(filteredTokens[0].assetBalance >= MIN_PLR_STAKE_AMOUNT);
-    setPlrBalances(filteredTokens);
-    setBalancesWithoutPlr(filteredWithoutPlr);
   }, []);
 
   useEffect(() => {
     const fetchBal = async () => {
       let totalStkPlr = BigNumber.from(0);
-      for (let account in accounts) {
+      for (let account of accounts) {
         const accountAddress = getAccountAddress(account);
         const balance = await getBalanceForAddress(CHAIN.ETHEREUM, stakedTokenAddress, accountAddress);
         if (balance && !balance.isZero()) totalStkPlr.add(balance);
@@ -207,10 +216,26 @@ const PlrStaking = () => {
   }, [stakedTokenAddress]);
 
   useEffect(() => {
+    const fetchPlrBalances = async () => {
+      for (let account of accounts) {
+        if (!isArchanovaAccount(account) && !isKeyBasedAccount(account)) continue;
+
+        const accountAddress = getAccountAddress(account);
+        const balance = await getBalanceForAddress(CHAIN.ETHEREUM, ethereumPlrAddress, accountAddress);
+
+        if (!balance || balance.isZero()) continue;
+
+        if (isArchanovaAccount(account)) setArchanovaPlrBalance(balance);
+        else if (isKeyBasedAccount(account)) setKeybasedPlrBalance(balance);
+      }
+    };
+
     let accountType = WalletType.ETHERSPOT;
     if (isArchanovaAccount(activeAccount)) accountType = WalletType.ARCHANOVA;
     else if (isKeyBasedAccount(activeAccount)) accountType = WalletType.KEYBASED;
     setAccountType(accountType);
+
+    if (accountType === WalletType.ETHERSPOT) fetchPlrBalances();
   }, [activeAccount]);
 
   useEffect(() => {
@@ -256,20 +281,40 @@ const PlrStaking = () => {
     return valueInFiat;
   };
 
+  const selectActiveAccount = () => {
+    if (isArchanovaAccount(activeAccount)) setSelectedAccount(WalletType.ARCHANOVA);
+    else if (isKeyBasedAccount(activeAccount)) setSelectedAccount(WalletType.KEYBASED);
+    else setSelectedAccount(WalletType.ETHERSPOT);
+  };
+
   const selectChain = (chain) => {
     const balance = plrBalances.find((bal) => bal.chain === chain);
 
-    if (!balance || balance.assetBalance < MIN_PLR_STAKE_AMOUNT) return;
+    if (!balance?.assetBalance || ethers.utils.parseUnits(balance.assetBalance).lt(minStakeAmount)) return;
 
+    selectActiveAccount();
     setSelectedChain(chain);
+  };
+
+  const selectWallet = (wallet: WalletType) => {
+    let balance: BigNumber;
+    if (wallet === WalletType.ARCHANOVA) balance = archanovaPlrBalance;
+    else if (wallet === WalletType.KEYBASED) balance = keybasedPlrBalance;
+
+    if (!balance || balance.isZero() || balance.lt(minStakeAmount)) return;
+
+    setSelectedAccount(wallet);
+    setSelectedChain(CHAIN.ETHEREUM);
   };
 
   const onSelectToken = (token) => {
     setShowModal(false);
+    selectActiveAccount();
     navigation.navigate(PLR_STAKING_VALIDATOR, {
       token: token,
       chain: token.chain,
       balancesWithoutPlr: balancesWithoutPlr,
+      selectedAccount,
     });
   };
 
@@ -278,17 +323,28 @@ const PlrStaking = () => {
   };
 
   const onStake = () => {
-    const token = plrBalances.find((bl) => bl?.chain === selectedChain);
+    let token;
+    if (!isArchanovaAccount(activeAccount) && !isKeyBasedAccount(activeAccount)) {
+      token = plrBalances.find((bl) => bl?.chain === selectedChain);
+    } else {
+      token = {
+        ...defaultPlrToken,
+        address: ethereumPlrAddress,
+        chain: CHAIN.ETHEREUM,
+      };
+    }
+
     if (!token) return;
 
     navigation.navigate(PLR_STAKING_VALIDATOR, {
       token: token,
       chain: token.chain,
       balancesWithoutPlr: balancesWithoutPlr,
+      selectedAccount,
     });
   };
 
-  const stakedPlrFiat = getFiatValue(stkPlrBal, getPlrAddressForChain(CHAIN.ETHEREUM), true) || 0;
+  const stakedPlrFiat = getFiatValue(stkPlrBal, ethereumPlrAddress, true) || 0;
 
   const renderStakedInfo = () => {
     if (!stkPlrBal || stkPlrBal.isZero()) return null;
@@ -312,6 +368,19 @@ const PlrStaking = () => {
       />
     );
   };
+
+  const archanovaDisabled = !archanovaPlrBalance || archanovaPlrBalance.lt(minStakeAmount);
+  const formattedArchanovaPlr: string = archanovaPlrBalance
+    ? formatTokenValue(convertToBigNumberJs(utils.formatEther(archanovaPlrBalance)), defaultPlrToken.symbol, {
+        decimalPlaces: 2,
+      })
+    : '';
+  const keybasedDisabled = !keybasedPlrBalance || keybasedPlrBalance.lt(minStakeAmount);
+  const formattedKeybasedPlr = keybasedPlrBalance
+    ? formatTokenValue(convertToBigNumberJs(utils.formatEther(keybasedPlrBalance)), defaultPlrToken.symbol, {
+        decimalPlaces: 2,
+      })
+    : '';
 
   return (
     <Container>
@@ -402,13 +471,17 @@ const PlrStaking = () => {
               {plrBalances.map((bal) => {
                 const { titleShort } = chainsConfig[bal.chain];
 
-                const disabled = bal?.assetBalance < MIN_PLR_STAKE_AMOUNT || isNaN(bal.assetBalance);
+                const disabled =
+                  ethers.utils.parseUnits(bal?.assetBalance || 0).lt(minStakeAmount) || isNaN(bal.assetBalance);
 
                 return (
                   <BalanceItem onPress={() => selectChain(bal.chain)} disabled={disabled}>
                     <BalanceLeftItem>
                       <Spacing w={spacing.large} />
-                      <RadioButton visible={bal.chain === selectedChain} disabled={disabled} />
+                      <RadioButton
+                        visible={bal.chain === selectedChain && selectedAccount === accountType}
+                        disabled={disabled}
+                      />
                       <Spacing w={spacing.small} />
                       {/* @ts-ignore */}
                       <Icon name={bal.chain + 16} />
@@ -427,10 +500,84 @@ const PlrStaking = () => {
                 );
               })}
             </BalanceSelectWrapper>
+
+            {archanovaPlrBalance && !archanovaPlrBalance.isZero() && (
+              <BalanceSelectWrapper>
+                <BalanceItem>
+                  <BalanceLeftItem>
+                    <>
+                      <Icon name="pillar16" />
+                      <BalanceTitle>{`${t('archanova')} ${t('wallet')}`}</BalanceTitle>
+                    </>
+                  </BalanceLeftItem>
+
+                  <BalanceRightItem>
+                    <BalanceValueText>{formattedArchanovaPlr}</BalanceValueText>
+                    <BalanceValueText fiat>
+                      {formatFiatValue(getFiatValue(archanovaPlrBalance, ethereumPlrAddress, true), currency)}
+                    </BalanceValueText>
+                  </BalanceRightItem>
+                </BalanceItem>
+                <BalanceItem onPress={() => selectWallet(WalletType.ARCHANOVA)} disabled={archanovaDisabled}>
+                  <BalanceLeftItem>
+                    <Spacing w={spacing.large} />
+                    <RadioButton visible={selectedAccount === WalletType.ARCHANOVA} disabled={archanovaDisabled} />
+                    <Spacing w={spacing.small} />
+                    {/* @ts-ignore */}
+                    <Icon name={CHAIN.ETHEREUM + 16} />
+                    <BalanceTitle disabled={archanovaDisabled}>{ethereumTitle}</BalanceTitle>
+                  </BalanceLeftItem>
+
+                  <BalanceRightItem>
+                    <BalanceValueText disabled={archanovaDisabled}>{formattedArchanovaPlr}</BalanceValueText>
+                    <BalanceValueText fiat disabled={archanovaDisabled}>
+                      {formatFiatValue(getFiatValue(archanovaPlrBalance, ethereumPlrAddress, true), currency)}
+                    </BalanceValueText>
+                  </BalanceRightItem>
+                </BalanceItem>
+              </BalanceSelectWrapper>
+            )}
+
+            {keybasedPlrBalance && !keybasedPlrBalance.isZero() && (
+              <BalanceSelectWrapper>
+                <BalanceItem>
+                  <BalanceLeftItem>
+                    <>
+                      <Icon name="wallet16" />
+                      <BalanceTitle>{`${t('keybased')} ${t('wallet')}`}</BalanceTitle>
+                    </>
+                  </BalanceLeftItem>
+
+                  <BalanceRightItem>
+                    <BalanceValueText>{formattedKeybasedPlr}</BalanceValueText>
+                    <BalanceValueText fiat>
+                      {formatFiatValue(getFiatValue(keybasedPlrBalance, ethereumPlrAddress, true), currency)}
+                    </BalanceValueText>
+                  </BalanceRightItem>
+                </BalanceItem>
+                <BalanceItem onPress={() => selectWallet(WalletType.KEYBASED)} disabled={keybasedDisabled}>
+                  <BalanceLeftItem>
+                    <Spacing w={spacing.large} />
+                    <RadioButton visible={selectedAccount === WalletType.KEYBASED} disabled={keybasedDisabled} />
+                    <Spacing w={spacing.small} />
+                    {/* @ts-ignore */}
+                    <Icon name={CHAIN.ETHEREUM + 16} />
+                    <BalanceTitle disabled={keybasedDisabled}>{ethereumTitle}</BalanceTitle>
+                  </BalanceLeftItem>
+
+                  <BalanceRightItem>
+                    <BalanceValueText disabled={keybasedDisabled}>{formattedKeybasedPlr}</BalanceValueText>
+                    <BalanceValueText fiat disabled={keybasedDisabled}>
+                      {formatFiatValue(getFiatValue(keybasedPlrBalance, ethereumPlrAddress, true), currency)}
+                    </BalanceValueText>
+                  </BalanceRightItem>
+                </BalanceItem>
+              </BalanceSelectWrapper>
+            )}
           </PlrBalancesWrapper>
         )}
 
-        {!plrBalances?.length || (!hasEnoughPlr && <LimitWarningText>{t('limitWarning')}</LimitWarningText>)}
+        {(!plrBalances?.length || !hasEnoughPlr) && <LimitWarningText>{t('limitWarning')}</LimitWarningText>}
 
         <ContinueButtonWrapper>
           {!!hasEnoughPlr && (

--- a/src/screens/PlrStaking/PlrStakingValidator.tsx
+++ b/src/screens/PlrStaking/PlrStakingValidator.tsx
@@ -26,7 +26,7 @@ import { BigNumber, ethers } from 'ethers';
 
 // Constants
 import { CHAIN } from 'constants/chainConstantsTs';
-import { WalletType, stkPlrToken } from 'constants/plrStakingConstants';
+import { WalletType, defaultPlrToken, stkPlrToken } from 'constants/plrStakingConstants';
 import { TRANSACTION_TYPE } from 'constants/transactionsConstants';
 import { HOME } from 'constants/navigationConstants';
 
@@ -106,9 +106,10 @@ const PlrStakingValidator = () => {
   const token = navigation.getParam('token');
   const chain = navigation.getParam('chain');
   const balancesWithoutPlr = navigation.getParam('balancesWithoutPlr');
+  const selectedAccount = navigation.getParam('selectedAccount');
 
-  const activeAccount = useActiveAccount();
   const accounts = useAccounts();
+  const activeAccount = useActiveAccount();
 
   const inputRef: any = useRef();
   const stakeRef: any = useRef();
@@ -117,7 +118,7 @@ const PlrStakingValidator = () => {
   const [showModal, setShowModal] = useState(false);
   const [selectedToken, setSelectedToken] = useState(token);
   const [selectedChain, setSelectedChain] = useState(chain);
-  const [accountType, setAccountType] = useState<WalletType>(null);
+  const [accountType, setAccountType] = useState<WalletType>(selectedAccount);
 
   const [gasFeeAsset, setGasFeeAsset] = useState<AssetOption | null>(null);
   const [value, setValue] = useState(null);
@@ -188,16 +189,15 @@ const PlrStakingValidator = () => {
   );
 
   useEffect(() => {
-    let accountType = WalletType.ETHERSPOT;
-    if (isArchanovaAccount(activeAccount)) accountType = WalletType.ARCHANOVA;
-    else if (isKeyBasedAccount(activeAccount)) accountType = WalletType.KEYBASED;
-    setAccountType(accountType);
-  }, [activeAccount]);
-
-  useEffect(() => {
     if (!!plrToken || !toOptions) return;
     const asset = toOptions?.find((a) => a.chain === CHAIN.ETHEREUM && addressesEqual(a.address, ethereumPlrAddress));
     if (!!asset) setPlrToken(asset);
+    else
+      setPlrToken({
+        ...defaultPlrToken,
+        address: ethereumPlrAddress,
+        chain: CHAIN.ETHEREUM,
+      });
   }, [toOptions]);
 
   // Get Staking Fees
@@ -358,6 +358,10 @@ const PlrStakingValidator = () => {
     resetForm(true);
     setSelectedToken(token);
     setSelectedChain(token?.chain);
+
+    if (isArchanovaAccount(activeAccount)) setAccountType(WalletType.ARCHANOVA);
+    else if (isKeyBasedAccount(activeAccount)) setAccountType(WalletType.KEYBASED);
+    else setAccountType(WalletType.ETHERSPOT);
   };
 
   const validatePlr = (): boolean => {

--- a/src/screens/PlrStaking/PlrStakingValidator.tsx
+++ b/src/screens/PlrStaking/PlrStakingValidator.tsx
@@ -233,7 +233,7 @@ const PlrStakingValidator = () => {
 
       const data: ISendData = {
         sourceWallet: accountType,
-        formattedValue: `${truncateDecimalPlaces(value.toString(), 0)} ${selectedToken?.symbol}`,
+        formattedValue: `${truncateDecimalPlaces(value?.toString(), 0)} ${selectedToken?.symbol}`,
         asset: selectedToken,
         feeInfo: null,
       };
@@ -426,7 +426,7 @@ const PlrStakingValidator = () => {
 
       sendTransactionPayload = {
         to: etherspotAddress,
-        amount: truncateAmount(value.toString(), selectedToken.decimals),
+        amount: truncateAmount(value?.toString(), selectedToken.decimals),
         symbol: selectedToken.symbol,
         contractAddress: selectedToken.address,
         decimals: selectedToken.decimals,

--- a/src/utils/plrStakingHelper.tsx
+++ b/src/utils/plrStakingHelper.tsx
@@ -75,8 +75,8 @@ interface IStakingContractAbi {
 
 interface IStakingContractInfo {
   contractState: number;
-  minStakeAmount: string;
-  maxStakeAmount: string;
+  minStakeAmount: BigNumber;
+  maxStakeAmount: BigNumber;
   maxStakeTotal: string;
   totalStaked: string;
   rewardToken: string;
@@ -257,8 +257,8 @@ export const getStakingContractInfo = async (refresh?: boolean): Promise<IStakin
 
     storedContractInfo = {
       contractState,
-      minStakeAmount,
-      maxStakeAmount,
+      minStakeAmount: minStakingAmount,
+      maxStakeAmount: maxStakingAmount,
       maxStakeTotal,
       totalStaked,
       rewardToken,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-1756/plr-staking-unified-view-of-plr-tokens-on-different-wallets

You can now select PLR balances from Archanova and Keybased wallets when the Etherspot wallet is selected.

## Screenshots (if appropriate):
![Simulator Screenshot - iPhone 14 Pro - 2023-08-23 at 09 29 53](https://github.com/pillarwallet/pillarwallet/assets/55538608/d762e026-897d-4d66-90e2-7495623175e0)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)