### PR TITLE
fix: Set 9.8.1 npm version instead of latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,14 +120,14 @@ aliases:
         - ~/nodes_modules
   - &android_latest_npm
     run:
-      name: Install latest npm version
+      name: Install 9.8.1 npm version
       command: |
-        sudo npm install -g npm@latest
+        sudo npm install -g npm@9.8.1
   - &ios_latest_npm
     run:
-      name: Install latest npm version
+      name: Install 9.8.1 npm version
       command: |
-        npm install -g npm@latest
+        npm install -g npm@9.8.1
   - &ios_latest_yarn
     run:
       name: Install latest yarn version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Latest npm requires node engine to be "^18.17.0 || >=20.5.0", switch to specific version that will work for 16>
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- not tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)