### PR TITLE
PRO-1953 Re-entering app triggers PIN code instead of biometrics on android

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -370,7 +370,6 @@ export const lockScreenAction = (onLoginSuccess: ?OnValidPinCallback, errorMessa
               params: {
                 onLoginSuccess,
                 errorMessage,
-                forcePin: true,
               },
             },
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-1953/re-entering-app-triggers-pin-code-instead-of-biometrics-on-android

## Description
<!--- Describe your changes in detail -->
- Fixed: Biometric if Archanova account disconnected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://linear.app/pillarproject/issue/PRO-1953/re-entering-app-triggers-pin-code-instead-of-biometrics-on-android#comment-6980492b

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on Android device
- Tested on Simulator
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)