### PR TITLE
PRO-2234 Re: Bypassing lockout timeout

### DIFF
--- a/src/screens/PinCodeUnlock/PinCodeUnlock.js
+++ b/src/screens/PinCodeUnlock/PinCodeUnlock.js
@@ -217,6 +217,16 @@ class PinCodeUnlock extends React.Component<Props, State> {
               date: new Date(date),
             },
           });
+        } else {
+          updateAttempts({
+            pinAttemptsCount: 0,
+          });
+          todayAttempts({
+            failedAttempts: {
+              numberOfFailedAttempts: 0,
+              date: new Date(currentTime),
+            },
+          });
         }
         await this.handleLocking();
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://linear.app/pillarproject/issue/PRO-2234/pillar-wallet-bypassing-lockout-timeout

## Description
<!--- Describe your changes in detail -->
- Fixed: When sets a manual time and opens the app the next day at that time show countdown. actual time and manual time the difference shows.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested on local
-
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)