### PR TITLE
chore: update macos image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ orbs:
   aws-cli: circleci/aws-cli@3.1.4
   go: circleci/go@0.2.0
   slack: circleci/slack@3.4.2
-  macos: circleci/macos@2.4.1
+  macos: circleci/macos@2.5.2
 
 executors:
   ios-executor:
     working_directory: ~/pillarwallet
     macos:
-      xcode: "15.3.0"
+      xcode: "16.2.0"
     resource_class: macos.m1.medium.gen1
     environment:
       NODE_OPTIONS: "--max-old-space-size=4096"


### PR DESCRIPTION
This pull request updates the `.circleci/config.yml` file to ensure compatibility with the latest tools and improve the build environment. The changes focus on upgrading the `macos` orb version and the Xcode version used in the `ios-executor`.

### CI/CD Configuration Updates:
* Updated the `macos` orb from version `2.4.1` to `2.5.2` to use the latest features and fixes provided by CircleCI. (`[.circleci/config.ymlL7-R13](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L7-R13)`)
* Upgraded the Xcode version in the `ios-executor` from `15.3.0` to `16.2.0` to support newer iOS development environments. (`[.circleci/config.ymlL7-R13](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L7-R13)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the macOS environment and Xcode version used for iOS builds in the continuous integration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->