### PR TITLE
chore: update xcode version in fastfile

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -64,7 +64,7 @@ platform :ios do
   desc "Release to adhoc TestFlight"
   lane :deploy_ios_appcenter do |options|
 
-    xcversion(version: "15.3.0")
+    xcversion(version: "16.2.0")
     MY_APP_ID = "com.pillarproject.wallet.staging"
     MY_PROFILE = "match AdHoc com.pillarproject.wallet.staging"
 


### PR DESCRIPTION
This pull request includes a version update in the `ios/fastlane/Fastfile` to ensure compatibility with the latest Xcode version.

Version update:

* Updated `xcversion` from `15.3.0` to `16.2.0` in the `deploy_ios_appcenter` lane to align with the latest Xcode release. (`ios/fastlane/Fastfile`, [ios/fastlane/FastfileL67-R67](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deL67-R67))