### PR TITLE
chore: use xcode version in all the lanes

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -9,6 +9,7 @@ platform :ios do
 
   desc "Release to production TestFlight"
   lane :deploy_prod do |options|
+    xcversion(version: "16.2.0")
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString #{options[:build_number]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName #{options[:APP_NAME]}' ~/pillarwallet/ios/pillarwallet/Info.plist"
@@ -138,6 +139,7 @@ platform :ios do
 
   desc "Release to staging TestFlight"
   lane :deploy_staging do |options|
+    xcversion(version: "16.2.0")
 
     # insert circleCI's build number as our build number
     sh "/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{options[:APP_BUILD_NUMBER]}' ~/pillarwallet/ios/pillarwallet/Info.plist"


### PR DESCRIPTION
This pull request updates the iOS deployment process in the `Fastfile` to specify the Xcode version used during builds. The changes ensure consistency in the build environment for both production and staging releases.

Key changes:

* **Build environment consistency**:
  * Added `xcversion(version: "16.2.0")` to the `deploy_prod` lane to specify the Xcode version for production TestFlight releases. (`ios/fastlane/Fastfile`, [ios/fastlane/FastfileR12](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deR12))
  * Added `xcversion(version: "16.2.0")` to the `deploy_staging` lane to specify the Xcode version for staging TestFlight releases. (`ios/fastlane/Fastfile`, [ios/fastlane/FastfileR142](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deR142))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the Xcode version used during production and staging deployments to ensure consistency across deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->